### PR TITLE
Document model core, safety limits, error taxonomy

### DIFF
--- a/document.go
+++ b/document.go
@@ -1,0 +1,276 @@
+package omnist
+
+import "math/big"
+
+// ScalarKind identifies which of the seven scalar kinds a Scalar holds.
+//
+// Spec §2.2.1 defines exactly seven scalar kinds and is explicit that
+// implementations MUST NOT add or collapse kinds, since doing so changes the
+// Schema Algebra's subtyping lattice and therefore changes conformance
+// results. Do not add an eighth constant here.
+type ScalarKind int
+
+const (
+	// KindString is a sequence of Unicode code points.
+	KindString ScalarKind = iota
+	// KindInteger is an arbitrary-precision signed integer, subject to the
+	// §2.4 safety limit on digit count.
+	KindInteger
+	// KindNumber is a real number, represented as IEEE 754 binary64.
+	KindNumber
+	// KindBoolean is true or false.
+	KindBoolean
+	// KindDate is a calendar date: year, month, day.
+	KindDate
+	// KindTime is a time of day, with optional sub-second precision and
+	// optional UTC offset.
+	KindTime
+	// KindDateTime is a date and a time of day, joined.
+	KindDateTime
+)
+
+// String returns the taxonomy-style lowercase name of the kind (e.g.
+// "integer"), matching the kind names used in spec §2.2.1's table.
+func (k ScalarKind) String() string {
+	switch k {
+	case KindString:
+		return "string"
+	case KindInteger:
+		return "integer"
+	case KindNumber:
+		return "number"
+	case KindBoolean:
+		return "boolean"
+	case KindDate:
+		return "date"
+	case KindTime:
+		return "time"
+	case KindDateTime:
+		return "datetime"
+	default:
+		return "unknown"
+	}
+}
+
+// DateValue is a calendar date: year, month, day (spec §2.2.1 `date`).
+type DateValue struct {
+	Year  int
+	Month int
+	Day   int
+}
+
+// TimeValue is a time of day, with optional sub-second precision and
+// optional UTC offset (spec §2.2.1 `time`).
+type TimeValue struct {
+	Hour       int
+	Minute     int
+	Second     int
+	Nanosecond int
+	// HasOffset reports whether Offset is meaningful. A time value need not
+	// carry a UTC offset at all.
+	HasOffset bool
+	// OffsetSeconds is the UTC offset in seconds when HasOffset is true.
+	OffsetSeconds int
+}
+
+// DateTimeValue is a date and a time of day, joined (spec §2.2.1 `datetime`).
+type DateTimeValue struct {
+	Date DateValue
+	Time TimeValue
+}
+
+// Scalar is a tagged value holding exactly one of the seven scalar kinds.
+// Only the field matching Kind is meaningful; the others are zero.
+//
+// Per the design decision recorded in docs/workflow-playbook.md §2.2,
+// integer uses *big.Int (not int64) because spec §2.4 requires supporting
+// integer literals up to 4,300 decimal digits.
+type Scalar struct {
+	Kind ScalarKind
+
+	Str      string
+	Int      *big.Int
+	Num      float64
+	Bool     bool
+	Date     DateValue
+	Time     TimeValue
+	DateTime DateTimeValue
+}
+
+// NewStringScalar constructs a string-kind Scalar.
+func NewStringScalar(s string) Scalar { return Scalar{Kind: KindString, Str: s} }
+
+// NewIntegerScalar constructs an integer-kind Scalar. It copies v so the
+// caller's *big.Int may be safely mutated afterward.
+func NewIntegerScalar(v *big.Int) Scalar {
+	return Scalar{Kind: KindInteger, Int: new(big.Int).Set(v)}
+}
+
+// NewNumberScalar constructs a number-kind Scalar.
+func NewNumberScalar(n float64) Scalar { return Scalar{Kind: KindNumber, Num: n} }
+
+// NewBooleanScalar constructs a boolean-kind Scalar.
+func NewBooleanScalar(b bool) Scalar { return Scalar{Kind: KindBoolean, Bool: b} }
+
+// NewDateScalar constructs a date-kind Scalar.
+func NewDateScalar(d DateValue) Scalar { return Scalar{Kind: KindDate, Date: d} }
+
+// NewTimeScalar constructs a time-kind Scalar.
+func NewTimeScalar(t TimeValue) Scalar { return Scalar{Kind: KindTime, Time: t} }
+
+// NewDateTimeScalar constructs a datetime-kind Scalar.
+func NewDateTimeScalar(dt DateTimeValue) Scalar {
+	return Scalar{Kind: KindDateTime, DateTime: dt}
+}
+
+// Equal reports whether s and other are the same scalar per spec D-5:
+// two scalars are equal when their kinds AND values are equal. An integer
+// and a number of the same magnitude are distinct scalars in the Document
+// model even though integer is a subtype of number in the Schema model
+// (§6) — so this method deliberately does not do numeric cross-kind
+// comparison. Go's built-in == cannot be used for Scalar equality: the Int
+// field is a *big.Int pointer, so == would compare pointer identity rather
+// than value, and even a value-correct == would not by itself express the
+// kind-strictness rule this method exists to enforce.
+func (s Scalar) Equal(other Scalar) bool {
+	if s.Kind != other.Kind {
+		return false
+	}
+	switch s.Kind {
+	case KindString:
+		return s.Str == other.Str
+	case KindInteger:
+		if s.Int == nil || other.Int == nil {
+			return s.Int == other.Int
+		}
+		return s.Int.Cmp(other.Int) == 0
+	case KindNumber:
+		return s.Num == other.Num
+	case KindBoolean:
+		return s.Bool == other.Bool
+	case KindDate:
+		return s.Date == other.Date
+	case KindTime:
+		return s.Time == other.Time
+	case KindDateTime:
+		return s.DateTime == other.DateTime
+	default:
+		return false
+	}
+}
+
+// Value is a Document value: either a Scalar or null. Per spec §2.2's
+// grammar, `value = scalar-value | null`. IsNull distinguishes the null
+// value from a zero Scalar, since null carries no scalar kind of its own
+// (spec §2.2.1).
+type Value struct {
+	IsNull bool
+	Scalar Scalar
+}
+
+// NullValue returns the null value.
+func NullValue() Value { return Value{IsNull: true} }
+
+// ScalarValue wraps a Scalar as a Value.
+func ScalarValue(s Scalar) Value { return Value{Scalar: s} }
+
+// Target is what an Edge points to: exactly a Value or a Node, per spec
+// D-4 ("A target is a value or a node. No third case exists."). The zero
+// Target is invalid; construct one with ValueTarget or NodeTarget.
+//
+// Target is deliberately not an interface. An interface satisfied by two
+// concrete types can always be satisfied by a third one added later by a
+// caller outside this package, which would let a list-valued or otherwise
+// illegal target escape into user-visible Documents — exactly what D-4
+// forbids. A closed struct with an internal discriminant cannot be
+// extended from outside the package.
+type Target struct {
+	isNode bool
+	value  Value
+	node   *Node
+}
+
+// ValueTarget constructs a Target holding a value.
+func ValueTarget(v Value) Target { return Target{value: v} }
+
+// NodeTarget constructs a Target holding a node. Panics if n is nil, since
+// a nil node is not a legal target (it is neither a value nor a node).
+func NodeTarget(n *Node) Target {
+	if n == nil {
+		panic("omnist: NodeTarget called with nil *Node")
+	}
+	return Target{isNode: true, node: n}
+}
+
+// IsNode reports whether the target is a node (as opposed to a value).
+func (t Target) IsNode() bool { return t.isNode }
+
+// Node returns the target's node and true if the target is a node,
+// otherwise the zero value and false.
+func (t Target) Node() (*Node, bool) {
+	if !t.isNode {
+		return nil, false
+	}
+	return t.node, true
+}
+
+// Value returns the target's value and true if the target is a value,
+// otherwise the zero value and false.
+func (t Target) Value() (Value, bool) {
+	if t.isNode {
+		return Value{}, false
+	}
+	return t.value, true
+}
+
+// Edge is a single (label, target) pair within a Node's ordered edge list.
+type Edge struct {
+	Label  string
+	Target Target
+}
+
+// Node is an ordered list of labeled edges (spec §2.1/§2.2). Labels MAY
+// repeat; nothing in the Document model constrains uniqueness, ordering,
+// or the relationship between repeated labels (spec §2.2.2).
+//
+// Per the design decision recorded in docs/workflow-playbook.md §2.3, Node
+// stays edge-list-native everywhere: there is no separate map-collapsed
+// type. Callers append to Edges directly to build a Document; this
+// preserves invariant D-1 (edge order is exactly construction order) and
+// D-2 (repeated labels remain separate edges, never merged into a list) by
+// construction, since there is no map-shaped alternative to accidentally
+// use instead.
+type Node struct {
+	Edges []Edge
+}
+
+// NewNode returns an empty Node.
+func NewNode() *Node { return &Node{} }
+
+// AddValue appends an edge with the given label pointing at a value
+// target, in place, and returns the node for chaining.
+func (n *Node) AddValue(label string, v Value) *Node {
+	n.Edges = append(n.Edges, Edge{Label: label, Target: ValueTarget(v)})
+	return n
+}
+
+// AddNode appends an edge with the given label pointing at a node target,
+// in place, and returns the node for chaining.
+func (n *Node) AddNode(label string, child *Node) *Node {
+	n.Edges = append(n.Edges, Edge{Label: label, Target: NodeTarget(child)})
+	return n
+}
+
+// Document is a node or a bare value (spec §2.2: `Document = node | value`).
+// Exactly one of Node or Value is meaningful, selected by IsNode.
+type Document struct {
+	IsNode bool
+	Node   *Node
+	Value  Value
+}
+
+// NodeDocument wraps a Node as a Document.
+func NodeDocument(n *Node) Document { return Document{IsNode: true, Node: n} }
+
+// ValueDocument wraps a Value as a Document (a bare-value Document).
+func ValueDocument(v Value) Document { return Document{Value: v} }

