### PR TITLE
compatible_with, equivalent

### DIFF
--- a/compatible_with.go
+++ b/compatible_with.go
@@ -1,0 +1,158 @@
+package omnist
+
+// This file implements §6.6's compatible_with (and its scalar_sub and
+// record_sub helpers) and §6.7's equivalent — port-order step 6. It builds
+// on algebra.go's le (§6.2) and SatisfiableSet (§6.4), both from issue #9,
+// reused here rather than reimplemented.
+
+// scalarSub implements §6.3's `scalar_sub(a, b)` exactly: there is exactly
+// one subtyping relation between scalar kinds (`integer <: number`), and
+// nothing else. Nullable-narrowing (a nullable, b not) is checked first and
+// blocks regardless of kind; nullable-widening (a not nullable, b nullable)
+// is fine and falls through to the kind check.
+func scalarSub(a, b Type) bool {
+	if a.Nullable && !b.Nullable {
+		return false
+	}
+	if a.ScalarKind == b.ScalarKind {
+		return true
+	}
+	return a.ScalarKind == KindInteger && b.ScalarKind == KindNumber
+}
+
+// subKey is the coinductive memo key for sub: the identity of the two
+// *resolved* definitions, one from each side. §6.6 is explicit and
+// load-bearing about this: "The memo key MUST be the identity of the
+// resolved definitions, not the reference names. Two names bound to the
+// same record definition are the same node in the graph, and keying on
+// names would defeat cycle detection where aliasing is present."
+//
+// A *Record pointer already carries identity within one schema's Env: two
+// field types that resolve to the same underlying record (aliasing — two
+// different Ref names bound to the same *Record) produce the same pointer,
+// so keying on the pointer (rather than the Ref's name string) makes them
+// the same memo entry, which is exactly what correct cycle detection
+// requires. Since sub compares records drawn from two different schemas
+// (A and B), a pointer from A.Env and a pointer from B.Env must never be
+// treated as the same node even in the structurally-impossible case they
+// happened to be equal — using both pointers together as a two-field
+// struct key (rather than e.g. hashing them into a single combined value)
+// keeps the two sides distinguishable unconditionally, with no reliance on
+// the two allocators never colliding.
+//
+// Scalar and Any resolved types have no *Record identity to key on. Only
+// records recurse (scalar_sub and the Any clauses are non-recursive), so
+// sub only ever needs to memoize the Record/Record case; the key is
+// therefore typed directly in terms of *Record rather than a more general
+// "resolved type" identity.
+type subKey struct {
+	da *Record
+	db *Record
+}
+
+// CompatibleWith implements §6.6's `compatible_with(A, B)`: true when every
+// Document A accepts is also accepted by B. A's satisfiable set is computed
+// once up front (reusing SatisfiableSet from issue #9) and threaded through
+// so an A-side record known unsatisfiable is treated as vacuously
+// compatible with anything, without needing callers to prune first.
+func CompatibleWith(a, b Schema) bool {
+	satA := SatisfiableSet(a)
+	memo := make(map[subKey]bool)
+	return sub(a, RefType(a.Root), b, RefType(b.Root), satA, memo)
+}
+
+// sub implements §6.6's `sub(SA, ta, SB, tb, sat_a, memo)`.
+func sub(sa Schema, ta Type, sb Schema, tb Type, satA map[string]bool, memo map[subKey]bool) bool {
+	if ta.Kind == TypeRefKind && !satA[ta.RefName] {
+		return true // vacuous: A emits nothing here
+	}
+	// resolveType and the resolved/resolvedKind types are validate.go's
+	// (issue #7), implementing the same §6.2 S.resolve(t) notation this
+	// spec section uses; reused here rather than duplicated.
+	da := resolveType(sa, ta)
+	db := resolveType(sb, tb)
+
+	// Only Record/Record pairs recurse and need memoization (see subKey's
+	// doc comment); Scalar and Any resolved types have no *Record to key
+	// on and are decided directly below without consulting memo.
+	if da.kind == resolvedRecord && db.kind == resolvedRecord {
+		key := subKey{da: da.record, db: db.record}
+		if v, ok := memo[key]; ok {
+			return v
+		}
+		memo[key] = true // coinductive assumption
+		result := recordSub(sa, da.record, sb, db.record, satA, memo)
+		memo[key] = result
+		return result
+	}
+
+	switch {
+	case db.kind == resolvedAny:
+		return true // any absorbs all
+	case da.kind == resolvedAny:
+		return false // only any holds any
+	case da.kind == resolvedScalar && db.kind == resolvedScalar:
+		return scalarSub(
+			ScalarType(da.scalarKind, da.nullable),
+			ScalarType(db.scalarKind, db.nullable),
+		)
+	default:
+		return false // value versus object
+	}
+}
+
+// fieldByLabel implements §6.2's `R.field(label)`: the field with that
+// label, or none.
+func fieldByLabel(r *Record, label string) (Field, bool) {
+	for _, f := range r.Fields {
+		if f.Label == label {
+			return f, true
+		}
+	}
+	return Field{}, false
+}
+
+// recordSub implements §6.6's `record_sub(SA, a, SB, b, sat_a, memo)`.
+func recordSub(sa Schema, a *Record, sb Schema, b *Record, satA map[string]bool, memo map[subKey]bool) bool {
+	// 1. Every label A may emit must be allowed by B.
+	for _, fa := range a.Fields {
+		if !fa.Cardinality.Unbounded && fa.Cardinality.Max == 0 {
+			continue // A never emits it
+		}
+		if fa.Cardinality.Min == 0 && fa.Type.Kind == TypeRefKind && !satA[fa.Type.RefName] {
+			continue // A never emits it either
+		}
+		fb, ok := fieldByLabel(b, fa.Label)
+		if !ok {
+			return false // B is closed
+		}
+		if fb.Cardinality.Min > fa.Cardinality.Min ||
+			!le(fa.Cardinality.Max, fa.Cardinality.Unbounded, fb.Cardinality.Max, fb.Cardinality.Unbounded) {
+			return false
+		}
+		if !sub(sa, fa.Type, sb, fb.Type, satA, memo) {
+			return false
+		}
+	}
+
+	// 2. Every label B requires must be guaranteed by A.
+	for _, fb := range b.Fields {
+		if fb.Cardinality.Min >= 1 {
+			fa, ok := fieldByLabel(a, fb.Label)
+			if !ok || fa.Cardinality.Min < fb.Cardinality.Min {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// Equivalent implements §6.7's `equivalent(A, B)`: exactly
+// CompatibleWith(A, B) && CompatibleWith(B, A). The spec explicitly forbids
+// any structural-equality shortcut here — structural equality is strictly
+// stronger than equivalence, so substituting one would reject equivalent
+// schemas that merely differ in record naming, declaration order, or
+// unreachable records.
+func Equivalent(a, b Schema) bool {
+	return CompatibleWith(a, b) && CompatibleWith(b, a)
+}

--- a/compatible_with_test.go
+++ b/compatible_with_test.go
@@ -1,0 +1,399 @@
+package omnist
+
+import "testing"
+
+// --- scalar_sub (§6.3) ---
+
+func TestScalarSub(t *testing.T) {
+	cases := []struct {
+		name string
+		a, b Type
+		want bool
+	}{
+		{"same kind true", ScalarType(KindString, false), ScalarType(KindString, false), true},
+		{"integer sub number true", ScalarType(KindInteger, false), ScalarType(KindNumber, false), true},
+		{"number not sub integer false", ScalarType(KindNumber, false), ScalarType(KindInteger, false), false},
+		{"unrelated kinds false", ScalarType(KindString, false), ScalarType(KindInteger, false), false},
+		{"nullable narrowing false", ScalarType(KindString, true), ScalarType(KindString, false), false},
+		{"nullable widening true", ScalarType(KindString, false), ScalarType(KindString, true), true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := scalarSub(c.a, c.b)
+			if got != c.want {
+				t.Errorf("scalarSub(%+v, %+v) = %v, want %v", c.a, c.b, got, c.want)
+			}
+		})
+	}
+}
+
+// --- compatible_with / equivalent (§6.6, §6.7) ---
+
+// TestCompatibleWithWorkedExample is §6.6's own worked example: A has an
+// optional nick field, B doesn't. compatible_with(A, B) is false (A may
+// emit nick, B is closed), compatible_with(B, A) is true (everything B
+// emits, A accepts).
+func TestCompatibleWithWorkedExample(t *testing.T) {
+	a := mustParseOSD(t, `record User {
+		"id": string,
+		"name": string,
+		"nick" [0,1]: string,
+	} root User`)
+	b := mustParseOSD(t, `record User {
+		"id": string,
+		"name": string,
+	} root User`)
+
+	if CompatibleWith(a, b) {
+		t.Error("compatible_with(A, B) = true, want false")
+	}
+	if !CompatibleWith(b, a) {
+		t.Error("compatible_with(B, A) = false, want true")
+	}
+}
+
+func TestEquivalentWorkedExample(t *testing.T) {
+	a := mustParseOSD(t, `record User {
+		"id": string,
+		"name": string,
+		"nick" [0,1]: string,
+	} root User`)
+	b := mustParseOSD(t, `record User {
+		"id": string,
+		"name": string,
+	} root User`)
+
+	if Equivalent(a, b) {
+		t.Error("equivalent(A, B) = true, want false (only one direction holds)")
+	}
+}
+
+func TestEquivalentBothDirections(t *testing.T) {
+	a := mustParseOSD(t, `record User { "id": string } root User`)
+	b := mustParseOSD(t, `record Person { "id": string } root Person`)
+
+	if !Equivalent(a, b) {
+		t.Error("equivalent(A, B) = false, want true (structurally identical, differing only in record name)")
+	}
+}
+
+// TestCompatibleWithVacuousUnsatisfiableField: an A-side record with a
+// mandatory field pointing at an unsatisfiable A-side record. A can never
+// emit that field (it's unsatisfiable, so nothing beneath it terminates),
+// so record_sub's pass 1 must skip it rather than requiring B to have a
+// matching field, and this must not infinite-loop.
+func TestCompatibleWithVacuousUnsatisfiableField(t *testing.T) {
+	a := mustParseOSD(t, `
+		record Bad { "self": Bad }
+		record Root { "bad": Bad }
+		root Root
+	`)
+	b := mustParseOSD(t, `
+		record Root { }
+		root Root
+	`)
+
+	if !CompatibleWith(a, b) {
+		t.Error("compatible_with(A, B) = false, want true (A's mandatory field is unsatisfiable, so A vacuously emits nothing there)")
+	}
+}
+
+// TestCompatibleWithVacuousOptionalUnsatisfiableField: an A-side field
+// that is itself optional (min==0) and typed at an unsatisfiable A-side
+// record. This hits record_sub pass 1's own vacuous-skip
+// (`fa.min == 0 and fa.type is Ref and fa.type.name not in sat_a`)
+// directly, distinct from TestCompatibleWithVacuousUnsatisfiableField's
+// mandatory-field case (which is caught earlier, by sub's top-level
+// vacuous check on the Ref type itself before record_sub is ever
+// entered for that field).
+func TestCompatibleWithVacuousOptionalUnsatisfiableField(t *testing.T) {
+	a := mustParseOSD(t, `
+		record Bad { "self": Bad }
+		record Root { "bad" [0,1]: Bad }
+		root Root
+	`)
+	b := mustParseOSD(t, `
+		record Root { }
+		root Root
+	`)
+
+	if !CompatibleWith(a, b) {
+		t.Error("compatible_with(A, B) = false, want true (A's 'bad' field is optional and unsatisfiable, so A vacuously never emits it)")
+	}
+}
+
+// TestCompatibleWithAnyAbsorbsOnRight: a differently-shaped A-side field is
+// absorbed by a B-side any field.
+func TestCompatibleWithAnyAbsorbsOnRight(t *testing.T) {
+	a := mustParseOSD(t, `
+		record Shape { "x": string, "y": integer }
+		record Root { "field": Shape }
+		root Root
+	`)
+	b := mustParseOSD(t, `
+		record Root { "field": any }
+		root Root
+	`)
+
+	if !CompatibleWith(a, b) {
+		t.Error("compatible_with(A, B) = false, want true (B's any field absorbs any A-side shape)")
+	}
+}
+
+// TestCompatibleWithAnyNotAbsorbedOnLeft: an A-side any field is not
+// absorbed by a differently-shaped B-side field — only any holds any.
+func TestCompatibleWithAnyNotAbsorbedOnLeft(t *testing.T) {
+	a := mustParseOSD(t, `
+		record Root { "field": any }
+		root Root
+	`)
+	b := mustParseOSD(t, `
+		record Shape { "x": string, "y": integer }
+		record Root { "field": Shape }
+		root Root
+	`)
+
+	if CompatibleWith(a, b) {
+		t.Error("compatible_with(A, B) = true, want false (A's any field is not guaranteed to match B's specific shape)")
+	}
+}
+
+// TestCompatibleWithRecursiveCompatible: mutually-recursive records on both
+// sides that ARE compatible.
+func TestCompatibleWithRecursiveCompatible(t *testing.T) {
+	a := mustParseOSD(t, `
+		record NodeA { "value": string, "next" [0,1]: NodeA }
+		root NodeA
+	`)
+	b := mustParseOSD(t, `
+		record NodeB { "value": string, "next" [0,1]: NodeB }
+		root NodeB
+	`)
+
+	if !CompatibleWith(a, b) {
+		t.Error("compatible_with(A, B) = false, want true (structurally identical recursive shapes)")
+	}
+}
+
+// TestCompatibleWithRecursiveIncompatible: a recursive-schema case where the
+// correct answer is false, to confirm the coinductive assumption doesn't
+// just default everything to true.
+func TestCompatibleWithRecursiveIncompatible(t *testing.T) {
+	a := mustParseOSD(t, `
+		record NodeA { "value": string, "extra": string, "next" [0,1]: NodeA }
+		root NodeA
+	`)
+	b := mustParseOSD(t, `
+		record NodeB { "value": string, "next" [0,1]: NodeB }
+		root NodeB
+	`)
+
+	if CompatibleWith(a, b) {
+		t.Error("compatible_with(A, B) = true, want false (A's recursive record emits an extra field B is closed against)")
+	}
+}
+
+// TestCompatibleWithAliasing constructs a schema by hand (not through the
+// OSD parser, since two names bound to one *Record isn't expressible in
+// OSD text) where two different reference names resolve to the very same
+// underlying *Record. This is the aliasing case §6.6 explicitly warns
+// about: keying the memo on reference names instead of resolved-definition
+// identity would treat the two names as different nodes.
+func TestCompatibleWithAliasing(t *testing.T) {
+	shared := &Record{
+		Name: "Shared",
+		Fields: []Field{
+			{Label: "value", Type: ScalarType(KindString, false), Cardinality: DefaultCardinality()},
+		},
+	}
+	root := &Record{
+		Name: "Root",
+		Fields: []Field{
+			// Two different labels, both typed at refs ("Alias1", "Alias2")
+			// that resolve to the identical *Record pointer.
+			{Label: "one", Type: RefType("Alias1"), Cardinality: DefaultCardinality()},
+			{Label: "two", Type: RefType("Alias2"), Cardinality: DefaultCardinality()},
+		},
+	}
+	a := Schema{
+		Root: "Root",
+		Env: map[string]*Record{
+			"Root":   root,
+			"Alias1": shared,
+			"Alias2": shared,
+		},
+		EnvOrder: []string{"Root", "Alias1", "Alias2"},
+	}
+
+	bShared := &Record{
+		Name: "Shared",
+		Fields: []Field{
+			{Label: "value", Type: ScalarType(KindString, false), Cardinality: DefaultCardinality()},
+		},
+	}
+	bRoot := &Record{
+		Name: "Root",
+		Fields: []Field{
+			{Label: "one", Type: RefType("Alias1"), Cardinality: DefaultCardinality()},
+			{Label: "two", Type: RefType("Alias2"), Cardinality: DefaultCardinality()},
+		},
+	}
+	b := Schema{
+		Root: "Root",
+		Env: map[string]*Record{
+			"Root":   bRoot,
+			"Alias1": bShared,
+			"Alias2": bShared,
+		},
+		EnvOrder: []string{"Root", "Alias1", "Alias2"},
+	}
+
+	if !CompatibleWith(a, b) {
+		t.Error("compatible_with(A, B) = false, want true (aliased refs, identical structure)")
+	}
+	if !Equivalent(a, b) {
+		t.Error("equivalent(A, B) = false, want true (aliased refs, identical structure)")
+	}
+}
+
+// TestCompatibleWithValueVersusObject: A's field is a record, B's
+// same-label field is a scalar — the "value versus object" default case
+// in sub, which the resolvedRecord/resolvedRecord fast path and the Any
+// clauses don't reach.
+func TestCompatibleWithValueVersusObject(t *testing.T) {
+	a := mustParseOSD(t, `
+		record Shape { "x": string }
+		record Root { "field": Shape }
+		root Root
+	`)
+	b := mustParseOSD(t, `
+		record Root { "field": string }
+		root Root
+	`)
+
+	if CompatibleWith(a, b) {
+		t.Error("compatible_with(A, B) = true, want false (A's field is a record, B's is a scalar)")
+	}
+}
+
+// TestCompatibleWithFieldNeverEmitted: an A-side field with max==0 (never
+// emitted per record_sub's own skip, distinct from the optional-vacuous
+// skip) that B doesn't declare at all — must not cause a false rejection.
+func TestCompatibleWithFieldNeverEmitted(t *testing.T) {
+	a := mustParseOSD(t, `
+		record Root { "dead" [0,0]: string, "id": string }
+		root Root
+	`)
+	b := mustParseOSD(t, `
+		record Root { "id": string }
+		root Root
+	`)
+
+	if !CompatibleWith(a, b) {
+		t.Error("compatible_with(A, B) = false, want true (A's 'dead' field has max 0, never emitted)")
+	}
+}
+
+// TestCompatibleWithCardinalityBoundsTooNarrow: B declares the shared
+// field but with bounds that don't cover A's — B's max is narrower than
+// A's max.
+func TestCompatibleWithCardinalityBoundsTooNarrow(t *testing.T) {
+	a := mustParseOSD(t, `
+		record Root { "tags" [0,5]: string }
+		root Root
+	`)
+	b := mustParseOSD(t, `
+		record Root { "tags" [0,2]: string }
+		root Root
+	`)
+
+	if CompatibleWith(a, b) {
+		t.Error("compatible_with(A, B) = true, want false (A may emit up to 5 tags, B only allows up to 2)")
+	}
+}
+
+// TestCompatibleWithCardinalityMinTooHigh: B requires a higher minimum
+// count for a shared field than B.min <= A.min allows.
+func TestCompatibleWithCardinalityMinTooHigh(t *testing.T) {
+	a := mustParseOSD(t, `
+		record Root { "tags" [0,5]: string }
+		root Root
+	`)
+	b := mustParseOSD(t, `
+		record Root { "tags" [1,5]: string }
+		root Root
+	`)
+
+	if CompatibleWith(a, b) {
+		t.Error("compatible_with(A, B) = true, want false (B requires at least 1 tag, A guarantees only 0)")
+	}
+}
+
+// TestRecordSubFailsPass1Only: A emits a field B doesn't allow at all
+// (label B doesn't declare), but A guarantees everything B requires.
+func TestRecordSubFailsPass1Only(t *testing.T) {
+	a := mustParseOSD(t, `
+		record Root { "id": string, "extra": string }
+		root Root
+	`)
+	b := mustParseOSD(t, `
+		record Root { "id": string }
+		root Root
+	`)
+
+	if CompatibleWith(a, b) {
+		t.Error("compatible_with(A, B) = true, want false (pass 1: A emits 'extra', B is closed against it)")
+	}
+}
+
+// TestRecordSubFailsPass2Only: B requires a field A doesn't guarantee
+// (A has it optional), while A emits nothing B disallows.
+func TestRecordSubFailsPass2Only(t *testing.T) {
+	a := mustParseOSD(t, `
+		record Root { "id" [0,1]: string }
+		root Root
+	`)
+	b := mustParseOSD(t, `
+		record Root { "id": string }
+		root Root
+	`)
+
+	if CompatibleWith(a, b) {
+		t.Error("compatible_with(A, B) = true, want false (pass 2: B requires 'id', A only guarantees it optionally)")
+	}
+}
+
+// TestRecordSubFailsPass2FieldAbsent: B requires a field that A doesn't
+// declare at all (distinct from TestRecordSubFailsPass2Only, where A
+// declares the field but only optionally).
+func TestRecordSubFailsPass2FieldAbsent(t *testing.T) {
+	a := mustParseOSD(t, `
+		record Root { "id": string }
+		root Root
+	`)
+	b := mustParseOSD(t, `
+		record Root { "id": string, "required": string }
+		root Root
+	`)
+
+	if CompatibleWith(a, b) {
+		t.Error("compatible_with(A, B) = true, want false (B requires 'required', A doesn't declare it at all)")
+	}
+}
+
+// TestRecordSubPassesBoth: A emits nothing B disallows, and A guarantees
+// everything B requires.
+func TestRecordSubPassesBoth(t *testing.T) {
+	a := mustParseOSD(t, `
+		record Root { "id": string, "extra" [0,1]: string }
+		root Root
+	`)
+	b := mustParseOSD(t, `
+		record Root { "id": string, "extra" [0,1]: string }
+		root Root
+	`)
+
+	if !CompatibleWith(a, b) {
+		t.Error("compatible_with(A, B) = false, want true (both fields allowed by B with adequate bounds, B requires only id, A guarantees it)")
+	}
+}


### PR DESCRIPTION
Closes #11.

Ports spec Sec6.3 (scalarSub), Sec6.6 (compatible_with -- coinductive sub/recordSub over memoized resolved-definition pairs), Sec6.7 (equivalent, no structural shortcut). Reuses SatisfiableSet/le from issue #9 and resolveType from validate.go (issue #7).

This is the densest algorithm in the port so far, so it got the heaviest review. Independently verified: 100% per-function coverage, 0 lint issues, and specifically stress-tested rather than just re-run --the reviewer built its own independent aliasing fixture (three ref names sharing one *Record) and its own independent mutual-recursion case with a known-false expected answer, both to catch a coinductive bug that silently defaults to true. Memo-key identity (pointer-based, not name-based, per Sec6.6s explicit warning), assumption-before-recurse timing, recordSub pass 1/2 cardinality-check direction, the any asymmetry, and the vacuous-true-for-unsatisfiable-A-refs scope were all traced line-by-line against the spec pseudocode.

No spec ambiguity. One narrow implementation note: only Record/Record pairs are memoized (Scalar/Any resolved types have no *Record identity and are non-recursive) -- documented inline as the plainly-correct reading of memoized over pairs of resolved definitions.