### PR TITLE
validate(document, schema)

### DIFF
--- a/validate.go
+++ b/validate.go
@@ -1,0 +1,206 @@
+package omnist
+
+import "fmt"
+
+// This file implements validate(document, schema) per spec §3.6 and its
+// §3.6.1 pseudocode: check a Document (document.go, spec ch.2) against a
+// Schema (schema.go, spec ch.3) and report every conformance failure found,
+// not just the first.
+
+// Validate checks doc against s and returns every diagnostic found. An
+// empty (non-nil) slice means doc conforms to s (spec §3.6: "an empty list
+// means valid").
+//
+// validate MUST run within the depth limit of §2.4 (spec §3.6's own text);
+// exceeding it produces a document.limit.depth diagnostic (via the
+// existing LimitChecker from issue #1's limits.go) rather than a
+// validate.* finding, and descent stops at that point.
+func Validate(doc Document, s Schema) []Diagnostic {
+	result := []Diagnostic{}
+	checker := NewLimitChecker(DefaultLimits())
+	conform(documentTarget(doc), s, RefType(s.Root), RootPath(), checker, &result)
+	return result
+}
+
+// documentTarget adapts a Document (spec §2.2: node | value) to a Target
+// (spec D-4: value | node) so conform's single recursive walk can treat the
+// document root the same way it treats every edge target beneath it.
+func documentTarget(doc Document) Target {
+	if doc.IsNode {
+		return NodeTarget(doc.Node)
+	}
+	return ValueTarget(doc.Value)
+}
+
+// resolvedKind identifies which of Type's three alternatives S.resolve(t)
+// produced (spec §3.3's `Type = Scalar | Ref | Any`, via §6.2's
+// S.resolve notation).
+type resolvedKind int
+
+const (
+	resolvedScalar resolvedKind = iota
+	resolvedRecord
+	resolvedAny
+)
+
+// resolved is S.resolve(t): a Type resolved through the schema's env to
+// exactly one of a scalar declaration, a Record, or `any`. A Ref whose name
+// is absent from Env resolves to a nil Record; that indicates a
+// not-well-formed schema (spec §3.3 S-6 requires every reference to
+// resolve), which is a schema.* well-formedness concern from issue #5, not
+// something validate re-checks — conformRecord treats a nil Record as
+// "no fields, closed", so any node there reports unexpected-field for every
+// edge rather than panicking.
+type resolved struct {
+	kind       resolvedKind
+	scalarKind ScalarKind
+	nullable   bool
+	record     *Record
+}
+
+// resolveType implements S.resolve(t) from the §3.6.1 pseudocode.
+func resolveType(s Schema, t Type) resolved {
+	switch t.Kind {
+	case TypeAnyKind:
+		return resolved{kind: resolvedAny}
+	case TypeScalarKind:
+		return resolved{kind: resolvedScalar, scalarKind: t.ScalarKind, nullable: t.Nullable}
+	case TypeRefKind:
+		return resolved{kind: resolvedRecord, record: s.Env[t.RefName]}
+	default:
+		// Type is a closed struct (schema.go) constructed only via
+		// ScalarType/RefType/AnyType, so every legal value hits one of the
+		// three cases above. This default only guards against a future
+		// TypeKind constant added without updating resolveType.
+		return resolved{kind: resolvedAny}
+	}
+}
+
+// conform is `conform(node, S, t, path, result)` from §3.6.1: it resolves t
+// and dispatches to the scalar or record check, or stops descent for `any`
+// (spec §3.7: "Descent stops. The subtree is accepted unchecked.").
+func conform(target Target, s Schema, t Type, path Path, checker *LimitChecker, result *[]Diagnostic) {
+	r := resolveType(s, t)
+	switch r.kind {
+	case resolvedAny:
+		return
+	case resolvedScalar:
+		conformScalar(target, r, path, result)
+	case resolvedRecord:
+		conformRecord(target, s, r.record, path, checker, result)
+	}
+}
+
+// conformScalar is `conform_scalar(node, s, path, result)` from §3.6.1.
+func conformScalar(target Target, r resolved, path Path, result *[]Diagnostic) {
+	if target.IsNode() {
+		addDiagnostic(result, path, CodeValidateShapeMismatch, "expected a scalar value, got an object")
+		return
+	}
+	v, _ := target.Value()
+	if v.IsNull {
+		if !r.nullable {
+			addDiagnostic(result, path, CodeValidateNullNotAllowed, "null not allowed here")
+		}
+		return // null is never checked against kind, matching kind or not.
+	}
+	if v.Scalar.Kind != r.scalarKind {
+		addDiagnostic(result, path, CodeValidateTypeMismatch, "value does not match declared kind")
+	}
+}
+
+// conformRecord is `conform_record(node, S, rec, path, result)` from
+// §3.6.1. rec may be nil (see resolved's doc comment); a nil record has no
+// fields, so every edge is unexpected and no field is ever satisfied.
+func conformRecord(target Target, s Schema, rec *Record, path Path, checker *LimitChecker, result *[]Diagnostic) {
+	if !target.IsNode() {
+		addDiagnostic(result, path, CodeValidateShapeMismatch, "expected an object, got a value")
+		return
+	}
+	node, _ := target.Node()
+
+	// §3.6's explicit note: validate MUST run within the §2.4 depth limit,
+	// and exceeding it is a resource-cap error, not a validation finding.
+	// Every EnterNode is paired with exactly one LeaveNode (even on the
+	// limit-exceeded path) so the checker's running depth stays correct for
+	// sibling subtrees visited later in the same walk.
+	if diag := checker.EnterNode(path.String()); diag != nil {
+		*result = append(*result, *diag)
+		checker.LeaveNode()
+		return
+	}
+	defer checker.LeaveNode()
+
+	// Closedness and targets (spec §3.6 points 2 and 3): walk edges in
+	// order for path-index bookkeeping only (§3.6.1's comment: "in edge
+	// order; order not otherwise used"). counts accumulates independently
+	// of that order for the cardinality check below, per D-3 order
+	// independence.
+	counts := make(map[string]int, len(node.Edges))
+	for i, e := range node.Edges {
+		counts[e.Label]++
+		occurrence, repeated := PathIndexInNode(node, i)
+		childPath := path.Child(e.Label, occurrence, repeated)
+
+		f := findField(rec, e.Label)
+		if f == nil {
+			addDiagnostic(result, childPath, CodeValidateUnexpectedField, "field not declared on this record")
+			// No further descent: an undeclared field has no type to check
+			// against (§3.6.1's first "easy to miss" detail).
+			continue
+		}
+		conform(e.Target, s, f.Type, childPath, checker, result)
+	}
+
+	// Cardinality (spec §3.6 point 1). The error's path is the record's
+	// own path, not any edge's, even when the count is nonzero-but-wrong
+	// (§3.6.1's second "easy to miss" detail) — never childPath.
+	if rec == nil {
+		return
+	}
+	for _, f := range rec.Fields {
+		c := counts[f.Label]
+		if c < int(f.Cardinality.Min) || (!f.Cardinality.Unbounded && c > int(f.Cardinality.Max)) {
+			addDiagnostic(result, path, CodeValidateCardinality, cardinalityMessage(f, c))
+		}
+	}
+}
+
+// findField looks up rec.field(label) from the pseudocode. rec may be nil
+// (see resolved's doc comment on conformRecord).
+func findField(rec *Record, label string) *Field {
+	if rec == nil {
+		return nil
+	}
+	for i := range rec.Fields {
+		if rec.Fields[i].Label == label {
+			return &rec.Fields[i]
+		}
+	}
+	return nil
+}
+
+// cardinalityMessage renders the §3.6.1 message template: "field X occurs
+// N time(s), expected [min,max]", with "max" rendered as "" (unbounded)
+// when the field's cardinality has no upper bound, matching the OSD
+// unbounded-max spelling used elsewhere in this repository (schema.go,
+// spec §3.4's `[n,]` form).
+func cardinalityMessage(f Field, count int) string {
+	max := "unbounded"
+	if !f.Cardinality.Unbounded {
+		max = fmt.Sprintf("%d", f.Cardinality.Max)
+	}
+	return fmt.Sprintf("field %s occurs %d time(s), expected [%d,%s]", f.Label, count, f.Cardinality.Min, max)
+}
+
+// addDiagnostic appends an error-severity diagnostic at path to result.
+// Every validate.* code is an error per spec §8.2's severity table (only
+// lint.* and format.* codes use warning/info).
+func addDiagnostic(result *[]Diagnostic, path Path, code Code, message string) {
+	*result = append(*result, Diagnostic{
+		Path:     path.String(),
+		Code:     code,
+		Message:  message,
+		Severity: SeverityError,
+	})
+}