--- a/document_test.go
+++ b/document_test.go
@@ -1,0 +1,233 @@
+package omnist
+
+import (
+	"math/big"
+	"testing"
+)
+
+func TestScalarKindString(t *testing.T) {
+	cases := []struct {
+		k    ScalarKind
+		want string
+	}{
+		{KindString, "string"},
+		{KindInteger, "integer"},
+		{KindNumber, "number"},
+		{KindBoolean, "boolean"},
+		{KindDate, "date"},
+		{KindTime, "time"},
+		{KindDateTime, "datetime"},
+		{ScalarKind(99), "unknown"},
+	}
+	for _, c := range cases {
+		if got := c.k.String(); got != c.want {
+			t.Errorf("ScalarKind(%d).String() = %q, want %q", c.k, got, c.want)
+		}
+	}
+}
+
+func TestScalarConstructors(t *testing.T) {
+	if s := NewStringScalar("hi"); s.Kind != KindString || s.Str != "hi" {
+		t.Errorf("NewStringScalar: got %+v", s)
+	}
+	bi := big.NewInt(42)
+	s := NewIntegerScalar(bi)
+	if s.Kind != KindInteger || s.Int.Cmp(bi) != 0 {
+		t.Errorf("NewIntegerScalar: got %+v", s)
+	}
+	// Mutating the caller's big.Int afterward must not affect the scalar
+	// (constructor copies).
+	bi.SetInt64(0)
+	if s.Int.Cmp(big.NewInt(42)) != 0 {
+		t.Errorf("NewIntegerScalar did not copy: got %v", s.Int)
+	}
+	if s := NewNumberScalar(1.5); s.Kind != KindNumber || s.Num != 1.5 {
+		t.Errorf("NewNumberScalar: got %+v", s)
+	}
+	if s := NewBooleanScalar(true); s.Kind != KindBoolean || !s.Bool {
+		t.Errorf("NewBooleanScalar: got %+v", s)
+	}
+	d := DateValue{Year: 2026, Month: 8, Day: 7}
+	if s := NewDateScalar(d); s.Kind != KindDate || s.Date != d {
+		t.Errorf("NewDateScalar: got %+v", s)
+	}
+	tm := TimeValue{Hour: 1, Minute: 2, Second: 3}
+	if s := NewTimeScalar(tm); s.Kind != KindTime || s.Time != tm {
+		t.Errorf("NewTimeScalar: got %+v", s)
+	}
+	dt := DateTimeValue{Date: d, Time: tm}
+	if s := NewDateTimeScalar(dt); s.Kind != KindDateTime || s.DateTime != dt {
+		t.Errorf("NewDateTimeScalar: got %+v", s)
+	}
+}
+
+func TestScalarEqual(t *testing.T) {
+	one := NewIntegerScalar(big.NewInt(1))
+	oneAgain := NewIntegerScalar(big.NewInt(1))
+	two := NewIntegerScalar(big.NewInt(2))
+	oneAsNumber := NewNumberScalar(1.0)
+
+	if !one.Equal(oneAgain) {
+		t.Error("equal integers reported unequal")
+	}
+	if one.Equal(two) {
+		t.Error("unequal integers reported equal")
+	}
+	// D-5: integer 1 and number 1.0 are NOT equal, despite same magnitude.
+	if one.Equal(oneAsNumber) {
+		t.Error("D-5 violated: integer 1 equal to number 1.0")
+	}
+	if oneAsNumber.Equal(one) {
+		t.Error("D-5 violated (reversed): number 1.0 equal to integer 1")
+	}
+
+	str1 := NewStringScalar("a")
+	str2 := NewStringScalar("a")
+	str3 := NewStringScalar("b")
+	if !str1.Equal(str2) || str1.Equal(str3) {
+		t.Error("string equality broken")
+	}
+
+	num1 := NewNumberScalar(2.5)
+	num2 := NewNumberScalar(2.5)
+	num3 := NewNumberScalar(3.5)
+	if !num1.Equal(num2) || num1.Equal(num3) {
+		t.Error("number equality broken")
+	}
+
+	b1 := NewBooleanScalar(true)
+	b2 := NewBooleanScalar(true)
+	b3 := NewBooleanScalar(false)
+	if !b1.Equal(b2) || b1.Equal(b3) {
+		t.Error("boolean equality broken")
+	}
+
+	d1 := NewDateScalar(DateValue{2026, 1, 1})
+	d2 := NewDateScalar(DateValue{2026, 1, 1})
+	d3 := NewDateScalar(DateValue{2026, 1, 2})
+	if !d1.Equal(d2) || d1.Equal(d3) {
+		t.Error("date equality broken")
+	}
+
+	t1 := NewTimeScalar(TimeValue{Hour: 1})
+	t2 := NewTimeScalar(TimeValue{Hour: 1})
+	t3 := NewTimeScalar(TimeValue{Hour: 2})
+	if !t1.Equal(t2) || t1.Equal(t3) {
+		t.Error("time equality broken")
+	}
+
+	dt1 := NewDateTimeScalar(DateTimeValue{Date: DateValue{2026, 1, 1}})
+	dt2 := NewDateTimeScalar(DateTimeValue{Date: DateValue{2026, 1, 1}})
+	dt3 := NewDateTimeScalar(DateTimeValue{Date: DateValue{2026, 1, 2}})
+	if !dt1.Equal(dt2) || dt1.Equal(dt3) {
+		t.Error("datetime equality broken")
+	}
+
+	// Nil *big.Int handling (zero-value Scalar with Kind integer).
+	zeroInt := Scalar{Kind: KindInteger}
+	if !zeroInt.Equal(Scalar{Kind: KindInteger}) {
+		t.Error("two nil-Int integer scalars should be equal")
+	}
+	if zeroInt.Equal(one) {
+		t.Error("nil-Int scalar should not equal a real integer scalar")
+	}
+
+	// Unknown kind on both sides is never equal (default branch).
+	unknown1 := Scalar{Kind: ScalarKind(99)}
+	unknown2 := Scalar{Kind: ScalarKind(99)}
+	if unknown1.Equal(unknown2) {
+		t.Error("unknown kind should never report equal")
+	}
+}
+
+func TestValueAndNullValue(t *testing.T) {
+	n := NullValue()
+	if !n.IsNull {
+		t.Error("NullValue should have IsNull true")
+	}
+	v := ScalarValue(NewStringScalar("x"))
+	if v.IsNull || v.Scalar.Str != "x" {
+		t.Errorf("ScalarValue: got %+v", v)
+	}
+}
+
+func TestTargetValueAndNode(t *testing.T) {
+	v := ScalarValue(NewStringScalar("leaf"))
+	vt := ValueTarget(v)
+	if vt.IsNode() {
+		t.Error("value target reported IsNode true")
+	}
+	if _, ok := vt.Node(); ok {
+		t.Error("value target's Node() should report ok=false")
+	}
+	gotV, ok := vt.Value()
+	if !ok || !gotV.Scalar.Equal(v.Scalar) {
+		t.Errorf("value target's Value() = %+v, %v", gotV, ok)
+	}
+
+	child := NewNode()
+	nt := NodeTarget(child)
+	if !nt.IsNode() {
+		t.Error("node target reported IsNode false")
+	}
+	if _, ok := nt.Value(); ok {
+		t.Error("node target's Value() should report ok=false")
+	}
+	gotN, ok := nt.Node()
+	if !ok || gotN != child {
+		t.Errorf("node target's Node() = %v, %v", gotN, ok)
+	}
+}
+
+func TestNodeTargetNilPanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("NodeTarget(nil) should panic")
+		}
+	}()
+	NodeTarget(nil)
+}
+
+func TestNodeBuildingPreservesOrderAndRepeats(t *testing.T) {
+	// D-1/D-2: order preserved, repeated labels stay as separate edges.
+	n := NewNode().
+		AddValue("item", ScalarValue(NewStringScalar("pen"))).
+		AddValue("note", ScalarValue(NewStringScalar("rush"))).
+		AddValue("item", ScalarValue(NewStringScalar("pad")))
+
+	if len(n.Edges) != 3 {
+		t.Fatalf("expected 3 edges, got %d", len(n.Edges))
+	}
+	wantLabels := []string{"item", "note", "item"}
+	for i, want := range wantLabels {
+		if n.Edges[i].Label != want {
+			t.Errorf("edge %d label = %q, want %q", i, n.Edges[i].Label, want)
+		}
+	}
+	v0, _ := n.Edges[0].Target.Value()
+	v2, _ := n.Edges[2].Target.Value()
+	if v0.Scalar.Str != "pen" || v2.Scalar.Str != "pad" {
+		t.Error("repeated-label edges were merged or reordered")
+	}
+
+	child := NewNode()
+	n2 := NewNode().AddNode("child", child)
+	gotChild, ok := n2.Edges[0].Target.Node()
+	if !ok || gotChild != child {
+		t.Error("AddNode did not wire up the node target correctly")
+	}
+}
+
+func TestDocumentConstructors(t *testing.T) {
+	n := NewNode()
+	d := NodeDocument(n)
+	if !d.IsNode || d.Node != n {
+		t.Errorf("NodeDocument: got %+v", d)
+	}
+
+	v := ScalarValue(NewBooleanScalar(true))
+	d2 := ValueDocument(v)
+	if d2.IsNode || !d2.Value.Scalar.Equal(v.Scalar) {
+		t.Errorf("ValueDocument: got %+v", d2)
+	}
+}

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,148 @@
+package omnist
+
+import "fmt"
+
+// Code is a diagnostic code from the spec §8.3 taxonomy: a lowercase,
+// dot-separated path whose first segment is the family. Codes are stable
+// identifiers; once published, a code's meaning MUST NOT change.
+type Code string
+
+// parse.* — text to Document, stage 1 (spec §8.3.1).
+const (
+	CodeParseUnexpectedToken    Code = "parse.unexpected-token"
+	CodeParseTrailingContent    Code = "parse.trailing-content"
+	CodeParseUnterminatedString Code = "parse.unterminated-string"
+	CodeParseInvalidEscape      Code = "parse.invalid-escape"
+	CodeParseUnpairedSurrogate  Code = "parse.unpaired-surrogate"
+	CodeParseControlCharacter   Code = "parse.control-character"
+	CodeParseReservedWordLabel  Code = "parse.reserved-word-label"
+	CodeParseBareWord           Code = "parse.bare-word"
+	CodeParseEmptyArray         Code = "parse.empty-array"
+	CodeParseNestedArray        Code = "parse.nested-array"
+	CodeParseSeparatorInArray   Code = "parse.separator-in-array"
+)
+
+// document.* — building and limits (spec §8.3.2).
+const (
+	CodeDocumentLimitDepth       Code = "document.limit.depth"
+	CodeDocumentLimitNodes       Code = "document.limit.nodes"
+	CodeDocumentLimitIntDigits   Code = "document.limit.int-digits"
+	CodeDocumentUnlabeledElement Code = "document.unlabeled-element"
+)
+
+// schema.* — schema well-formedness (spec §8.3.3).
+const (
+	CodeSchemaNoRoot                Code = "schema.no-root"
+	CodeSchemaUnknownType           Code = "schema.unknown-type"
+	CodeSchemaDuplicateRecord       Code = "schema.duplicate-record"
+	CodeSchemaDuplicateField        Code = "schema.duplicate-field"
+	CodeSchemaReservedName          Code = "schema.reserved-name"
+	CodeSchemaInvalidCardinality    Code = "schema.invalid-cardinality"
+	CodeSchemaNonIntegerCardinality Code = "schema.non-integer-cardinality"
+	CodeSchemaEmptyCardinality      Code = "schema.empty-cardinality"
+	CodeSchemaUnquotedLabel         Code = "schema.unquoted-label"
+	CodeSchemaNullableRef           Code = "schema.nullable-ref"
+	CodeSchemaNullableAny           Code = "schema.nullable-any"
+)
+
+// validate.* — document against schema (spec §8.3.4).
+const (
+	CodeValidateShapeMismatch   Code = "validate.shape-mismatch"
+	CodeValidateTypeMismatch    Code = "validate.type-mismatch"
+	CodeValidateNullNotAllowed  Code = "validate.null-not-allowed"
+	CodeValidateUnexpectedField Code = "validate.unexpected-field"
+	CodeValidateCardinality     Code = "validate.cardinality"
+)
+
+// materialize.* — schema-directed deserialization (spec §8.3.5).
+const (
+	CodeMaterializeInexactConversion Code = "materialize.inexact-conversion"
+)
+
+// algebra.* — operations over schemas (spec §8.3.6).
+const (
+	CodeAlgebraExtractInvalidatesRoot  Code = "algebra.extract-invalidates-root"
+	CodeAlgebraInferNoSamples          Code = "algebra.infer-no-samples"
+	CodeAlgebraInferScalarRoot         Code = "algebra.infer-scalar-root"
+	CodeAlgebraInferConflictingScalars Code = "algebra.infer-conflicting-scalars"
+)
+
+// lint.* — schema diagnostics (spec §8.3.7).
+const (
+	CodeLintUnsatisfiableRecord Code = "lint.unsatisfiable-record"
+	CodeLintUnreachableRecord   Code = "lint.unreachable-record"
+	CodeLintDuplicateRecord     Code = "lint.duplicate-record"
+	CodeLintAnyField            Code = "lint.any-field"
+)
+
+// format.* — codec adjustments (spec §8.3.8).
+const (
+	CodeFormatTemporalStringified Code = "format.temporal-stringified"
+	CodeFormatFloatSpecial        Code = "format.float-special"
+	CodeFormatNullUnrepresentable Code = "format.null-unrepresentable"
+	CodeFormatAttributeDropped    Code = "format.attribute-dropped"
+	CodeFormatNamespaceDropped    Code = "format.namespace-dropped"
+	CodeFormatInterleavingLost    Code = "format.interleaving-lost"
+	CodeFormatMultipleRoots       Code = "format.multiple-roots"
+)
+
+// write.* (spec §8.3.9).
+const (
+	CodeWriteUnsupportedValue Code = "write.unsupported-value"
+)
+
+// Severity is a diagnostic's severity level, per spec §8.2's table.
+type Severity int
+
+const (
+	SeverityError Severity = iota
+	SeverityWarning
+	SeverityInfo
+)
+
+// String returns the taxonomy-style lowercase name of the severity.
+func (s Severity) String() string {
+	switch s {
+	case SeverityError:
+		return "error"
+	case SeverityWarning:
+		return "warning"
+	case SeverityInfo:
+		return "info"
+	default:
+		return "unknown"
+	}
+}
+
+// Diagnostic is a single reported problem, carrying at least the four
+// fields spec §8.2 requires: code, path, message, severity.
+type Diagnostic struct {
+	Path     string
+	Code     Code
+	Message  string
+	Severity Severity
+}
+
+// Error implements the error interface so a Diagnostic can be used
+// wherever a plain error is expected.
+func (d Diagnostic) Error() string {
+	return fmt.Sprintf("%s: %s: %s", d.Path, d.Code, d.Message)
+}
+
+// ParseError is the structured error a stage-1 (text to Document) reader
+// reports, per the design decision recorded in
+// docs/workflow-playbook.md §2.4. Its Path field MUST be a text-position
+// path per spec §8.4 (e.g. "14:8"), since a parse.* diagnostic fires
+// before any Document exists to descend a Document-shaped path into.
+type ParseError struct {
+	Line    int
+	Col     int
+	Path    string
+	Code    Code
+	Message string
+}
+
+// Error implements the error interface.
+func (e ParseError) Error() string {
+	return fmt.Sprintf("%d:%d: %s: %s", e.Line, e.Col, e.Code, e.Message)
+}

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,0 +1,93 @@
+package omnist
+
+import "testing"
+
+func TestSeverityString(t *testing.T) {
+	cases := []struct {
+		s    Severity
+		want string
+	}{
+		{SeverityError, "error"},
+		{SeverityWarning, "warning"},
+		{SeverityInfo, "info"},
+		{Severity(99), "unknown"},
+	}
+	for _, c := range cases {
+		if got := c.s.String(); got != c.want {
+			t.Errorf("Severity(%d).String() = %q, want %q", c.s, got, c.want)
+		}
+	}
+}
+
+func TestDiagnosticError(t *testing.T) {
+	d := Diagnostic{
+		Path:     "$.port",
+		Code:     CodeValidateTypeMismatch,
+		Message:  "expected integer",
+		Severity: SeverityError,
+	}
+	want := "$.port: validate.type-mismatch: expected integer"
+	if got := d.Error(); got != want {
+		t.Errorf("Diagnostic.Error() = %q, want %q", got, want)
+	}
+	// Diagnostic must satisfy the error interface.
+	var _ error = d
+}
+
+func TestParseErrorError(t *testing.T) {
+	e := ParseError{
+		Line:    14,
+		Col:     8,
+		Path:    "14:8",
+		Code:    CodeParseUnexpectedToken,
+		Message: "unexpected token",
+	}
+	want := "14:8: parse.unexpected-token: unexpected token"
+	if got := e.Error(); got != want {
+		t.Errorf("ParseError.Error() = %q, want %q", got, want)
+	}
+	var _ error = e
+}
+
+// TestAllTaxonomyCodesPresent is a light sanity check that every family's
+// constants are distinct non-empty strings, catching copy-paste
+// duplication across the long const blocks in errors.go.
+func TestAllTaxonomyCodesPresent(t *testing.T) {
+	codes := []Code{
+		CodeParseUnexpectedToken, CodeParseTrailingContent, CodeParseUnterminatedString,
+		CodeParseInvalidEscape, CodeParseUnpairedSurrogate, CodeParseControlCharacter,
+		CodeParseReservedWordLabel, CodeParseBareWord, CodeParseEmptyArray,
+		CodeParseNestedArray, CodeParseSeparatorInArray,
+		CodeDocumentLimitDepth, CodeDocumentLimitNodes, CodeDocumentLimitIntDigits,
+		CodeDocumentUnlabeledElement,
+		CodeSchemaNoRoot, CodeSchemaUnknownType, CodeSchemaDuplicateRecord,
+		CodeSchemaDuplicateField, CodeSchemaReservedName, CodeSchemaInvalidCardinality,
+		CodeSchemaNonIntegerCardinality, CodeSchemaEmptyCardinality,
+		CodeSchemaUnquotedLabel, CodeSchemaNullableRef, CodeSchemaNullableAny,
+		CodeValidateShapeMismatch, CodeValidateTypeMismatch, CodeValidateNullNotAllowed,
+		CodeValidateUnexpectedField, CodeValidateCardinality,
+		CodeMaterializeInexactConversion,
+		CodeAlgebraExtractInvalidatesRoot, CodeAlgebraInferNoSamples,
+		CodeAlgebraInferScalarRoot, CodeAlgebraInferConflictingScalars,
+		CodeLintUnsatisfiableRecord, CodeLintUnreachableRecord,
+		CodeLintDuplicateRecord, CodeLintAnyField,
+		CodeFormatTemporalStringified, CodeFormatFloatSpecial,
+		CodeFormatNullUnrepresentable, CodeFormatAttributeDropped,
+		CodeFormatNamespaceDropped, CodeFormatInterleavingLost,
+		CodeFormatMultipleRoots,
+		CodeWriteUnsupportedValue,
+	}
+	seen := make(map[Code]bool, len(codes))
+	for _, c := range codes {
+		if c == "" {
+			t.Errorf("empty code constant found")
+		}
+		if seen[c] {
+			t.Errorf("duplicate code constant: %q", c)
+		}
+		seen[c] = true
+	}
+	if len(codes) != 48 {
+		t.Errorf("expected 48 taxonomy codes, got %d", len(codes))
+	}
+}

