### PR TITLE
OML reader (text to Document)

### DIFF
--- a/oml_lexer.go
+++ b/oml_lexer.go
@@ -1,0 +1,539 @@
+package omnist
+
+import (
+	"fmt"
+	"math"
+	"math/big"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// tokenKind identifies the lexical category of a token, per spec §4.2's
+// fixed tokenizer priority order.
+type tokenKind int
+
+const (
+	tokEOF tokenKind = iota
+	tokString
+	tokLBrace
+	tokRBrace
+	tokLBracket
+	tokRBracket
+	tokColon
+	tokComma
+	tokDateTime
+	tokDate
+	tokTime
+	tokNumber
+	tokInteger
+	tokIdent
+)
+
+// token is one lexical token, carrying enough decoded value to build a
+// Document leaf directly, plus position info for ParseError.
+type token struct {
+	kind tokenKind
+	text string // raw source text (identifier/label text, or number's raw digits)
+	line int    // 1-based line of the token's first character
+	col  int    // 1-based column of the token's first character
+
+	// sepBefore reports whether a separator (a run of skipped trivia
+	// containing at least one newline or ';', per spec §4.2.1) preceded
+	// this token. hspace/comment-only runs do not set this.
+	sepBefore bool
+	// sepLine/sepCol locate the first newline or ';' of that separator,
+	// for error reporting when a separator appears somewhere it must not
+	// (inside an array, per §4.3.1).
+	sepLine, sepCol int
+
+	// Decoded values, meaningful only for the corresponding kind.
+	strVal      string
+	intVal      *big.Int
+	intDigits   int
+	numVal      float64
+	dateVal     DateValue
+	timeVal     TimeValue
+	dateTimeVal DateTimeValue
+}
+
+// lexer turns OML source text into a stream of tokens per spec §4.2's
+// maximal-munch-under-fixed-priority-order algorithm: at each position the
+// first matching rule (in the fixed order) wins outright, consuming only
+// that rule's own match — there is no cross-rule "longest match wins" and
+// no backtracking. This means, for example, that reserved-float matches
+// ("nan", "inf", "-inf") win over IDENT even when a longer IDENT would
+// otherwise be extractable from the same position (e.g. "nano" lexes as
+// NUMBER("nan") followed by IDENT("o")); this is the literal, intended
+// consequence of the algorithm as specified in §4.2, not a bug worked
+// around here.
+type lexer struct {
+	src  []rune
+	pos  int
+	line int
+	col  int
+
+	limits *LimitChecker
+}
+
+func newLexer(text string, limits *LimitChecker) *lexer {
+	return &lexer{src: []rune(text), pos: 0, line: 1, col: 1, limits: limits}
+}
+
+func (l *lexer) atEOF() bool { return l.pos >= len(l.src) }
+
+func (l *lexer) peekRune() rune {
+	if l.atEOF() {
+		return 0
+	}
+	return l.src[l.pos]
+}
+
+func (l *lexer) peekRuneAt(offset int) rune {
+	if l.pos+offset >= len(l.src) {
+		return 0
+	}
+	return l.src[l.pos+offset]
+}
+
+// advance consumes one rune, updating line/col.
+func (l *lexer) advance() rune {
+	r := l.src[l.pos]
+	l.pos++
+	if r == '\n' {
+		l.line++
+		l.col = 1
+	} else {
+		l.col++
+	}
+	return r
+}
+
+// skipTrivia consumes horizontal space and comments (which emit no
+// token), and tracks whether a newline or ';' was seen among them (which
+// makes the following token separator-preceded, per §4.2.1).
+func (l *lexer) skipTrivia() (sawSep bool, sepLine, sepCol int) {
+	for !l.atEOF() {
+		r := l.peekRune()
+		switch r {
+		case ' ', '\t':
+			l.advance()
+		case '\r':
+			// CRLF or lone CR both count as a newline separator.
+			if !sawSep {
+				sawSep, sepLine, sepCol = true, l.line, l.col
+			}
+			l.advance()
+			if l.peekRune() == '\n' {
+				l.advance()
+			}
+		case '\n':
+			if !sawSep {
+				sawSep, sepLine, sepCol = true, l.line, l.col
+			}
+			l.advance()
+		case ';':
+			if !sawSep {
+				sawSep, sepLine, sepCol = true, l.line, l.col
+			}
+			l.advance()
+		case '#':
+			for !l.atEOF() && l.peekRune() != '\n' {
+				l.advance()
+			}
+		default:
+			return sawSep, sepLine, sepCol
+		}
+	}
+	return sawSep, sepLine, sepCol
+}
+
+var (
+	reDateTime = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2}(\.\d{1,6})?)?([+-]\d{2}:\d{2})?`)
+	reDate     = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}`)
+	reTime     = regexp.MustCompile(`^\d{2}:\d{2}(:\d{2}(\.\d{1,6})?)?([+-]\d{2}:\d{2})?`)
+	reNumber   = regexp.MustCompile(`^-?\d+(\.\d+([eE][+-]?\d+)?|[eE][+-]?\d+)`)
+	reInteger  = regexp.MustCompile(`^-?\d+`)
+	reIdent    = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_-]*`)
+)
+
+// remainingString returns the source from the current position onward, as
+// a string, for regexp matching. Cheap enough: called once per token.
+func (l *lexer) remainingString() string {
+	return string(l.src[l.pos:])
+}
+
+// next returns the next token, or a *ParseError. It is the single entry
+// point implementing §4.2's priority order.
+func (l *lexer) next() (token, *ParseError) {
+	sawSep, sepLine, sepCol := l.skipTrivia()
+	startLine, startCol := l.line, l.col
+
+	if l.atEOF() {
+		return token{kind: tokEOF, line: startLine, col: startCol, sepBefore: sawSep, sepLine: sepLine, sepCol: sepCol}, nil
+	}
+
+	r := l.peekRune()
+
+	// Rule 1: STRING family.
+	if r == '"' || r == '\'' {
+		tok, err := l.scanString()
+		if err != nil {
+			return token{}, err
+		}
+		tok.line, tok.col = startLine, startCol
+		tok.sepBefore, tok.sepLine, tok.sepCol = sawSep, sepLine, sepCol
+		return tok, nil
+	}
+
+	// Rule 2: punctuation.
+	if k, ok := punctKind(r); ok {
+		l.advance()
+		return token{kind: k, text: string(r), line: startLine, col: startCol, sepBefore: sawSep, sepLine: sepLine, sepCol: sepCol}, nil
+	}
+
+	rest := l.remainingString()
+
+	// Rule 3: DATETIME.
+	if m := reDateTime.FindString(rest); m != "" {
+		l.consumeRunes(len([]rune(m)))
+		return token{kind: tokDateTime, text: m, dateTimeVal: parseDateTimeValue(m), line: startLine, col: startCol, sepBefore: sawSep, sepLine: sepLine, sepCol: sepCol}, nil
+	}
+
+	// Rule 4: DATE (not followed by a valid DATETIME, already excluded above).
+	if m := reDate.FindString(rest); m != "" {
+		l.consumeRunes(len([]rune(m)))
+		return token{kind: tokDate, text: m, dateVal: parseDateValue(m), line: startLine, col: startCol, sepBefore: sawSep, sepLine: sepLine, sepCol: sepCol}, nil
+	}
+
+	// Rule 5: TIME.
+	if m := reTime.FindString(rest); m != "" {
+		l.consumeRunes(len([]rune(m)))
+		return token{kind: tokTime, text: m, timeVal: parseTimeValue(m), line: startLine, col: startCol, sepBefore: sawSep, sepLine: sepLine, sepCol: sepCol}, nil
+	}
+
+	// Rule 6: NUMBER (decimal or exponent form).
+	if m := reNumber.FindString(rest); m != "" {
+		l.consumeRunes(len([]rune(m)))
+		f, _ := strconv.ParseFloat(m, 64)
+		return token{kind: tokNumber, text: m, numVal: f, line: startLine, col: startCol, sepBefore: sawSep, sepLine: sepLine, sepCol: sepCol}, nil
+	}
+
+	// Rule 7: reserved float spellings, emitted as NUMBER.
+	if m, val, ok := matchReservedFloat(rest); ok {
+		l.consumeRunes(len([]rune(m)))
+		return token{kind: tokNumber, text: m, numVal: val, line: startLine, col: startCol, sepBefore: sawSep, sepLine: sepLine, sepCol: sepCol}, nil
+	}
+
+	// Rule 8: INTEGER.
+	if m := reInteger.FindString(rest); m != "" {
+		l.consumeRunes(len([]rune(m)))
+		digits := len(m)
+		if strings.HasPrefix(m, "-") {
+			digits--
+		}
+		if diag := l.limits.CheckIntDigits(fmt.Sprintf("%d:%d", startLine, startCol), digits); diag != nil {
+			return token{}, &ParseError{Line: startLine, Col: startCol, Path: fmt.Sprintf("%d:%d", startLine, startCol), Code: diag.Code, Message: diag.Message}
+		}
+		bi, _ := new(big.Int).SetString(m, 10)
+		return token{kind: tokInteger, text: m, intVal: bi, intDigits: digits, line: startLine, col: startCol, sepBefore: sawSep, sepLine: sepLine, sepCol: sepCol}, nil
+	}
+
+	// Rule 9: IDENT.
+	if m := reIdent.FindString(rest); m != "" {
+		l.consumeRunes(len([]rune(m)))
+		return token{kind: tokIdent, text: m, line: startLine, col: startCol, sepBefore: sawSep, sepLine: sepLine, sepCol: sepCol}, nil
+	}
+
+	return token{}, &ParseError{
+		Line: startLine, Col: startCol,
+		Path:    fmt.Sprintf("%d:%d", startLine, startCol),
+		Code:    CodeParseUnexpectedToken,
+		Message: fmt.Sprintf("unexpected character %q", r),
+	}
+}
+
+func punctKind(r rune) (tokenKind, bool) {
+	switch r {
+	case '{':
+		return tokLBrace, true
+	case '}':
+		return tokRBrace, true
+	case '[':
+		return tokLBracket, true
+	case ']':
+		return tokRBracket, true
+	case ':':
+		return tokColon, true
+	case ',':
+		return tokComma, true
+	}
+	return 0, false
+}
+
+// consumeRunes advances n runes, tracking line/col (none of the matched
+// texts here (dates/times/numbers/idents) can themselves contain a
+// newline, so this does not need the newline-handling in advance, but
+// reuses it for a single code path).
+func (l *lexer) consumeRunes(n int) {
+	for i := 0; i < n; i++ {
+		l.advance()
+	}
+}
+
+// matchReservedFloat matches the literal reserved-float spellings "nan",
+// "inf", "-inf" per §4.2 rule 7 and the reserved-number ABNF production.
+// Per the priority-order semantics documented on lexer, this is a fixed
+// literal match, not extended to consume further ident-continuation
+// characters that might follow.
+func matchReservedFloat(rest string) (matched string, val float64, ok bool) {
+	switch {
+	case strings.HasPrefix(rest, "nan"):
+		return "nan", math.NaN(), true
+	case strings.HasPrefix(rest, "-inf"):
+		return "-inf", math.Inf(-1), true
+	case strings.HasPrefix(rest, "inf"):
+		return "inf", math.Inf(1), true
+	}
+	return "", 0, false
+}
+
+// --- temporal value construction ---
+//
+// parseDateValue/parseTimeValue/parseDateTimeValue are only ever called on
+// text already matched by reDate/reTime/reDateTime, which fully pin the
+// digit layout these functions assume (down to field widths). Given that
+// precondition the Sscanf/index calls below cannot fail, so — unlike the
+// lexer's other decoders — these deliberately have no error return: an
+// error-returning version would carry a permanently-dead "malformed"
+// branch that no input could ever reach (regex guarantees the format),
+// which is worse for coverage and for readability than asserting the
+// precondition in this comment once, here.
+
+func parseDateValue(s string) DateValue {
+	var y, mo, d int
+	_, _ = fmt.Sscanf(s, "%4d-%2d-%2d", &y, &mo, &d)
+	return DateValue{Year: y, Month: mo, Day: d}
+}
+
+func parseTimeValue(s string) TimeValue {
+	rest := s
+	var hh, mm int
+	_, _ = fmt.Sscanf(rest, "%2d:%2d", &hh, &mm)
+	rest = rest[5:]
+	tv := TimeValue{Hour: hh, Minute: mm}
+	if strings.HasPrefix(rest, ":") {
+		var ss int
+		_, _ = fmt.Sscanf(rest[1:], "%2d", &ss)
+		tv.Second = ss
+		rest = rest[3:]
+		if strings.HasPrefix(rest, ".") {
+			end := 1
+			for end < len(rest) && rest[end] >= '0' && rest[end] <= '9' {
+				end++
+			}
+			tv.Nanosecond = fracToNanos(rest[1:end])
+			rest = rest[end:]
+		}
+	}
+	if len(rest) == 6 && (rest[0] == '+' || rest[0] == '-') {
+		var oh, om int
+		_, _ = fmt.Sscanf(rest[1:], "%2d:%2d", &oh, &om)
+		sign := 1
+		if rest[0] == '-' {
+			sign = -1
+		}
+		tv.HasOffset = true
+		tv.OffsetSeconds = sign * (oh*3600 + om*60)
+	}
+	return tv
+}
+
+func parseDateTimeValue(s string) DateTimeValue {
+	idx := strings.IndexByte(s, 'T')
+	return DateTimeValue{Date: parseDateValue(s[:idx]), Time: parseTimeValue(s[idx+1:])}
+}
+
+// fracToNanos converts a fractional-second digit string (1-6 digits, as
+// matched by the grammar) to nanoseconds, right-padding to 9 digits.
+func fracToNanos(digits string) int {
+	padded := (digits + "000000000")[:9]
+	n, _ := strconv.Atoi(padded)
+	return n
+}
+
+// --- string scanning ---
+
+func (l *lexer) scanString() (token, *ParseError) {
+	if l.peekRune() == '\'' {
+		return l.scanRawString()
+	}
+	// '"' next: distinguish multiline ("""...""") from single dquote.
+	if l.peekRune() == '"' && l.peekRuneAt(1) == '"' && l.peekRuneAt(2) == '"' {
+		return l.scanMultilineString()
+	}
+	return l.scanDQuoteString()
+}
+
+func (l *lexer) errAt(line, col int, code Code, msg string) *ParseError {
+	return &ParseError{Line: line, Col: col, Path: fmt.Sprintf("%d:%d", line, col), Code: code, Message: msg}
+}
+
+func (l *lexer) scanRawString() (token, *ParseError) {
+	startLine, startCol := l.line, l.col
+	l.advance() // opening '
+	var b strings.Builder
+	for {
+		if l.atEOF() {
+			return token{}, l.errAt(startLine, startCol, CodeParseUnterminatedString, "unterminated raw string")
+		}
+		r := l.advance()
+		if r == '\'' {
+			return token{kind: tokString, strVal: b.String()}, nil
+		}
+		b.WriteRune(r)
+	}
+}
+
+func (l *lexer) scanDQuoteString() (token, *ParseError) {
+	startLine, startCol := l.line, l.col
+	l.advance() // opening "
+	var b strings.Builder
+	for {
+		if l.atEOF() {
+			return token{}, l.errAt(startLine, startCol, CodeParseUnterminatedString, "unterminated string")
+		}
+		cLine, cCol := l.line, l.col
+		r := l.advance()
+		switch {
+		case r == '"':
+			return token{kind: tokString, strVal: b.String()}, nil
+		case r == '\\':
+			if l.atEOF() {
+				return token{}, l.errAt(startLine, startCol, CodeParseUnterminatedString, "unterminated string")
+			}
+			if err := l.scanEscape(&b, cLine, cCol); err != nil {
+				return token{}, err
+			}
+		case r < 0x20:
+			return token{}, l.errAt(cLine, cCol, CodeParseControlCharacter, "control character in string")
+		default:
+			b.WriteRune(r)
+		}
+	}
+}
+
+func (l *lexer) scanEscape(b *strings.Builder, escLine, escCol int) *ParseError {
+	e := l.advance()
+	switch e {
+	case '"':
+		b.WriteRune('"')
+	case '\\':
+		b.WriteRune('\\')
+	case '/':
+		b.WriteRune('/')
+	case 'b':
+		b.WriteRune('\b')
+	case 'f':
+		b.WriteRune('\f')
+	case 'n':
+		b.WriteRune('\n')
+	case 'r':
+		b.WriteRune('\r')
+	case 't':
+		b.WriteRune('\t')
+	case 'u':
+		cp, err := l.scanHex4(escLine, escCol)
+		if err != nil {
+			return err
+		}
+		switch {
+		case cp >= 0xD800 && cp <= 0xDBFF:
+			// High surrogate: must be immediately followed by \uXXXX low surrogate.
+			if l.peekRune() != '\\' || l.peekRuneAt(1) != 'u' {
+				return l.errAt(escLine, escCol, CodeParseUnpairedSurrogate, "unpaired surrogate escape")
+			}
+			l.advance() // backslash
+			l.advance() // u
+			low, err := l.scanHex4(escLine, escCol)
+			if err != nil {
+				return err
+			}
+			if low < 0xDC00 || low > 0xDFFF {
+				return l.errAt(escLine, escCol, CodeParseUnpairedSurrogate, "unpaired surrogate escape")
+			}
+			combined := 0x10000 + (cp-0xD800)*0x400 + (low - 0xDC00)
+			b.WriteRune(rune(combined))
+		case cp >= 0xDC00 && cp <= 0xDFFF:
+			// Lone low surrogate.
+			return l.errAt(escLine, escCol, CodeParseUnpairedSurrogate, "unpaired surrogate escape")
+		default:
+			b.WriteRune(rune(cp))
+		}
+	default:
+		return l.errAt(escLine, escCol, CodeParseInvalidEscape, fmt.Sprintf("invalid escape \\%c", e))
+	}
+	return nil
+}
+
+func (l *lexer) scanHex4(errLine, errCol int) (int, *ParseError) {
+	if l.pos+4 > len(l.src) {
+		return 0, l.errAt(errLine, errCol, CodeParseUnterminatedString, "unterminated \\u escape")
+	}
+	digits := string(l.src[l.pos : l.pos+4])
+	v, err := strconv.ParseUint(digits, 16, 32)
+	if err != nil {
+		return 0, l.errAt(errLine, errCol, CodeParseInvalidEscape, "invalid \\u escape")
+	}
+	l.consumeRunes(4)
+	return int(v), nil
+}
+
+// scanMultilineString implements §4.5's multiline-string rule: closes at
+// the first run of three or more '"'; the first three are consumed as the
+// terminator and any further quotes in that run are left in the buffer
+// for the scanner to re-tokenize (this is what makes the four-quote
+// worked example in §4.8 produce an unterminated-string error rather than
+// consuming a fourth literal quote character).
+func (l *lexer) scanMultilineString() (token, *ParseError) {
+	startLine, startCol := l.line, l.col
+	l.advance()
+	l.advance()
+	l.advance() // opening """
+	if l.peekRune() == '\r' {
+		l.advance()
+		if l.peekRune() == '\n' {
+			l.advance()
+		}
+	} else if l.peekRune() == '\n' {
+		l.advance()
+	}
+	var b strings.Builder
+	for {
+		if l.atEOF() {
+			return token{}, l.errAt(startLine, startCol, CodeParseUnterminatedString, "unterminated multiline string")
+		}
+		cLine, cCol := l.line, l.col
+		r := l.peekRune()
+		if r == '"' {
+			run := 0
+			for l.peekRuneAt(run) == '"' {
+				run++
+			}
+			if run >= 3 {
+				l.consumeRunes(3)
+				return token{kind: tokString, strVal: b.String()}, nil
+			}
+			// A run of one or two quotes is literal content.
+			for i := 0; i < run; i++ {
+				b.WriteRune(l.advance())
+			}
+			continue
+		}
+		if r == '\t' || r == '\n' || r >= 0x20 {
+			b.WriteRune(l.advance())
+			continue
+		}
+		return token{}, l.errAt(cLine, cCol, CodeParseControlCharacter, "control character in multiline string")
+	}
+}

--- a/oml_parser.go
+++ b/oml_parser.go
@@ -1,0 +1,422 @@
+package omnist
+
+import "fmt"
+
+// ReadOML parses OML source text into a Document (spec ch.4, "text to
+// Document, stage 1"). limits configures the safety limits enforced while
+// reading (integer digit count at tokenize time, nesting depth at parse
+// time), per the design decision that Limits is always caller-configurable
+// rather than hardcoded (docs/workflow-playbook.md §2.4, limits.go).
+//
+// On any parse failure the returned error is a *ParseError whose Path is a
+// text-position path ("line:col", 1-based) per spec §8.4 — no Document
+// path is possible, since a parse.* failure occurs before a Document
+// exists.
+func ReadOML(text string, limits Limits) (Document, error) {
+	checker := NewLimitChecker(limits)
+	p := &parser{lex: newLexer(text, checker), checker: checker}
+	if err := p.advance(); err != nil {
+		return Document{}, err
+	}
+	doc, err := p.parseDocument()
+	if err != nil {
+		return Document{}, err
+	}
+	return doc, nil
+}
+
+type parser struct {
+	lex     *lexer
+	checker *LimitChecker
+	cur     token
+}
+
+func (p *parser) advance() *ParseError {
+	tok, err := p.lex.next()
+	if err != nil {
+		return err
+	}
+	p.cur = tok
+	return nil
+}
+
+func (p *parser) errAt(t token, code Code, msg string) *ParseError {
+	return &ParseError{Line: t.line, Col: t.col, Path: fmt.Sprintf("%d:%d", t.line, t.col), Code: code, Message: msg}
+}
+
+// isReservedWord reports whether text is one of the three parser-level
+// reserved words excluded from bare-label position (spec §4.4). nan/inf
+// are excluded earlier, by the tokenizer (§4.2.2), so they never reach
+// this check as an IDENT in the first place.
+func isReservedWord(text string) bool {
+	return text == "null" || text == "true" || text == "false"
+}
+
+// startsLabelColon reports whether the current token could begin a label
+// immediately followed by ':' — i.e. is a STRING, or an IDENT that is not
+// null/true/false. It does not itself check the following token; callers
+// combine it with a one-token lookahead per §4.6.1.
+func (p *parser) startsLabelColon() bool {
+	switch p.cur.kind {
+	case tokString:
+		return true
+	case tokIdent:
+		return !isReservedWord(p.cur.text)
+	default:
+		return false
+	}
+}
+
+// parseDocument implements §4.6/§4.6.1: [SEP] (node-edges / scalar) [SEP],
+// with the top-level lookahead disambiguation. Leading/trailing SEP is
+// invisible here already (the lexer never emits separator tokens; it only
+// tracks sepBefore on the following real token), so this reduces to:
+// decide the shape from the current token plus one token of lookahead,
+// parse it, then require EOF.
+func (p *parser) parseDocument() (Document, error) {
+	if p.cur.kind == tokEOF {
+		return NodeDocument(NewNode()), nil
+	}
+
+	if p.looksLikeEdgeStart() {
+		// parseNodeEdges(tokEOF) only returns successfully once p.cur is
+		// tokEOF (that is its loop's own exit condition), so there is no
+		// separate trailing-content check to make here.
+		node, err := p.parseNodeEdges(tokEOF)
+		if err != nil {
+			return Document{}, err
+		}
+		return NodeDocument(node), nil
+	}
+
+	val, err := p.parseScalarValue()
+	if err != nil {
+		return Document{}, err
+	}
+	if p.cur.kind != tokEOF {
+		return Document{}, p.errAt(p.cur, CodeParseTrailingContent, "content remains after the document")
+	}
+	return ValueDocument(val), nil
+}
+
+// looksLikeEdgeStart implements the §4.6.1 one-token lookahead: STRING or
+// non-reserved IDENT, followed by ':'. It must peek one token ahead
+// without disturbing p.cur for the caller that takes the scalar branch,
+// so it snapshots the lexer position/state and restores it when the
+// scalar branch is chosen — the lexer itself has no other mutable state
+// besides position/line/col, and the LimitChecker isn't touched by
+// tokenizing a single lookahead token except for CheckIntDigits, which is
+// a pure validation (no counters mutated), so re-scanning the same token
+// on the scalar branch is safe and side-effect free.
+//
+// If the lookahead token itself turns out to be malformed, this reports
+// "not an edge start" rather than an error: normal parsing will retokenize
+// the same position immediately afterward (on the scalar branch) and
+// surface that same lex error there, which is where a caller expects a
+// *ParseError from, not from a lookahead helper.
+func (p *parser) looksLikeEdgeStart() bool {
+	if !p.startsLabelColon() {
+		return false
+	}
+	savedLex := *p.lex
+	next, err := p.lex.next()
+	*p.lex = savedLex
+	if err != nil {
+		return false
+	}
+	return next.kind == tokColon
+}
+
+// parseNodeEdges parses zero or more edges (spec node-edges = [ edge
+// *( SEP edge ) ]) until closing is seen (tokRBrace or tokEOF). It does
+// not consume the closing token.
+func (p *parser) parseNodeEdges(closing tokenKind) (*Node, error) {
+	node := NewNode()
+	first := true
+	for p.cur.kind != closing {
+		if p.cur.kind == tokEOF && closing != tokEOF {
+			return nil, p.errAt(p.cur, CodeParseUnexpectedToken, "unexpected end of input, expected '}'")
+		}
+		if !first && !p.cur.sepBefore {
+			return nil, p.errAt(p.cur, CodeParseUnexpectedToken, "expected a separator (newline or ';') between edges")
+		}
+		edges, err := p.parseEdge()
+		if err != nil {
+			return nil, err
+		}
+		node.Edges = append(node.Edges, edges...)
+		first = false
+	}
+	return node, nil
+}
+
+// parseEdge parses one `label ':' [SEP] value` production. Per §4.3.1,
+// when value is an array, this expands to multiple edges sharing label;
+// otherwise it is exactly one edge.
+func (p *parser) parseEdge() ([]Edge, error) {
+	label, err := p.parseLabel()
+	if err != nil {
+		return nil, err
+	}
+	if p.cur.kind != tokColon {
+		return nil, p.errAt(p.cur, CodeParseUnexpectedToken, "expected ':' after label")
+	}
+	if err := p.advance(); err != nil {
+		return nil, err
+	}
+
+	if p.cur.kind == tokLBracket {
+		targets, err := p.parseArray()
+		if err != nil {
+			return nil, err
+		}
+		edges := make([]Edge, len(targets))
+		for i, t := range targets {
+			edges[i] = Edge{Label: label, Target: t}
+		}
+		return edges, nil
+	}
+
+	target, err := p.parseValueTarget()
+	if err != nil {
+		return nil, err
+	}
+	return []Edge{{Label: label, Target: target}}, nil
+}
+
+// parseLabel implements spec §4.4: label = STRING / bare-label, with a
+// bare label rejected when its text is null/true/false.
+func (p *parser) parseLabel() (string, error) {
+	switch p.cur.kind {
+	case tokString:
+		s := p.cur.strVal
+		if err := p.advance(); err != nil {
+			return "", err
+		}
+		return s, nil
+	case tokIdent:
+		if isReservedWord(p.cur.text) {
+			return "", p.errAt(p.cur, CodeParseReservedWordLabel, fmt.Sprintf("%q used as a bare label", p.cur.text))
+		}
+		s := p.cur.text
+		if err := p.advance(); err != nil {
+			return "", err
+		}
+		return s, nil
+	default:
+		return "", p.errAt(p.cur, CodeParseUnexpectedToken, "expected a label")
+	}
+}
+
+// parseValueTarget parses spec `value` minus the array alternative. Every
+// caller has already excluded tokLBracket before calling this: parseEdge
+// routes '[' to parseArray directly (arrays expand to multiple edges, not
+// one Target), and parseArray's own element loop checks for a nested '['
+// and reports parse.nested-array before ever calling this — so there is
+// no array-start case left to handle here.
+func (p *parser) parseValueTarget() (Target, error) {
+	if p.cur.kind == tokLBrace {
+		node, err := p.parseBracedNode()
+		if err != nil {
+			return Target{}, err
+		}
+		return NodeTarget(node), nil
+	}
+	v, err := p.parseScalarValue()
+	if err != nil {
+		return Target{}, err
+	}
+	return ValueTarget(v), nil
+}
+
+// parseBracedNode parses `'{' [SEP] node-edges [SEP] '}'`, enforcing the
+// parse-time nesting-depth limit via the shared LimitChecker (spec §4.7;
+// do not duplicate limits.go's logic here).
+//
+// Per §4.6.1's wording ("this lookahead fires ... at the start of each
+// value inside { }"): inside braces the content is unambiguously
+// node-edges — the grammar's `value = scalar | "{" node-edges "}" |
+// array` alternative is already selected by the '{' punctuation itself,
+// so there is no scalar-vs-edge-list choice left to disambiguate here.
+// We read that clause as referring to the same "does this position begin
+// an edge, or is the list empty" decision node-edges always makes (via
+// startsLabelColon-shaped structure, degenerately: RBrace vs edge start),
+// not a second invocation of the top-level scalar/edge-list lookahead.
+// This is a narrow reading of loosely worded prose, not a case affecting
+// any worked example in §4.8, and is called out here per the issue's
+// instruction to flag such readings in code.
+func (p *parser) parseBracedNode() (*Node, error) {
+	openTok := p.cur
+	diag := p.checker.EnterNode(fmt.Sprintf("%d:%d", openTok.line, openTok.col))
+	if diag != nil {
+		return nil, &ParseError{Line: openTok.line, Col: openTok.col, Path: fmt.Sprintf("%d:%d", openTok.line, openTok.col), Code: diag.Code, Message: diag.Message}
+	}
+	defer p.checker.LeaveNode()
+
+	if err := p.advance(); err != nil { // consume '{'
+		return nil, err
+	}
+	// parseNodeEdges(tokRBrace) only returns successfully once p.cur is
+	// tokRBrace (that is its loop's own exit condition; the tokEOF case
+	// inside it is reported as an error there instead), so there is no
+	// separate "expected '}'" check to make here.
+	node, err := p.parseNodeEdges(tokRBrace)
+	if err != nil {
+		return nil, err
+	}
+	if err := p.advance(); err != nil { // consume '}'
+		return nil, err
+	}
+	return node, nil
+}
+
+// parseScalarValue parses spec `scalar` (STRING / DATETIME / DATE / TIME /
+// NUMBER / INTEGER / null / true / false). A bare IDENT that is not one
+// of the three reserved words is not a scalar (§4.3: "OML has no implicit
+// string-from-identifier coercion anywhere").
+func (p *parser) parseScalarValue() (Value, error) {
+	t := p.cur
+	switch t.kind {
+	case tokString:
+		if err := p.advance(); err != nil {
+			return Value{}, err
+		}
+		return ScalarValue(NewStringScalar(t.strVal)), nil
+	case tokInteger:
+		if err := p.advance(); err != nil {
+			return Value{}, err
+		}
+		return ScalarValue(NewIntegerScalar(t.intVal)), nil
+	case tokNumber:
+		if err := p.advance(); err != nil {
+			return Value{}, err
+		}
+		return ScalarValue(NewNumberScalar(t.numVal)), nil
+	case tokDate:
+		if err := p.advance(); err != nil {
+			return Value{}, err
+		}
+		return ScalarValue(NewDateScalar(t.dateVal)), nil
+	case tokTime:
+		if err := p.advance(); err != nil {
+			return Value{}, err
+		}
+		return ScalarValue(NewTimeScalar(t.timeVal)), nil
+	case tokDateTime:
+		if err := p.advance(); err != nil {
+			return Value{}, err
+		}
+		return ScalarValue(NewDateTimeScalar(t.dateTimeVal)), nil
+	case tokIdent:
+		switch t.text {
+		case "null":
+			if err := p.advance(); err != nil {
+				return Value{}, err
+			}
+			return NullValue(), nil
+		case "true":
+			if err := p.advance(); err != nil {
+				return Value{}, err
+			}
+			return ScalarValue(NewBooleanScalar(true)), nil
+		case "false":
+			if err := p.advance(); err != nil {
+				return Value{}, err
+			}
+			return ScalarValue(NewBooleanScalar(false)), nil
+		default:
+			return Value{}, p.errAt(t, CodeParseBareWord, fmt.Sprintf("bare word %q is not a valid value", t.text))
+		}
+	case tokLBracket:
+		return Value{}, p.errAt(t, CodeParseUnexpectedToken, "array is not valid here")
+	default:
+		return Value{}, p.errAt(t, CodeParseUnexpectedToken, "expected a value")
+	}
+}
+
+// parseArray implements spec §4.3.1. Arrays are parse-time sugar: this
+// returns the element Targets to be expanded into repeated edges by the
+// caller (parseEdge), since an array is not itself a Document-model
+// construct.
+//
+// SPEC NOTE (narrow, resolved per prose): grammars/oml.abnf's `array`
+// production includes `[SEP]` around elements, which — since SEP's own
+// definition includes newline and ';' — would literally permit a newline
+// or ';' inside `[...]`. Prose §4.3.1 is explicit and unambiguous that
+// this is an error ("Comma is the only element separator. A newline or ';'
+// inside [...] is an error"), and only the prose defines the
+// parse.separator-in-array error code this behavior requires. Per
+// grammars/oml.abnf's own header, "where [ABNF and prose] disagree, that
+// is a defect to be fixed, not a choice" — this repo cannot fix
+// omnist-spec, so this is implemented per prose (hspace/comments are
+// still skipped silently inside arrays; a newline or ';' is rejected) and
+// is flagged prominently in the issue report as a genuine ABNF/prose
+// disagreement, not silently resolved.
+func (p *parser) parseArray() ([]Target, error) {
+	openTok := p.cur
+	if err := p.advance(); err != nil { // consume '['
+		return nil, err
+	}
+	if err := p.rejectArraySep(); err != nil {
+		return nil, err
+	}
+
+	if p.cur.kind == tokRBracket {
+		return nil, p.errAt(openTok, CodeParseEmptyArray, "'[]' is not a valid value")
+	}
+
+	var targets []Target
+	for {
+		if p.cur.kind == tokLBracket {
+			return nil, p.errAt(p.cur, CodeParseNestedArray, "array element must not itself be an array")
+		}
+		target, err := p.parseValueTarget()
+		if err != nil {
+			return nil, err
+		}
+		targets = append(targets, target)
+
+		if err := p.rejectArraySep(); err != nil {
+			return nil, err
+		}
+
+		switch p.cur.kind {
+		case tokComma:
+			if err := p.advance(); err != nil {
+				return nil, err
+			}
+			if err := p.rejectArraySep(); err != nil {
+				return nil, err
+			}
+			if p.cur.kind == tokRBracket {
+				// Trailing comma before ']' is legal.
+				if err := p.advance(); err != nil {
+					return nil, err
+				}
+				return targets, nil
+			}
+		case tokRBracket:
+			if err := p.advance(); err != nil {
+				return nil, err
+			}
+			return targets, nil
+		default:
+			return nil, p.errAt(p.cur, CodeParseUnexpectedToken, "expected ',' or ']' in array")
+		}
+	}
+}
+
+// rejectArraySep checks whether the current token is separator-preceded
+// by a newline or ';' — illegal inside '[...]' per §4.3.1 — and returns
+// the parse.separator-in-array error if so.
+func (p *parser) rejectArraySep() error {
+	if p.cur.sepBefore {
+		return &ParseError{
+			Line: p.cur.sepLine, Col: p.cur.sepCol,
+			Path:    fmt.Sprintf("%d:%d", p.cur.sepLine, p.cur.sepCol),
+			Code:    CodeParseSeparatorInArray,
+			Message: "newline or ';' is not a valid array separator",
+		}
+	}
+	return nil
+}