--- a/validate_test.go
+++ b/validate_test.go
@@ -1,0 +1,433 @@
+package omnist
+
+import (
+	"math/big"
+	"testing"
+)
+
+// personSchema builds:
+//
+//	record Person {
+//	    "name":               string,
+//	    "age"    [0,1]:       integer,
+//	    "email"  [0,]:        string,
+//	    "tag"    [2,3]:       string,
+//	    "coupon" [0,1]:       string?,
+//	    "friend" [0,1]:       Person,
+//	    "data":               any,
+//	}
+//	root Person
+func personSchema() Schema {
+	person := &Record{
+		Name: "Person",
+		Fields: []Field{
+			{Label: "name", Type: ScalarType(KindString, false), Cardinality: DefaultCardinality()},
+			{Label: "age", Type: ScalarType(KindInteger, false), Cardinality: Cardinality{Min: 0, Max: 1}},
+			{Label: "email", Type: ScalarType(KindString, false), Cardinality: Cardinality{Min: 0, Unbounded: true}},
+			{Label: "tag", Type: ScalarType(KindString, false), Cardinality: Cardinality{Min: 2, Max: 3}},
+			{Label: "coupon", Type: ScalarType(KindString, true), Cardinality: Cardinality{Min: 0, Max: 1}},
+			{Label: "friend", Type: RefType("Person"), Cardinality: Cardinality{Min: 0, Max: 1}},
+			{Label: "data", Type: AnyType(), Cardinality: DefaultCardinality()},
+		},
+	}
+	return Schema{Root: "Person", Env: map[string]*Record{"Person": person}}
+}
+
+// validPerson builds a Node satisfying personSchema with the minimum
+// required edges: name, tag x2, data.
+func validPerson() *Node {
+	n := NewNode()
+	n.AddValue("name", ScalarValue(NewStringScalar("Ann")))
+	n.AddValue("tag", ScalarValue(NewStringScalar("a")))
+	n.AddValue("tag", ScalarValue(NewStringScalar("b")))
+	n.AddValue("data", ScalarValue(NewStringScalar("anything")))
+	return n
+}
+
+func hasCode(diags []Diagnostic, code Code) bool {
+	for _, d := range diags {
+		if d.Code == code {
+			return true
+		}
+	}
+	return false
+}
+
+func codesOf(diags []Diagnostic) []Code {
+	out := make([]Code, len(diags))
+	for i, d := range diags {
+		out[i] = d.Code
+	}
+	return out
+}
+
+func TestValidateValidDocument(t *testing.T) {
+	s := personSchema()
+	doc := NodeDocument(validPerson())
+	got := Validate(doc, s)
+	if len(got) != 0 {
+		t.Fatalf("Validate() = %+v, want empty (valid)", got)
+	}
+}
+
+func TestValidateEmptyResultIsNonNil(t *testing.T) {
+	// §3.6: "an empty list means valid" — confirm the zero-diagnostics
+	// result is an actual empty slice, not a nil that happens to have len 0
+	// (both satisfy "empty", but the constructor should be deliberate).
+	got := Validate(NodeDocument(validPerson()), personSchema())
+	if got == nil {
+		t.Fatal("Validate() returned nil, want non-nil empty slice")
+	}
+}
+
+func TestValidateNodeWhereScalarExpected(t *testing.T) {
+	s := personSchema()
+	n := validPerson()
+	// "name" expects a scalar; give it a node instead.
+	n.Edges[0] = Edge{Label: "name", Target: NodeTarget(NewNode())}
+	got := Validate(NodeDocument(n), s)
+	if len(got) != 1 || got[0].Code != CodeValidateShapeMismatch || got[0].Path != "$.name" {
+		t.Fatalf("Validate() = %+v, want single shape-mismatch at $.name", got)
+	}
+}
+
+func TestValidateScalarWhereNodeExpected(t *testing.T) {
+	s := personSchema()
+	n := validPerson()
+	// "friend" expects a Person node; give it a scalar instead.
+	n.AddValue("friend", ScalarValue(NewStringScalar("not a node")))
+	got := Validate(NodeDocument(n), s)
+	if len(got) != 1 || got[0].Code != CodeValidateShapeMismatch || got[0].Path != "$.friend" {
+		t.Fatalf("Validate() = %+v, want single shape-mismatch at $.friend", got)
+	}
+}
+
+func TestValidateRootBareValueAgainstRecordRoot(t *testing.T) {
+	s := personSchema()
+	got := Validate(ValueDocument(ScalarValue(NewStringScalar("x"))), s)
+	if len(got) != 1 || got[0].Code != CodeValidateShapeMismatch || got[0].Path != "$" {
+		t.Fatalf("Validate() = %+v, want single shape-mismatch at $", got)
+	}
+}
+
+func TestValidateNullAtNonNullableScalar(t *testing.T) {
+	s := personSchema()
+	n := validPerson()
+	n.Edges[0] = Edge{Label: "name", Target: ValueTarget(NullValue())}
+	got := Validate(NodeDocument(n), s)
+	if len(got) != 1 || got[0].Code != CodeValidateNullNotAllowed || got[0].Path != "$.name" {
+		t.Fatalf("Validate() = %+v, want single null-not-allowed at $.name", got)
+	}
+}
+
+func TestValidateNullAtNullableScalar(t *testing.T) {
+	s := personSchema()
+	n := validPerson()
+	n.AddValue("coupon", NullValue())
+	got := Validate(NodeDocument(n), s)
+	if len(got) != 0 {
+		t.Fatalf("Validate() = %+v, want empty (null allowed on coupon)", got)
+	}
+}
+
+func TestValidateWrongScalarKind(t *testing.T) {
+	s := personSchema()
+	n := validPerson()
+	n.AddValue("age", ScalarValue(NewStringScalar("not an integer")))
+	got := Validate(NodeDocument(n), s)
+	if len(got) != 1 || got[0].Code != CodeValidateTypeMismatch || got[0].Path != "$.age" {
+		t.Fatalf("Validate() = %+v, want single type-mismatch at $.age", got)
+	}
+}
+
+func TestValidateUndeclaredFieldNoDescent(t *testing.T) {
+	s := personSchema()
+	n := validPerson()
+	// "extra" is undeclared. Its subtree is itself invalid (a "tag" edge
+	// with the wrong cardinality would independently fail if checked) —
+	// confirm validate reports ONLY unexpected-field, proving it never
+	// descends into the undeclared field's target (§3.6.1's first "easy to
+	// miss" detail).
+	bogusChild := NewNode()
+	bogusChild.AddValue("whatever", ScalarValue(NewIntegerScalar(big.NewInt(42))))
+	n.AddNode("extra", bogusChild)
+	got := Validate(NodeDocument(n), s)
+	if len(got) != 1 || got[0].Code != CodeValidateUnexpectedField || got[0].Path != "$.extra" {
+		t.Fatalf("Validate() = %+v, want exactly one unexpected-field at $.extra", got)
+	}
+}
+
+func TestValidateCardinalityTooFew(t *testing.T) {
+	s := personSchema()
+	n := NewNode()
+	n.AddValue("name", ScalarValue(NewStringScalar("Ann")))
+	n.AddValue("tag", ScalarValue(NewStringScalar("a"))) // only 1, needs [2,3]
+	n.AddValue("data", ScalarValue(NewStringScalar("x")))
+	got := Validate(NodeDocument(n), s)
+	if len(got) != 1 || got[0].Code != CodeValidateCardinality || got[0].Path != "$" {
+		t.Fatalf("Validate() = %+v, want single cardinality error at $", got)
+	}
+}
+
+func TestValidateCardinalityTooMany(t *testing.T) {
+	s := personSchema()
+	n := validPerson()
+	n.AddValue("tag", ScalarValue(NewStringScalar("c")))
+	n.AddValue("tag", ScalarValue(NewStringScalar("d"))) // now 4, max is 3
+	got := Validate(NodeDocument(n), s)
+	if len(got) != 1 || got[0].Code != CodeValidateCardinality || got[0].Path != "$" {
+		t.Fatalf("Validate() = %+v, want single cardinality error at $ (nonzero-but-wrong count)", got)
+	}
+}
+
+func TestValidateCardinalityMissingRequiredIsZeroCount(t *testing.T) {
+	s := personSchema()
+	n := NewNode()
+	n.AddValue("tag", ScalarValue(NewStringScalar("a")))
+	n.AddValue("tag", ScalarValue(NewStringScalar("b")))
+	n.AddValue("data", ScalarValue(NewStringScalar("x")))
+	// "name" (required, [1,1]) entirely absent.
+	got := Validate(NodeDocument(n), s)
+	if len(got) != 1 || got[0].Code != CodeValidateCardinality || got[0].Path != "$" {
+		t.Fatalf("Validate() = %+v, want single cardinality error at $ for missing name", got)
+	}
+}
+
+func TestValidateCardinalityUnbounded(t *testing.T) {
+	s := personSchema()
+	n := validPerson()
+	for i := 0; i < 50; i++ {
+		n.AddValue("email", ScalarValue(NewStringScalar("e")))
+	}
+	got := Validate(NodeDocument(n), s)
+	if len(got) != 0 {
+		t.Fatalf("Validate() = %+v, want empty (email is [0,] unbounded)", got)
+	}
+}
+
+func TestValidateAnyFieldAcceptsArbitrarySubtree(t *testing.T) {
+	s := personSchema()
+	n := validPerson()
+	// Replace "data" with an arbitrarily-shaped, otherwise-invalid subtree:
+	// any label, any nesting. It must validate unchecked.
+	weird := NewNode()
+	weird.AddValue("anything goes", ScalarValue(NewIntegerScalar(big.NewInt(42))))
+	inner := NewNode()
+	inner.AddValue("x", NullValue())
+	weird.AddNode("nested too", inner)
+	n.Edges[3] = Edge{Label: "data", Target: NodeTarget(weird)}
+	got := Validate(NodeDocument(n), s)
+	if len(got) != 0 {
+		t.Fatalf("Validate() = %+v, want empty (any accepts anything)", got)
+	}
+}
+
+func TestValidateNullableOptionalFourCombinations(t *testing.T) {
+	s := personSchema()
+
+	// present, non-null: valid.
+	n1 := validPerson()
+	n1.AddValue("coupon", ScalarValue(NewStringScalar("SAVE10")))
+	if got := Validate(NodeDocument(n1), s); len(got) != 0 {
+		t.Errorf("present-non-null: got %+v, want empty", got)
+	}
+
+	// present, null: valid (coupon is nullable).
+	n2 := validPerson()
+	n2.AddValue("coupon", NullValue())
+	if got := Validate(NodeDocument(n2), s); len(got) != 0 {
+		t.Errorf("present-null: got %+v, want empty", got)
+	}
+
+	// absent: valid (coupon is [0,1]).
+	n3 := validPerson()
+	if got := Validate(NodeDocument(n3), s); len(got) != 0 {
+		t.Errorf("absent: got %+v, want empty", got)
+	}
+
+	// present more than once: invalid, cardinality (max 1).
+	n4 := validPerson()
+	n4.AddValue("coupon", ScalarValue(NewStringScalar("A")))
+	n4.AddValue("coupon", ScalarValue(NewStringScalar("B")))
+	got := Validate(NodeDocument(n4), s)
+	if len(got) != 1 || got[0].Code != CodeValidateCardinality {
+		t.Errorf("present-twice: got %+v, want single cardinality error", got)
+	}
+}
+
+func TestValidateDepthLimitExceeded(t *testing.T) {
+	s := personSchema()
+	limits := DefaultLimits()
+
+	// Build a chain of self-referencing "friend" nodes one level deeper
+	// than MaxDepth. Each node still satisfies Person's other required
+	// fields so the ONLY failure is the depth limit, isolating it from any
+	// validate.* finding.
+	leaf := func() *Node {
+		n := NewNode()
+		n.AddValue("name", ScalarValue(NewStringScalar("Ann")))
+		n.AddValue("tag", ScalarValue(NewStringScalar("a")))
+		n.AddValue("tag", ScalarValue(NewStringScalar("b")))
+		n.AddValue("data", ScalarValue(NewStringScalar("x")))
+		return n
+	}
+	root := leaf()
+	cur := root
+	for i := 0; i < limits.MaxDepth+2; i++ {
+		child := leaf()
+		cur.AddNode("friend", child)
+		cur = child
+	}
+
+	got := Validate(NodeDocument(root), s)
+	if len(got) == 0 {
+		t.Fatal("Validate() = empty, want a depth-limit diagnostic")
+	}
+	for _, d := range got {
+		if d.Code != CodeDocumentLimitDepth {
+			t.Errorf("unexpected diagnostic code %v alongside depth limit: %+v", d.Code, got)
+		}
+	}
+	if !hasCode(got, CodeDocumentLimitDepth) {
+		t.Fatalf("Validate() = %+v, want a document.limit.depth diagnostic, not a validate.* finding", got)
+	}
+}
+
+func TestValidateOrderIndependence(t *testing.T) {
+	s := personSchema()
+
+	a := NewNode()
+	a.AddValue("name", ScalarValue(NewStringScalar("Ann")))
+	a.AddValue("tag", ScalarValue(NewStringScalar("x")))
+	a.AddValue("tag", ScalarValue(NewStringScalar("y")))
+	a.AddValue("data", ScalarValue(NewStringScalar("d")))
+
+	// Same edges, permuted order (D-3's own worked example shape:
+	// [(a,1),(b,2)] vs [(b,2),(a,1)]).
+	b := NewNode()
+	b.AddValue("data", ScalarValue(NewStringScalar("d")))
+	b.AddValue("tag", ScalarValue(NewStringScalar("y")))
+	b.AddValue("tag", ScalarValue(NewStringScalar("x")))
+	b.AddValue("name", ScalarValue(NewStringScalar("Ann")))
+
+	gotA := Validate(NodeDocument(a), s)
+	gotB := Validate(NodeDocument(b), s)
+	if len(gotA) != 0 || len(gotB) != 0 {
+		t.Fatalf("Validate(a) = %+v, Validate(b) = %+v, want both empty", gotA, gotB)
+	}
+
+	// Also confirm order independence on an INVALID document: the same
+	// multiset of edges, permuted, must produce the same diagnostics
+	// (same codes/paths), not merely both-empty.
+	c := NewNode()
+	c.AddValue("name", ScalarValue(NewStringScalar("Ann")))
+	c.AddValue("tag", ScalarValue(NewStringScalar("only one"))) // too few
+	c.AddValue("data", ScalarValue(NewStringScalar("d")))
+
+	d := NewNode()
+	d.AddValue("data", ScalarValue(NewStringScalar("d")))
+	d.AddValue("name", ScalarValue(NewStringScalar("Ann")))
+	d.AddValue("tag", ScalarValue(NewStringScalar("only one")))
+
+	gotC := Validate(NodeDocument(c), s)
+	gotD := Validate(NodeDocument(d), s)
+	if len(gotC) != 1 || len(gotD) != 1 || gotC[0] != gotD[0] {
+		t.Fatalf("Validate(c) = %+v, Validate(d) = %+v, want identical single diagnostic", gotC, gotD)
+	}
+}
+
+func TestValidateMultipleSimultaneousFailures(t *testing.T) {
+	s := personSchema()
+	n := NewNode()
+	// Missing "name" (cardinality) AND "age" has the wrong kind AND an
+	// undeclared field is present: three independent problems, all MUST be
+	// reported (§3.6: "MUST report every failure, not just the first").
+	n.AddValue("tag", ScalarValue(NewStringScalar("a")))
+	n.AddValue("tag", ScalarValue(NewStringScalar("b")))
+	n.AddValue("data", ScalarValue(NewStringScalar("x")))
+	n.AddValue("age", ScalarValue(NewStringScalar("not an integer")))
+	n.AddValue("bogus", ScalarValue(NewStringScalar("nope")))
+
+	got := Validate(NodeDocument(n), s)
+	if len(got) != 3 {
+		t.Fatalf("Validate() = %+v (len %d), want 3 independent diagnostics", got, len(got))
+	}
+	if !hasCode(got, CodeValidateCardinality) || !hasCode(got, CodeValidateTypeMismatch) || !hasCode(got, CodeValidateUnexpectedField) {
+		t.Fatalf("Validate() codes = %v, want cardinality+type-mismatch+unexpected-field", codesOf(got))
+	}
+}
+
+func TestValidateRepeatedLabelPathIndex(t *testing.T) {
+	s := personSchema()
+	n := validPerson()
+	n.AddValue("email", ScalarValue(NewIntegerScalar(big.NewInt(42)))) // wrong kind, first "email"
+	n.AddValue("email", ScalarValue(NewStringScalar("ok")))            // wrong kind on first only
+	got := Validate(NodeDocument(n), s)
+	if len(got) != 1 {
+		t.Fatalf("Validate() = %+v, want single type-mismatch", got)
+	}
+	if got[0].Path != "$.email[0]" {
+		t.Errorf("Path = %q, want $.email[0] (repeated-label occurrence index)", got[0].Path)
+	}
+}
+
+func TestValidateSingleOccurrenceLabelHasNoIndex(t *testing.T) {
+	s := personSchema()
+	n := validPerson()
+	n.Edges[0] = Edge{Label: "name", Target: NodeTarget(NewNode())}
+	got := Validate(NodeDocument(n), s)
+	if len(got) != 1 || got[0].Path != "$.name" {
+		t.Fatalf("Validate() = %+v, want path $.name with no bracketed index", got)
+	}
+}
+
+func TestCardinalityMessageBoundedAndUnbounded(t *testing.T) {
+	bounded := cardinalityMessage(Field{Label: "tag", Cardinality: Cardinality{Min: 2, Max: 3}}, 1)
+	want := "field tag occurs 1 time(s), expected [2,3]"
+	if bounded != want {
+		t.Errorf("cardinalityMessage(bounded) = %q, want %q", bounded, want)
+	}
+	unbounded := cardinalityMessage(Field{Label: "email", Cardinality: Cardinality{Min: 0, Unbounded: true}}, 5)
+	wantU := "field email occurs 5 time(s), expected [0,unbounded]"
+	if unbounded != wantU {
+		t.Errorf("cardinalityMessage(unbounded) = %q, want %q", unbounded, wantU)
+	}
+}
+
+// TestResolveTypeDefaultCase exercises resolveType's defensive default
+// branch, which only guards against a future TypeKind constant added
+// without updating resolveType — schema.go's exported Type struct makes
+// this reachable from outside the package too, so it is not truly dead
+// code, just never hit by any legally-constructed Type today.
+func TestResolveTypeDefaultCase(t *testing.T) {
+	got := resolveType(personSchema(), Type{Kind: TypeKind(99)})
+	if got.kind != resolvedAny {
+		t.Fatalf("resolveType(unknown kind) = %+v, want resolvedAny", got)
+	}
+}
+
+// TestValidateUnresolvableRef covers a Ref type whose name is absent from
+// Env — see resolved's doc comment: that's a schema.* well-formedness
+// concern from issue #5, not something validate re-checks, but validate
+// must still behave sanely (treat it as a closed record with no fields)
+// rather than panicking. Exercises conformRecord's and findField's nil-rec
+// branches.
+func TestValidateUnresolvableRef(t *testing.T) {
+	person := &Record{
+		Name: "Person",
+		Fields: []Field{
+			{Label: "ghost", Type: RefType("Ghost"), Cardinality: Cardinality{Min: 0, Max: 1}},
+		},
+	}
+	s := Schema{Root: "Person", Env: map[string]*Record{"Person": person}}
+
+	ghostNode := NewNode()
+	ghostNode.AddValue("x", ScalarValue(NewStringScalar("anything")))
+	root := NewNode()
+	root.AddNode("ghost", ghostNode)
+
+	got := Validate(NodeDocument(root), s)
+	if len(got) != 1 || got[0].Code != CodeValidateUnexpectedField || got[0].Path != "$.ghost.x" {
+		t.Fatalf("Validate() = %+v, want single unexpected-field at $.ghost.x (unresolvable ref treated as empty closed record)", got)
+	}
+}


### PR DESCRIPTION
Closes #7.

Ports spec Sec3.6.1s conform/conform_scalar/conform_record pseudocode directly. Uses the existing LimitChecker for depth (resource-cap errors reported separately from validate.* findings, per spec), and the existing Path/errcode infrastructure from issue #1.

Independently verified line-by-line against the pseudocode: undeclared-field-no-descent, cardinality-error-path-is-always-parent (including the nonzero-but-wrong case), any short-circuit, nullable/optional as genuinely separate checks, EnterNode/LeaveNode paired even on the error path, order independence (full diagnostic-equality check under permutation), multiple simultaneous failures all reported. One spec-reading question resolved correctly: Sec3.6.1s pseudocode comment brackets only the second-and-later occurrence of a repeated label, but Sec8.4s normative text and worked example bracket every occurrence once a label repeats -- implemented per Sec8.4 (the correct authority), tested, and documented inline.

No load-bearing spec ambiguity.