--- a/limits.go
+++ b/limits.go
@@ -1,0 +1,107 @@
+package omnist
+
+// Limits bounds the work a Document builder will do before refusing to
+// continue, per spec §2.4. The existence and meaning of the three limits
+// is normative; the specific numbers are not, so Limits is a configurable
+// struct rather than package-level constants. Every conformant
+// implementation MUST enforce a finite limit on all three — "no limit" is
+// not a legal value for any field.
+type Limits struct {
+	// MaxDepth is the maximum levels of node nesting, counted from the
+	// Document root.
+	MaxDepth int
+	// MaxNodes is the maximum nodes materialized while building one
+	// Document.
+	MaxNodes int
+	// MaxIntDigits is the maximum decimal digits in an integer literal,
+	// sign excluded.
+	MaxIntDigits int
+}
+
+// DefaultLimits returns the spec §2.4 reference defaults: depth 200, node
+// count 1,000,000, integer digits 4,300.
+func DefaultLimits() Limits {
+	return Limits{
+		MaxDepth:     200,
+		MaxNodes:     1_000_000,
+		MaxIntDigits: 4300,
+	}
+}
+
+// LimitChecker tracks running depth and node count as a tree is walked,
+// and validates integer literal digit counts, against a fixed Limits
+// configuration. It is stateful and not safe for concurrent use.
+//
+// Nothing in this repository calls LimitChecker yet — issue #1 builds the
+// Document model and its safety-limit machinery only; future OML/OSD/JSON
+// etc. readers are expected to construct one LimitChecker per Document
+// they build and call its methods as they walk the input.
+type LimitChecker struct {
+	limits       Limits
+	currentDepth int
+	nodeCount    int
+}
+
+// NewLimitChecker returns a LimitChecker enforcing limits.
+func NewLimitChecker(limits Limits) *LimitChecker {
+	return &LimitChecker{limits: limits}
+}
+
+// EnterNode records descending into one more level of nesting and
+// materializing one more node. Call it when a reader starts building a new
+// node (including the root). Call LeaveNode when done with that node's
+// children. Returns a Diagnostic with code CodeDocumentLimitDepth or
+// CodeDocumentLimitNodes if the corresponding limit is exceeded, otherwise
+// nil.
+func (c *LimitChecker) EnterNode(path string) *Diagnostic {
+	c.currentDepth++
+	if c.currentDepth > c.limits.MaxDepth {
+		return &Diagnostic{
+			Path:     path,
+			Code:     CodeDocumentLimitDepth,
+			Message:  "nesting exceeds the configured depth limit",
+			Severity: SeverityError,
+		}
+	}
+	c.nodeCount++
+	if c.nodeCount > c.limits.MaxNodes {
+		return &Diagnostic{
+			Path:     path,
+			Code:     CodeDocumentLimitNodes,
+			Message:  "node count exceeds the configured node limit",
+			Severity: SeverityError,
+		}
+	}
+	return nil
+}
+
+// LeaveNode records ascending back out of one level of nesting entered via
+// EnterNode. Callers MUST call it exactly once for each successful
+// EnterNode call, after that node's children have all been processed.
+func (c *LimitChecker) LeaveNode() {
+	if c.currentDepth > 0 {
+		c.currentDepth--
+	}
+}
+
+// Depth returns the current nesting depth.
+func (c *LimitChecker) Depth() int { return c.currentDepth }
+
+// NodeCount returns the number of nodes entered so far.
+func (c *LimitChecker) NodeCount() int { return c.nodeCount }
+
+// CheckIntDigits validates that digitCount (the number of decimal digits
+// in an integer literal, sign excluded) does not exceed the configured
+// limit. Returns a Diagnostic with code CodeDocumentLimitIntDigits if it
+// does, otherwise nil.
+func (c *LimitChecker) CheckIntDigits(path string, digitCount int) *Diagnostic {
+	if digitCount > c.limits.MaxIntDigits {
+		return &Diagnostic{
+			Path:     path,
+			Code:     CodeDocumentLimitIntDigits,
+			Message:  "integer literal exceeds the configured digit limit",
+			Severity: SeverityError,
+		}
+	}
+	return nil
+}