--- a/oml_parser_test.go
+++ b/oml_parser_test.go
@@ -1,0 +1,824 @@
+package omnist
+
+import (
+	"math"
+	"math/big"
+	"strings"
+	"testing"
+)
+
+func mustParse(t *testing.T, src string) Document {
+	t.Helper()
+	doc, err := ReadOML(src, DefaultLimits())
+	if err != nil {
+		t.Fatalf("ReadOML(%q) unexpected error: %v", src, err)
+	}
+	return doc
+}
+
+func mustFail(t *testing.T, src string) *ParseError {
+	t.Helper()
+	_, err := ReadOML(src, DefaultLimits())
+	if err == nil {
+		t.Fatalf("ReadOML(%q) expected error, got none", src)
+	}
+	pe, ok := err.(*ParseError)
+	if !ok {
+		t.Fatalf("ReadOML(%q) error is not *ParseError: %T %v", src, err, err)
+	}
+	return pe
+}
+
+func wantCode(t *testing.T, pe *ParseError, code Code) {
+	t.Helper()
+	if pe.Code != code {
+		t.Errorf("code = %q, want %q (err: %v)", pe.Code, code, pe)
+	}
+}
+
+// --- §4.8 worked examples, verbatim ---
+
+func TestWorkedDateTime(t *testing.T) {
+	doc := mustParse(t, `2024-01-01T10:30`)
+	if doc.IsNode || doc.Value.IsNull || doc.Value.Scalar.Kind != KindDateTime {
+		t.Fatalf("got %+v", doc)
+	}
+	want := DateTimeValue{Date: DateValue{2024, 1, 1}, Time: TimeValue{Hour: 10, Minute: 30}}
+	if doc.Value.Scalar.DateTime != want {
+		t.Errorf("got %+v want %+v", doc.Value.Scalar.DateTime, want)
+	}
+}
+
+func TestWorkedDateThenTrailingIdent(t *testing.T) {
+	pe := mustFail(t, `2024-01-01T99`)
+	wantCode(t, pe, CodeParseTrailingContent)
+}
+
+func TestWorkedRawString(t *testing.T) {
+	doc := mustParse(t, `a: 'C:\no\escapes'`)
+	edge := doc.Node.Edges[0]
+	v, _ := edge.Target.Value()
+	if v.Scalar.Str != `C:\no\escapes` {
+		t.Errorf("got %q", v.Scalar.Str)
+	}
+}
+
+func TestWorkedMultilineBasic(t *testing.T) {
+	doc := mustParse(t, "a: \"\"\"\nhello\nworld\"\"\"")
+	edge := doc.Node.Edges[0]
+	v, _ := edge.Target.Value()
+	if v.Scalar.Str != "hello\nworld" {
+		t.Errorf("got %q", v.Scalar.Str)
+	}
+}
+
+func TestWorkedMultilineTwoQuoteRuns(t *testing.T) {
+	doc := mustParse(t, "a: \"\"\"\nsays \"\"hi\"\" there\"\"\"")
+	edge := doc.Node.Edges[0]
+	v, _ := edge.Target.Value()
+	if v.Scalar.Str != `says ""hi"" there` {
+		t.Errorf("got %q", v.Scalar.Str)
+	}
+}
+
+func TestWorkedMultilineFourClosingQuotes(t *testing.T) {
+	pe := mustFail(t, "a: \"\"\"\nx\"\"\"\"")
+	wantCode(t, pe, CodeParseUnterminatedString)
+}
+
+func TestWorkedNanLabelError(t *testing.T) {
+	// nan is a NUMBER token and never reaches label position: the parser
+	// sees NUMBER, COLON — trailing content after the scalar-branch nan.
+	pe := mustFail(t, `nan: 1`)
+	wantCode(t, pe, CodeParseTrailingContent)
+}
+
+func TestWorkedQuotedNan(t *testing.T) {
+	doc := mustParse(t, `"nan": 1`)
+	edge := doc.Node.Edges[0]
+	if edge.Label != "nan" {
+		t.Errorf("label = %q", edge.Label)
+	}
+}
+
+func TestWorkedNullAtTopLevel(t *testing.T) {
+	pe := mustFail(t, `null: 1`)
+	wantCode(t, pe, CodeParseTrailingContent)
+}
+
+func TestWorkedNullInsideNode(t *testing.T) {
+	pe := mustFail(t, `a: { null: 1 }`)
+	wantCode(t, pe, CodeParseReservedWordLabel)
+}
+
+func TestWorkedRepeatedTags(t *testing.T) {
+	doc := mustParse(t, "tag: \"x\"\ntag: \"y\"")
+	if len(doc.Node.Edges) != 2 {
+		t.Fatalf("got %d edges", len(doc.Node.Edges))
+	}
+	v0, _ := doc.Node.Edges[0].Target.Value()
+	v1, _ := doc.Node.Edges[1].Target.Value()
+	if v0.Scalar.Str != "x" || v1.Scalar.Str != "y" {
+		t.Errorf("got %q %q", v0.Scalar.Str, v1.Scalar.Str)
+	}
+}
+
+func TestWorkedArraySugar(t *testing.T) {
+	doc := mustParse(t, `b: [1, 2, 3]`)
+	if len(doc.Node.Edges) != 3 {
+		t.Fatalf("got %d edges", len(doc.Node.Edges))
+	}
+	for i, want := range []int64{1, 2, 3} {
+		v, _ := doc.Node.Edges[i].Target.Value()
+		if v.Scalar.Int.Cmp(big.NewInt(want)) != 0 {
+			t.Errorf("edge %d = %v want %d", i, v.Scalar.Int, want)
+		}
+		if doc.Node.Edges[i].Label != "b" {
+			t.Errorf("edge %d label = %q", i, doc.Node.Edges[i].Label)
+		}
+	}
+}
+
+func TestWorkedEmptyArray(t *testing.T) {
+	pe := mustFail(t, `a: []`)
+	wantCode(t, pe, CodeParseEmptyArray)
+}
+
+func TestWorkedEmptyBraces(t *testing.T) {
+	doc := mustParse(t, `a: {}`)
+	if len(doc.Node.Edges) != 1 {
+		t.Fatalf("got %d edges", len(doc.Node.Edges))
+	}
+	n, ok := doc.Node.Edges[0].Target.Node()
+	if !ok || len(n.Edges) != 0 {
+		t.Errorf("got %+v", doc.Node.Edges[0].Target)
+	}
+}
+
+func TestWorkedBareScalar(t *testing.T) {
+	doc := mustParse(t, `"hello"`)
+	if doc.IsNode {
+		t.Fatalf("expected bare-value document, got node")
+	}
+	if doc.Value.Scalar.Str != "hello" {
+		t.Errorf("got %q", doc.Value.Scalar.Str)
+	}
+}
+
+// --- tokenizer priority-order edge cases ---
+
+func TestPriorityDateVsDateTimeTrailingIdent(t *testing.T) {
+	doc := mustParse(t, `2024-01-01`)
+	if doc.Value.Scalar.Kind != KindDate {
+		t.Fatalf("got kind %v", doc.Value.Scalar.Kind)
+	}
+}
+
+func TestPriorityNanBecomesNumberNotIdent(t *testing.T) {
+	// Confirms nan never reaches label position even mid-document.
+	pe := mustFail(t, `a: { nan: 1 }`)
+	// nan tokenizes as NUMBER; inside braces label-position expects
+	// STRING/IDENT, so NUMBER where a label is expected is unexpected-token.
+	wantCode(t, pe, CodeParseUnexpectedToken)
+}
+
+// --- string forms ---
+
+func TestDQuoteEscapes(t *testing.T) {
+	doc := mustParse(t, `a: "\"\\\/\b\f\n\r\t"`)
+	v, _ := doc.Node.Edges[0].Target.Value()
+	want := "\"\\/\b\f\n\r\t"
+	if v.Scalar.Str != want {
+		t.Errorf("got %q want %q", v.Scalar.Str, want)
+	}
+}
+
+func TestDQuoteUnicodeEscape(t *testing.T) {
+	doc := mustParse(t, `a: "\u00e9"`)
+	v, _ := doc.Node.Edges[0].Target.Value()
+	if v.Scalar.Str != "é" {
+		t.Errorf("got %q", v.Scalar.Str)
+	}
+}
+
+func TestDQuoteSurrogatePair(t *testing.T) {
+	// U+1F600 GRINNING FACE, as a surrogate pair.
+	doc := mustParse(t, `a: "\ud83d\ude00"`)
+	v, _ := doc.Node.Edges[0].Target.Value()
+	if v.Scalar.Str != "😀" {
+		t.Errorf("got %q", v.Scalar.Str)
+	}
+}
+
+func TestDQuoteUnpairedHighSurrogate(t *testing.T) {
+	pe := mustFail(t, `a: "\ud83d"`)
+	wantCode(t, pe, CodeParseUnpairedSurrogate)
+}
+
+func TestDQuoteHighSurrogateFollowedByNonLowSurrogate(t *testing.T) {
+	pe := mustFail(t, `a: "\ud83d\u0041"`)
+	wantCode(t, pe, CodeParseUnpairedSurrogate)
+}
+
+func TestDQuoteLoneLowSurrogate(t *testing.T) {
+	pe := mustFail(t, `a: "\udc00"`)
+	wantCode(t, pe, CodeParseUnpairedSurrogate)
+}
+
+func TestDQuoteInvalidEscape(t *testing.T) {
+	pe := mustFail(t, `a: "\x"`)
+	wantCode(t, pe, CodeParseInvalidEscape)
+}
+
+func TestDQuoteInvalidHexEscape(t *testing.T) {
+	pe := mustFail(t, `a: "\uZZZZ"`)
+	wantCode(t, pe, CodeParseInvalidEscape)
+}
+
+func TestDQuoteTruncatedHexEscape(t *testing.T) {
+	pe := mustFail(t, `a: "\u12`)
+	wantCode(t, pe, CodeParseUnterminatedString)
+}
+
+func TestDQuoteControlCharacter(t *testing.T) {
+	pe := mustFail(t, "a: \"x\ty\"")
+	wantCode(t, pe, CodeParseControlCharacter)
+}
+
+func TestDQuoteUnterminated(t *testing.T) {
+	pe := mustFail(t, `a: "abc`)
+	wantCode(t, pe, CodeParseUnterminatedString)
+}
+
+func TestDQuoteUnterminatedAfterBackslash(t *testing.T) {
+	pe := mustFail(t, `a: "abc\`)
+	wantCode(t, pe, CodeParseUnterminatedString)
+}
+
+func TestRawStringLiteralBackslash(t *testing.T) {
+	doc := mustParse(t, `a: 'a\b'`)
+	v, _ := doc.Node.Edges[0].Target.Value()
+	if v.Scalar.Str != `a\b` {
+		t.Errorf("got %q", v.Scalar.Str)
+	}
+}
+
+func TestRawStringUnterminated(t *testing.T) {
+	pe := mustFail(t, `a: 'abc`)
+	wantCode(t, pe, CodeParseUnterminatedString)
+}
+
+func TestMultilineLeadingCRLFStripped(t *testing.T) {
+	doc := mustParse(t, "a: \"\"\"\r\nhi\"\"\"")
+	v, _ := doc.Node.Edges[0].Target.Value()
+	if v.Scalar.Str != "hi" {
+		t.Errorf("got %q", v.Scalar.Str)
+	}
+}
+
+func TestMultilineNoLeadingNewline(t *testing.T) {
+	doc := mustParse(t, `a: """hi"""`)
+	v, _ := doc.Node.Edges[0].Target.Value()
+	if v.Scalar.Str != "hi" {
+		t.Errorf("got %q", v.Scalar.Str)
+	}
+}
+
+func TestMultilineSingleQuoteLiteral(t *testing.T) {
+	doc := mustParse(t, `a: """x"y"""`)
+	v, _ := doc.Node.Edges[0].Target.Value()
+	if v.Scalar.Str != `x"y` {
+		t.Errorf("got %q", v.Scalar.Str)
+	}
+}
+
+func TestMultilineTabAllowed(t *testing.T) {
+	doc := mustParse(t, "a: \"\"\"x\ty\"\"\"")
+	v, _ := doc.Node.Edges[0].Target.Value()
+	if v.Scalar.Str != "x\ty" {
+		t.Errorf("got %q", v.Scalar.Str)
+	}
+}
+
+func TestMultilineControlCharacter(t *testing.T) {
+	pe := mustFail(t, "a: \"\"\"x\x01y\"\"\"")
+	wantCode(t, pe, CodeParseControlCharacter)
+}
+
+func TestMultilineUnterminated(t *testing.T) {
+	pe := mustFail(t, `a: """abc`)
+	wantCode(t, pe, CodeParseUnterminatedString)
+}
+
+func TestMultilineFiveClosingQuotesLeavesTwoLiteralQuotes(t *testing.T) {
+	// first 3 close it; the remaining 2 quotes form a new (empty,
+	// well-formed) dquote-string token, which then has no separator
+	// before it -> "missing separator between edges", not unterminated.
+	pe := mustFail(t, "a: \"\"\"x\"\"\"\"\"")
+	wantCode(t, pe, CodeParseUnexpectedToken)
+}
+
+// --- arrays ---
+
+func TestArrayNestedError(t *testing.T) {
+	pe := mustFail(t, `a: [[1]]`)
+	wantCode(t, pe, CodeParseNestedArray)
+}
+
+func TestArrayTrailingComma(t *testing.T) {
+	doc := mustParse(t, `a: [1, 2,]`)
+	if len(doc.Node.Edges) != 2 {
+		t.Fatalf("got %d edges", len(doc.Node.Edges))
+	}
+}
+
+func TestArrayNewlineSeparatorError(t *testing.T) {
+	pe := mustFail(t, "a: [1,\n2]")
+	wantCode(t, pe, CodeParseSeparatorInArray)
+}
+
+func TestArraySemicolonSeparatorError(t *testing.T) {
+	pe := mustFail(t, "a: [1;2]")
+	wantCode(t, pe, CodeParseSeparatorInArray)
+}
+
+func TestArrayOfNodes(t *testing.T) {
+	doc := mustParse(t, `a: [{x: 1}, {x: 2}]`)
+	if len(doc.Node.Edges) != 2 {
+		t.Fatalf("got %d edges", len(doc.Node.Edges))
+	}
+	n0, ok := doc.Node.Edges[0].Target.Node()
+	if !ok || len(n0.Edges) != 1 {
+		t.Fatalf("got %+v", doc.Node.Edges[0].Target)
+	}
+}
+
+func TestArrayMissingCommaError(t *testing.T) {
+	pe := mustFail(t, `a: [1 2]`)
+	wantCode(t, pe, CodeParseUnexpectedToken)
+}
+
+func TestArrayCommentFollowedByNewlineStillErrors(t *testing.T) {
+	// The comment itself is insignificant, but the newline after it is
+	// still a forbidden array separator - comments don't disable that rule.
+	pe := mustFail(t, "a: [1, # comment\n2]")
+	wantCode(t, pe, CodeParseSeparatorInArray)
+}
+
+func TestArrayCommentSameLineAllowed(t *testing.T) {
+	doc := mustParse(t, "a: [1, 2] # trailing comment")
+	if len(doc.Node.Edges) != 2 {
+		t.Fatalf("got %+v", doc.Node.Edges)
+	}
+}
+
+// --- document shapes / top-level disambiguation ---
+
+func TestEmptyDocument(t *testing.T) {
+	doc := mustParse(t, ``)
+	if !doc.IsNode || len(doc.Node.Edges) != 0 {
+		t.Fatalf("got %+v", doc)
+	}
+}
+
+func TestEmptyDocumentWhitespaceOnly(t *testing.T) {
+	doc := mustParse(t, "  \n  ")
+	if !doc.IsNode || len(doc.Node.Edges) != 0 {
+		t.Fatalf("got %+v", doc)
+	}
+}
+
+func TestBareIntegerDocument(t *testing.T) {
+	doc := mustParse(t, `42`)
+	if doc.Value.Scalar.Int.Cmp(big.NewInt(42)) != 0 {
+		t.Errorf("got %v", doc.Value.Scalar.Int)
+	}
+}
+
+func TestBareNullDocument(t *testing.T) {
+	doc := mustParse(t, `null`)
+	if !doc.Value.IsNull {
+		t.Errorf("got %+v", doc.Value)
+	}
+}
+
+func TestBareBooleanDocuments(t *testing.T) {
+	docT := mustParse(t, `true`)
+	if !docT.Value.Scalar.Bool {
+		t.Errorf("got %+v", docT.Value)
+	}
+	docF := mustParse(t, `false`)
+	if docF.Value.Scalar.Bool {
+		t.Errorf("got %+v", docF.Value)
+	}
+}
+
+func TestTwoBareScalarsError(t *testing.T) {
+	pe := mustFail(t, `1 2`)
+	wantCode(t, pe, CodeParseTrailingContent)
+}
+
+func TestBareIdentifierError(t *testing.T) {
+	pe := mustFail(t, `hello`)
+	wantCode(t, pe, CodeParseBareWord)
+}
+
+func TestSingleLineCompactForm(t *testing.T) {
+	doc := mustParse(t, `name: "Ann"; address: { city: "Zurich"; postcode: "8001" }; tag: "x"; tag: "y"`)
+	if len(doc.Node.Edges) != 4 {
+		t.Fatalf("got %d edges", len(doc.Node.Edges))
+	}
+}
+
+func TestMissingSeparatorBetweenEdgesError(t *testing.T) {
+	pe := mustFail(t, `a: 1 b: 2`)
+	wantCode(t, pe, CodeParseUnexpectedToken)
+}
+
+func TestNestedNode(t *testing.T) {
+	doc := mustParse(t, "name: \"Ann\"\naddress: {\n  city: \"Zurich\"\n  postcode: \"8001\"\n}\ntag: \"x\"\ntag: \"y\"")
+	if len(doc.Node.Edges) != 4 {
+		t.Fatalf("got %d edges: %+v", len(doc.Node.Edges), doc.Node.Edges)
+	}
+	addr, ok := doc.Node.Edges[1].Target.Node()
+	if !ok || len(addr.Edges) != 2 {
+		t.Fatalf("got %+v", doc.Node.Edges[1].Target)
+	}
+}
+
+func TestCommentHandling(t *testing.T) {
+	doc := mustParse(t, "# a comment\nname: \"Ann\" # trailing\n")
+	if len(doc.Node.Edges) != 1 {
+		t.Fatalf("got %+v", doc.Node.Edges)
+	}
+}
+
+func TestQuotedLabel(t *testing.T) {
+	doc := mustParse(t, `"weird label!": 1`)
+	if doc.Node.Edges[0].Label != "weird label!" {
+		t.Errorf("got %q", doc.Node.Edges[0].Label)
+	}
+}
+
+func TestUnclosedBraceError(t *testing.T) {
+	pe := mustFail(t, `a: { b: 1`)
+	wantCode(t, pe, CodeParseUnexpectedToken)
+}
+
+func TestUnexpectedTokenAtLabelPosition(t *testing.T) {
+	pe := mustFail(t, `a: { 1: 2 }`)
+	wantCode(t, pe, CodeParseUnexpectedToken)
+}
+
+func TestBareIdentifierFollowedByAnotherTokenIsBareWord(t *testing.T) {
+	// "a" is not followed by ':', so the top-level lookahead takes the
+	// scalar branch; "a" alone is not null/true/false, so it fails as a
+	// bare word before "1" is ever reached.
+	pe := mustFail(t, `a 1`)
+	wantCode(t, pe, CodeParseBareWord)
+}
+
+func TestValueIsRBraceError(t *testing.T) {
+	pe := mustFail(t, `a: }`)
+	wantCode(t, pe, CodeParseUnexpectedToken)
+}
+
+// --- limits ---
+
+func TestIntDigitLimitBoundaryOK(t *testing.T) {
+	digits := strings.Repeat("9", 4300)
+	doc := mustParse(t, digits)
+	if doc.Value.Scalar.Kind != KindInteger {
+		t.Fatalf("got %+v", doc.Value)
+	}
+}
+
+func TestIntDigitLimitExceeded(t *testing.T) {
+	digits := strings.Repeat("9", 4301)
+	pe := mustFail(t, digits)
+	wantCode(t, pe, CodeDocumentLimitIntDigits)
+}
+
+func buildNesting(n int) string {
+	var b strings.Builder
+	b.WriteString("a: ")
+	for i := 0; i < n; i++ {
+		b.WriteString("{ a: ")
+	}
+	b.WriteString("1")
+	for i := 0; i < n; i++ {
+		b.WriteString(" }")
+	}
+	return b.String()
+}
+
+func TestNestingDepthBoundaryOK(t *testing.T) {
+	// 200 '{' levels, per §4.7's boundary table.
+	src := buildNesting(200)
+	if _, err := ReadOML(src, DefaultLimits()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestNestingDepthExceeded(t *testing.T) {
+	src := buildNesting(201)
+	pe := mustFail(t, src)
+	wantCode(t, pe, CodeDocumentLimitDepth)
+}
+
+func TestCustomLimits(t *testing.T) {
+	limits := DefaultLimits()
+	limits.MaxIntDigits = 2
+	_, err := ReadOML("123", limits)
+	if err == nil {
+		t.Fatal("expected error with custom low limit")
+	}
+	pe := err.(*ParseError)
+	wantCode(t, pe, CodeDocumentLimitIntDigits)
+}
+
+// --- error paths (line:col) ---
+
+func TestErrorPathLineCol(t *testing.T) {
+	pe := mustFail(t, "a: 1\nb: {\n  c 2\n}")
+	if pe.Line != 3 {
+		t.Errorf("line = %d, want 3", pe.Line)
+	}
+	if pe.Path != "3:5" {
+		t.Errorf("path = %q, want 3:5", pe.Path)
+	}
+}
+
+func TestErrorPathFirstChar(t *testing.T) {
+	pe := mustFail(t, `1 2`)
+	if pe.Line != 1 || pe.Col != 3 {
+		t.Errorf("got %d:%d", pe.Line, pe.Col)
+	}
+}
+
+// --- numbers / negative / exponent / reserved floats ---
+
+func TestNegativeInteger(t *testing.T) {
+	doc := mustParse(t, `-42`)
+	if doc.Value.Scalar.Int.Cmp(big.NewInt(-42)) != 0 {
+		t.Errorf("got %v", doc.Value.Scalar.Int)
+	}
+}
+
+func TestDecimalNumber(t *testing.T) {
+	doc := mustParse(t, `3.14`)
+	if doc.Value.Scalar.Kind != KindNumber || doc.Value.Scalar.Num != 3.14 {
+		t.Errorf("got %+v", doc.Value.Scalar)
+	}
+}
+
+func TestExponentNumber(t *testing.T) {
+	doc := mustParse(t, `1e10`)
+	if doc.Value.Scalar.Num != 1e10 {
+		t.Errorf("got %v", doc.Value.Scalar.Num)
+	}
+}
+
+func TestNegativeDecimalWithExponent(t *testing.T) {
+	doc := mustParse(t, `-1.5e-3`)
+	if doc.Value.Scalar.Num != -1.5e-3 {
+		t.Errorf("got %v", doc.Value.Scalar.Num)
+	}
+}
+
+func TestReservedInfNumber(t *testing.T) {
+	doc := mustParse(t, `a: inf`)
+	v, _ := doc.Node.Edges[0].Target.Value()
+	if !math.IsInf(v.Scalar.Num, 1) {
+		t.Errorf("got %v", v.Scalar.Num)
+	}
+}
+
+func TestReservedNegInfNumber(t *testing.T) {
+	doc := mustParse(t, `a: -inf`)
+	v, _ := doc.Node.Edges[0].Target.Value()
+	if !math.IsInf(v.Scalar.Num, -1) {
+		t.Errorf("got %v", v.Scalar.Num)
+	}
+}
+
+func TestReservedNanNumber(t *testing.T) {
+	doc := mustParse(t, `a: nan`)
+	v, _ := doc.Node.Edges[0].Target.Value()
+	if !math.IsNaN(v.Scalar.Num) {
+		t.Errorf("got %v", v.Scalar.Num)
+	}
+}
+
+// --- date / time / datetime with offsets and fractions ---
+
+func TestTimeWithSecondsAndOffset(t *testing.T) {
+	doc := mustParse(t, `10:30:15+02:00`)
+	tv := doc.Value.Scalar.Time
+	if tv.Hour != 10 || tv.Minute != 30 || tv.Second != 15 || !tv.HasOffset || tv.OffsetSeconds != 7200 {
+		t.Errorf("got %+v", tv)
+	}
+}
+
+func TestTimeWithFraction(t *testing.T) {
+	doc := mustParse(t, `10:30:15.5`)
+	tv := doc.Value.Scalar.Time
+	if tv.Nanosecond != 500000000 {
+		t.Errorf("got %d", tv.Nanosecond)
+	}
+}
+
+func TestTimeWithNegativeOffset(t *testing.T) {
+	doc := mustParse(t, `10:30-05:30`)
+	tv := doc.Value.Scalar.Time
+	if !tv.HasOffset || tv.OffsetSeconds != -(5*3600+30*60) {
+		t.Errorf("got %+v", tv)
+	}
+}
+
+func TestDateTimeWithFractionAndOffset(t *testing.T) {
+	doc := mustParse(t, `2024-06-15T10:30:15.123456+00:00`)
+	dt := doc.Value.Scalar.DateTime
+	if dt.Date != (DateValue{2024, 6, 15}) {
+		t.Errorf("date = %+v", dt.Date)
+	}
+	if dt.Time.Second != 15 || dt.Time.Nanosecond != 123456000 || !dt.Time.HasOffset {
+		t.Errorf("time = %+v", dt.Time)
+	}
+}
+
+// --- reserved-word scalar values are fine (only label position is special) ---
+
+func TestReservedWordsAsValuesFine(t *testing.T) {
+	doc := mustParse(t, `a: { true_val: true; false_val: false; null_val: null }`)
+	n := doc.Node.Edges[0]
+	node, _ := n.Target.Node()
+	if len(node.Edges) != 3 {
+		t.Fatalf("got %+v", node.Edges)
+	}
+}
+
+func TestIdentLabelWithHyphenUnderscore(t *testing.T) {
+	doc := mustParse(t, `my-label_1: 1`)
+	if doc.Node.Edges[0].Label != "my-label_1" {
+		t.Errorf("got %q", doc.Node.Edges[0].Label)
+	}
+}
+
+// --- coverage: separator edge cases (lone CR, CR at EOF) ---
+
+func TestLoneCRAsSeparator(t *testing.T) {
+	doc := mustParse(t, "a: 1\rb: 2")
+	if len(doc.Node.Edges) != 2 {
+		t.Fatalf("got %+v", doc.Node.Edges)
+	}
+}
+
+func TestLoneCRAtEOF(t *testing.T) {
+	doc := mustParse(t, "a: 1\r")
+	if len(doc.Node.Edges) != 1 {
+		t.Fatalf("got %+v", doc.Node.Edges)
+	}
+}
+
+// --- coverage: genuinely unrecognized character ---
+
+func TestUnrecognizedCharacter(t *testing.T) {
+	pe := mustFail(t, `$`)
+	wantCode(t, pe, CodeParseUnexpectedToken)
+}
+
+// --- coverage: surrogate-pair second escape has invalid hex ---
+
+func TestDQuoteHighSurrogateThenInvalidHex(t *testing.T) {
+	pe := mustFail(t, `a: "\ud83d\uZZZZ"`)
+	wantCode(t, pe, CodeParseInvalidEscape)
+}
+
+// --- coverage: looksLikeEdgeStart's swallowed lookahead-lex-error path ---
+
+func TestLookaheadTokenMalformedFallsBackToScalarBareWord(t *testing.T) {
+	// "a" starts a label/scalar; the lookahead token right after it ("$")
+	// is unlexable, so looksLikeEdgeStart must not propagate that as the
+	// reported error - it falls back to the scalar branch, which then
+	// fails as a bare word without ever needing to retokenize "$".
+	pe := mustFail(t, `a$`)
+	wantCode(t, pe, CodeParseBareWord)
+}
+
+// --- coverage: p.advance() surfacing a lex error for the token that
+// immediately follows an already-consumed token, at every call site that
+// checks it. ---
+
+func TestAdvanceErrorAfterStringLabel(t *testing.T) {
+	pe := mustFail(t, "x: 1; \"a\"$: 2")
+	wantCode(t, pe, CodeParseUnexpectedToken)
+}
+
+func TestAdvanceErrorAfterIdentLabel(t *testing.T) {
+	pe := mustFail(t, "x: 1; a$: 2")
+	wantCode(t, pe, CodeParseUnexpectedToken)
+}
+
+func TestAdvanceErrorAfterOpenBrace(t *testing.T) {
+	pe := mustFail(t, `a: {$`)
+	wantCode(t, pe, CodeParseUnexpectedToken)
+}
+
+func TestAdvanceErrorAfterCloseBrace(t *testing.T) {
+	pe := mustFail(t, `a: {}$`)
+	wantCode(t, pe, CodeParseUnexpectedToken)
+}
+
+func TestAdvanceErrorAfterStringValue(t *testing.T) {
+	pe := mustFail(t, `a: "x"$`)
+	wantCode(t, pe, CodeParseUnexpectedToken)
+}
+
+func TestAdvanceErrorAfterIntegerValue(t *testing.T) {
+	pe := mustFail(t, `a: 1$`)
+	wantCode(t, pe, CodeParseUnexpectedToken)
+}
+
+func TestAdvanceErrorAfterNumberValue(t *testing.T) {
+	pe := mustFail(t, `a: 1.5$`)
+	wantCode(t, pe, CodeParseUnexpectedToken)
+}
+
+func TestAdvanceErrorAfterDateValue(t *testing.T) {
+	pe := mustFail(t, `a: 2024-01-01$`)
+	wantCode(t, pe, CodeParseUnexpectedToken)
+}
+
+func TestAdvanceErrorAfterTimeValue(t *testing.T) {
+	pe := mustFail(t, `a: 10:30$`)
+	wantCode(t, pe, CodeParseUnexpectedToken)
+}
+
+func TestAdvanceErrorAfterDateTimeValue(t *testing.T) {
+	pe := mustFail(t, `a: 2024-01-01T10:30$`)
+	wantCode(t, pe, CodeParseUnexpectedToken)
+}
+
+func TestAdvanceErrorAfterNullValue(t *testing.T) {
+	pe := mustFail(t, `a: null$`)
+	wantCode(t, pe, CodeParseUnexpectedToken)
+}
+
+func TestAdvanceErrorAfterTrueValue(t *testing.T) {
+	pe := mustFail(t, `a: true$`)
+	wantCode(t, pe, CodeParseUnexpectedToken)
+}
+
+func TestAdvanceErrorAfterFalseValue(t *testing.T) {
+	pe := mustFail(t, `a: false$`)
+	wantCode(t, pe, CodeParseUnexpectedToken)
+}
+
+func TestAdvanceErrorAfterOpenBracket(t *testing.T) {
+	pe := mustFail(t, `a: [$`)
+	wantCode(t, pe, CodeParseUnexpectedToken)
+}
+
+func TestAdvanceErrorAfterComma(t *testing.T) {
+	pe := mustFail(t, `a: [1,$`)
+	wantCode(t, pe, CodeParseUnexpectedToken)
+}
+
+func TestAdvanceErrorAfterTrailingCommaCloseBracket(t *testing.T) {
+	pe := mustFail(t, `a: [1,]$`)
+	wantCode(t, pe, CodeParseUnexpectedToken)
+}
+
+func TestAdvanceErrorAfterCloseBracket(t *testing.T) {
+	pe := mustFail(t, `a: [1]$`)
+	wantCode(t, pe, CodeParseUnexpectedToken)
+}
+
+// --- coverage: CRLF as a single separator ---
+
+func TestCRLFSeparator(t *testing.T) {
+	doc := mustParse(t, "a: 1\r\nb: 2")
+	if len(doc.Node.Edges) != 2 {
+		t.Fatalf("got %+v", doc.Node.Edges)
+	}
+}
+
+// --- coverage: bare array at top level (not in edge-value position) ---
+
+func TestBareArrayAtTopLevelIsUnexpectedToken(t *testing.T) {
+	pe := mustFail(t, `[1, 2]`)
+	wantCode(t, pe, CodeParseUnexpectedToken)
+}
+
+// --- coverage: separator immediately after '[', and a malformed element ---
+
+func TestArraySeparatorRightAfterOpenBracket(t *testing.T) {
+	pe := mustFail(t, "a: [\n1]")
+	wantCode(t, pe, CodeParseSeparatorInArray)
+}
+
+func TestArrayElementBareWordError(t *testing.T) {
+	pe := mustFail(t, `a: [x]`)
+	wantCode(t, pe, CodeParseBareWord)
+}


### PR DESCRIPTION
Closes #3.

Implements a tokenizer and recursive-descent parser for OML per spec ch.4, wired to the LimitChecker from issue #1. Stage-1 parsing only (no writer, no OSD, no validate/materialize).

Independently verified: 100% per-function coverage, 0 golangci-lint issues, tokenizer priority order/null-vs-nan rejection mechanisms/lookahead disambiguation/string-form edge cases/limit boundaries/array-sugar rules all traced by hand against spec ch.4, not just green tests.

Found and filed a real spec gap: omnist-spec#34 (grammars/oml.abnf permits newline/; inside array brackets, contradicting Sec4.3.1 prose which is the only place that motivates the parse.separator-in-array code). Narrow/cosmetic per the gap-handling protocol -- implemented per the unambiguous prose reading, documented in code, proceeded rather than blocking.