--- a/limits_test.go
+++ b/limits_test.go
@@ -1,0 +1,92 @@
+package omnist
+
+import "testing"
+
+func TestDefaultLimits(t *testing.T) {
+	l := DefaultLimits()
+	if l.MaxDepth != 200 || l.MaxNodes != 1_000_000 || l.MaxIntDigits != 4300 {
+		t.Errorf("DefaultLimits() = %+v, want spec §2.4 reference defaults", l)
+	}
+}
+
+func TestLimitCheckerDepthOK(t *testing.T) {
+	c := NewLimitChecker(Limits{MaxDepth: 2, MaxNodes: 100, MaxIntDigits: 10})
+	if diag := c.EnterNode("$"); diag != nil {
+		t.Fatalf("unexpected diagnostic at depth 1: %+v", diag)
+	}
+	if diag := c.EnterNode("$.a"); diag != nil {
+		t.Fatalf("unexpected diagnostic at depth 2: %+v", diag)
+	}
+	if c.Depth() != 2 {
+		t.Errorf("Depth() = %d, want 2", c.Depth())
+	}
+	if c.NodeCount() != 2 {
+		t.Errorf("NodeCount() = %d, want 2", c.NodeCount())
+	}
+	c.LeaveNode()
+	if c.Depth() != 1 {
+		t.Errorf("Depth() after LeaveNode = %d, want 1", c.Depth())
+	}
+}
+
+func TestLimitCheckerDepthExceeded(t *testing.T) {
+	c := NewLimitChecker(Limits{MaxDepth: 1, MaxNodes: 100, MaxIntDigits: 10})
+	if diag := c.EnterNode("$"); diag != nil {
+		t.Fatalf("unexpected diagnostic within depth limit: %+v", diag)
+	}
+	diag := c.EnterNode("$.a")
+	if diag == nil {
+		t.Fatal("expected a depth-limit diagnostic, got nil")
+	}
+	if diag.Code != CodeDocumentLimitDepth {
+		t.Errorf("Code = %q, want %q", diag.Code, CodeDocumentLimitDepth)
+	}
+	if diag.Path != "$.a" {
+		t.Errorf("Path = %q, want %q", diag.Path, "$.a")
+	}
+	if diag.Severity != SeverityError {
+		t.Errorf("Severity = %v, want SeverityError", diag.Severity)
+	}
+}
+
+func TestLimitCheckerNodesExceeded(t *testing.T) {
+	c := NewLimitChecker(Limits{MaxDepth: 100, MaxNodes: 2, MaxIntDigits: 10})
+	if diag := c.EnterNode("$"); diag != nil {
+		t.Fatalf("unexpected diagnostic for node 1: %+v", diag)
+	}
+	if diag := c.EnterNode("$.a"); diag != nil {
+		t.Fatalf("unexpected diagnostic for node 2: %+v", diag)
+	}
+	diag := c.EnterNode("$.b")
+	if diag == nil {
+		t.Fatal("expected a node-count-limit diagnostic, got nil")
+	}
+	if diag.Code != CodeDocumentLimitNodes {
+		t.Errorf("Code = %q, want %q", diag.Code, CodeDocumentLimitNodes)
+	}
+}
+
+func TestLimitCheckerLeaveNodeAtZeroIsNoop(t *testing.T) {
+	c := NewLimitChecker(DefaultLimits())
+	c.LeaveNode() // must not panic or go negative
+	if c.Depth() != 0 {
+		t.Errorf("Depth() = %d, want 0", c.Depth())
+	}
+}
+
+func TestLimitCheckerIntDigits(t *testing.T) {
+	c := NewLimitChecker(Limits{MaxDepth: 100, MaxNodes: 100, MaxIntDigits: 5})
+	if diag := c.CheckIntDigits("$.n", 5); diag != nil {
+		t.Fatalf("unexpected diagnostic at exactly the limit: %+v", diag)
+	}
+	diag := c.CheckIntDigits("$.n", 6)
+	if diag == nil {
+		t.Fatal("expected an int-digits-limit diagnostic, got nil")
+	}
+	if diag.Code != CodeDocumentLimitIntDigits {
+		t.Errorf("Code = %q, want %q", diag.Code, CodeDocumentLimitIntDigits)
+	}
+	if diag.Path != "$.n" {
+		t.Errorf("Path = %q, want %q", diag.Path, "$.n")
+	}
+}

--- a/path.go
+++ b/path.go
@@ -1,0 +1,81 @@
+package omnist
+
+import "strconv"
+
+// pathSegment is one label step in a Document path, per spec §8.4.
+type pathSegment struct {
+	label    string
+	index    int
+	hasIndex bool
+}
+
+// Path is a Document or Schema path, per spec §8.4: it starts at "$" and
+// descends by label, disambiguating a repeated label with a zero-based
+// occurrence index in brackets. The index is present if and only if the
+// label occurs more than once in the node it appears in — Path never
+// decides that on its own; callers supply it (typically via
+// PathIndexInNode) because only the caller walking a Node knows how many
+// edges in it share a label.
+//
+// The zero Path is the root path "$".
+type Path struct {
+	segments []pathSegment
+}
+
+// RootPath returns the path to the whole Document or schema: "$".
+func RootPath() Path {
+	return Path{}
+}
+
+// Child returns a new Path formed by descending one edge labeled label.
+// If repeated is true, index is rendered as a bracketed occurrence index
+// (e.g. "$.item[2]"); if repeated is false, index is ignored and no
+// bracket is rendered (e.g. "$.name"). Per spec §8.4 the index MUST be
+// present exactly when the label occurs more than once in that node, so
+// callers must determine repeated (e.g. via PathIndexInNode) rather than
+// always passing true.
+func (p Path) Child(label string, index int, repeated bool) Path {
+	next := make([]pathSegment, len(p.segments), len(p.segments)+1)
+	copy(next, p.segments)
+	next = append(next, pathSegment{label: label, index: index, hasIndex: repeated})
+	return Path{segments: next}
+}
+
+// String renders the path per spec §8.4: "$" for the root, "$.label" for
+// a single-occurrence edge, "$.label[N]" for a repeated label.
+func (p Path) String() string {
+	out := "$"
+	for _, seg := range p.segments {
+		out += "." + seg.label
+		if seg.hasIndex {
+			out += "[" + strconv.Itoa(seg.index) + "]"
+		}
+	}
+	return out
+}
+
+// PathIndexInNode reports the zero-based occurrence index of the edge at
+// edgeIndex within node.Edges, counting only edges sharing that edge's
+// label, and whether that label occurs more than once in node overall.
+// It is the helper a reader walking a Node uses to build the (index,
+// repeated) arguments Path.Child needs, so the "index present iff label
+// repeats" rule (spec §8.4) is computed in one place rather than
+// re-derived at every call site.
+//
+// Panics if edgeIndex is out of range, since that indicates a caller bug
+// rather than a reportable condition.
+func PathIndexInNode(node *Node, edgeIndex int) (occurrence int, repeated bool) {
+	label := node.Edges[edgeIndex].Label
+	count := 0
+	occurrenceOfTarget := -1
+	for i, e := range node.Edges {
+		if e.Label != label {
+			continue
+		}
+		if i == edgeIndex {
+			occurrenceOfTarget = count
+		}
+		count++
+	}
+	return occurrenceOfTarget, count > 1
+}

--- a/path_test.go
+++ b/path_test.go
@@ -1,0 +1,95 @@
+package omnist
+
+import "testing"
+
+func TestRootPathString(t *testing.T) {
+	if got := RootPath().String(); got != "$" {
+		t.Errorf("RootPath().String() = %q, want %q", got, "$")
+	}
+}
+
+func TestPathChildSingleOccurrence(t *testing.T) {
+	p := RootPath().Child("name", 0, false)
+	if got := p.String(); got != "$.name" {
+		t.Errorf("got %q, want %q", got, "$.name")
+	}
+}
+
+func TestPathChildRepeatedOccurrence(t *testing.T) {
+	// Spec §8.4 worked examples.
+	p0 := RootPath().Child("item", 0, true)
+	if got := p0.String(); got != "$.item[0]" {
+		t.Errorf("got %q, want %q", got, "$.item[0]")
+	}
+
+	p2sku := RootPath().Child("item", 2, true).Child("sku", 0, false)
+	if got := p2sku.String(); got != "$.item[2].sku" {
+		t.Errorf("got %q, want %q", got, "$.item[2].sku")
+	}
+}
+
+func TestPathChildDoesNotMutateParent(t *testing.T) {
+	root := RootPath()
+	child := root.Child("a", 0, false)
+	if root.String() != "$" {
+		t.Errorf("parent path mutated: %q", root.String())
+	}
+	if child.String() != "$.a" {
+		t.Errorf("child path = %q, want %q", child.String(), "$.a")
+	}
+	// Branching from the same parent must not share backing storage.
+	sibling := root.Child("b", 0, false)
+	if child.String() != "$.a" || sibling.String() != "$.b" {
+		t.Errorf("sibling branches interfered: child=%q sibling=%q", child.String(), sibling.String())
+	}
+}
+
+func TestPathIndexInNode(t *testing.T) {
+	// [(item,"pen"), (note,"rush"), (item,"pad")] from spec §2.1's example.
+	n := NewNode().
+		AddValue("item", ScalarValue(NewStringScalar("pen"))).
+		AddValue("note", ScalarValue(NewStringScalar("rush"))).
+		AddValue("item", ScalarValue(NewStringScalar("pad")))
+
+	occ, repeated := PathIndexInNode(n, 0)
+	if occ != 0 || !repeated {
+		t.Errorf("edge 0 (item): occ=%d repeated=%v, want 0,true", occ, repeated)
+	}
+	occ, repeated = PathIndexInNode(n, 1)
+	if occ != 0 || repeated {
+		t.Errorf("edge 1 (note): occ=%d repeated=%v, want 0,false", occ, repeated)
+	}
+	occ, repeated = PathIndexInNode(n, 2)
+	if occ != 1 || !repeated {
+		t.Errorf("edge 2 (item): occ=%d repeated=%v, want 1,true", occ, repeated)
+	}
+}
+
+func TestPathIndexInNodeThreeItems(t *testing.T) {
+	// Spec §8.4: "$.item[2].sku" implies a node with at least 3 `item`
+	// edges, where the third (index 2) has a `sku` child.
+	sku := NewNode().AddValue("sku", ScalarValue(NewStringScalar("abc")))
+	n := NewNode().
+		AddValue("item", ScalarValue(NewStringScalar("a"))).
+		AddValue("item", ScalarValue(NewStringScalar("b"))).
+		AddNode("item", sku)
+
+	occ, repeated := PathIndexInNode(n, 2)
+	if occ != 2 || !repeated {
+		t.Errorf("third item: occ=%d repeated=%v, want 2,true", occ, repeated)
+	}
+	p := RootPath().Child("item", occ, repeated).Child("sku", 0, false)
+	if got := p.String(); got != "$.item[2].sku" {
+		t.Errorf("got %q, want %q", got, "$.item[2].sku")
+	}
+}
+
+func TestPathIndexInNodePanicsOutOfRange(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected a panic for out-of-range edgeIndex")
+		}
+	}()
+	n := NewNode()
+	PathIndexInNode(n, 0)
+}


### PR DESCRIPTION
Closes #1.

Implements the Document model core per spec Sec2.2-2.4 and the Sec8.3 error-code taxonomy, following the four design decisions recorded in docs/workflow-playbook.md Sec2.

Independently verified: 100% per-function coverage, 0 golangci-lint issues, D-1/D-2/D-4/D-5 structural invariants confirmed by tracing the actual comparison/construction logic (not just green tests), all 48 error codes diffed programmatically against the spec table (exact match), path formatting hand-traced against the spec worked examples.

No spec ambiguity encountered.