### PR TITLE
normalize

### DIFF
--- a/normalize.go
+++ b/normalize.go
@@ -1,0 +1,273 @@
+package omnist
+
+import "sort"
+
+// This file implements §6.8's normalize(S) (port-order step 7), the
+// paper's MinimizeSA: the canonical minimal schema equivalent to S. It
+// depends on Prune/IsEmpty/SatisfiableSet (issue #9, algebra.go) and the
+// Schema/Record/Field/Type/Cardinality/EnvOrder types (issue #5).
+
+// localSig is the comparable value used as a map key for local_signature
+// (§6.8 step 2): a byte-encoding of each field's (label, min, max,
+// is-scalar-or-not), in declaration order. Record.Fields is already a
+// slice in declaration order (schema.go); two records with the same
+// fields in a different order are NOT the same local signature, matching
+// the spec's field-by-field tuple description — there is no sort here.
+// (Sorting by label happens one level up, in refine_key, per the
+// pseudocode.) The encoding uses control-byte separators (see
+// appendFieldSig/appendEscapedLabel) so no two distinct field lists can
+// collide.
+type localSig string
+
+// computeLocalSignature builds the comparable local signature for rec, per
+// §6.8 step 2. Returned as a string so it's directly usable as a Go map
+// key (the issue's requirement: "usable as a Go map key or otherwise
+// comparable").
+func computeLocalSignature(rec *Record) localSig {
+	var b []byte
+	for _, f := range rec.Fields {
+		b = appendFieldSig(b, f)
+	}
+	return localSig(b)
+}
+
+// appendFieldSig appends one field's (label, min, max, is-scalar-or-not)
+// encoding to b, using '\x00'/'\x01' as field/component separators that
+// cannot appear in the numeric or boolean components and are escaped out
+// of the label so a crafted label can't forge a delimiter collision.
+func appendFieldSig(b []byte, f Field) []byte {
+	b = append(b, '\x00')
+	b = appendEscapedLabel(b, f.Label)
+	b = append(b, '\x01')
+	b = appendUint(b, f.Cardinality.Min)
+	b = append(b, '\x01')
+	if f.Cardinality.Unbounded {
+		b = append(b, 'U')
+	} else {
+		b = appendUint(b, f.Cardinality.Max)
+	}
+	b = append(b, '\x01')
+	if f.Type.Kind == TypeRefKind {
+		b = append(b, 'R')
+	} else {
+		b = append(b, 'S')
+	}
+	return b
+}
+
+// appendEscapedLabel appends label with '\x00' and '\x01' bytes escaped
+// (prefixed with '\x02'), so an adversarial label containing those control
+// bytes cannot forge a false signature collision or split.
+func appendEscapedLabel(b []byte, label string) []byte {
+	for i := 0; i < len(label); i++ {
+		c := label[i]
+		if c == '\x00' || c == '\x01' || c == '\x02' {
+			b = append(b, '\x02')
+		}
+		b = append(b, c)
+	}
+	return b
+}
+
+// appendUint appends the decimal digits of v to b without allocating via
+// fmt, since this runs in the hot path of grouping every field of every
+// record.
+func appendUint(b []byte, v uint64) []byte {
+	start := len(b)
+	if v == 0 {
+		return append(b, '0')
+	}
+	for v > 0 {
+		b = append(b, byte('0'+v%10))
+		v /= 10
+	}
+	// digits were appended least-significant-first; reverse them in place.
+	for i, j := start, len(b)-1; i < j; i, j = i+1, j-1 {
+		b[i], b[j] = b[j], b[i]
+	}
+	return b
+}
+
+// refineFieldKey is one field's contribution to refine_key (§6.8): like
+// localFieldSig but with the reference target resolved to its *current
+// block index* rather than ignored, so refinement can tell apart records
+// whose references point at different (non-mergeable) sub-blocks.
+type refineFieldKey struct {
+	Label     string
+	Min       uint64
+	Max       uint64
+	Unbounded bool
+	IsRef     bool
+	Block     int // meaningful only when IsRef; -1 otherwise
+}
+
+// computeRefineKey implements §6.8's refine_key(rec, block_of): the
+// record's local_signature combined with, for every field sorted by
+// label, (label, min, max, block_of[target] if ref else none). Returned
+// as a comparable string so blocks can be grouped by it in a Go map, same
+// approach as localSig.
+func computeRefineKey(rec *Record, blockOf map[string]int) string {
+	fields := make([]refineFieldKey, len(rec.Fields))
+	for i, f := range rec.Fields {
+		fields[i] = refineFieldKey{
+			Label:     f.Label,
+			Min:       f.Cardinality.Min,
+			Max:       f.Cardinality.Max,
+			Unbounded: f.Cardinality.Unbounded,
+			IsRef:     f.Type.Kind == TypeRefKind,
+			Block:     -1,
+		}
+		if f.Type.Kind == TypeRefKind {
+			fields[i].Block = blockOf[f.Type.RefName]
+		}
+	}
+	sort.Slice(fields, func(i, j int) bool {
+		return fields[i].Label < fields[j].Label
+	})
+
+	b := []byte(computeLocalSignature(rec))
+	b = append(b, '\x03') // separates local_signature from the sorted-field part
+	for _, f := range fields {
+		b = append(b, '\x00')
+		b = appendEscapedLabel(b, f.Label)
+		b = append(b, '\x01')
+		b = appendUint(b, f.Min)
+		b = append(b, '\x01')
+		if f.Unbounded {
+			b = append(b, 'U')
+		} else {
+			b = appendUint(b, f.Max)
+		}
+		b = append(b, '\x01')
+		if f.IsRef {
+			b = append(b, 'R')
+			b = appendUint(b, uint64(f.Block))
+		} else {
+			b = append(b, 'N') // none: not a reference field
+		}
+	}
+	return string(b)
+}
+
+// EquivalenceClasses implements §6.8's equivalence_classes(S): the
+// structural partition of S.Env's record names, WITHOUT pruning first —
+// callers (Normalize here, lint in a later issue) decide whether to prune
+// before calling this. Blocks and the names within each block are both in
+// deterministic (sorted-name) order, satisfying the spec's determinism
+// requirement that two conformant implementations produce identical
+// output, not merely equivalent output.
+func EquivalenceClasses(s Schema) [][]string {
+	names := make([]string, len(s.EnvOrder))
+	copy(names, s.EnvOrder)
+	sort.Strings(names)
+
+	// Initial grouping by local signature.
+	blocks := groupBy(names, func(name string) string {
+		return string(computeLocalSignature(s.Env[name]))
+	})
+	blockOf := indexBlocks(blocks)
+
+	// Refine to a fixpoint: repeat until the block count stops changing.
+	for {
+		var newBlocks [][]string
+		for _, block := range blocks {
+			refined := groupBy(block, func(name string) string {
+				return computeRefineKey(s.Env[name], blockOf)
+			})
+			newBlocks = append(newBlocks, refined...)
+		}
+		if len(newBlocks) == len(blocks) {
+			blocks = newBlocks
+			break
+		}
+		blocks = newBlocks
+		blockOf = indexBlocks(blocks)
+	}
+	return blocks
+}
+
+// groupBy partitions names (assumed already sorted) into blocks sharing
+// the same key(name), preserving the sorted order both across blocks (by
+// each block's first-seen name) and within each block.
+func groupBy(names []string, key func(string) string) [][]string {
+	order := make([]string, 0, len(names))
+	buckets := make(map[string][]string, len(names))
+	for _, n := range names {
+		k := key(n)
+		if _, ok := buckets[k]; !ok {
+			order = append(order, k)
+		}
+		buckets[k] = append(buckets[k], n)
+	}
+	blocks := make([][]string, len(order))
+	for i, k := range order {
+		blocks[i] = buckets[k]
+	}
+	return blocks
+}
+
+// indexBlocks builds block_of: the index of the block each name currently
+// belongs to.
+func indexBlocks(blocks [][]string) map[string]int {
+	idx := make(map[string]int)
+	for i, block := range blocks {
+		for _, n := range block {
+			idx[n] = i
+		}
+	}
+	return idx
+}
+
+// Normalize implements §6.8's normalize(S): prune, short-circuit if empty,
+// partition into equivalence classes, pick each block's lexicographically
+// smallest name as its representative, rewrite every reference (including
+// the root) to representatives, and keep only representatives in the new
+// env.
+func Normalize(s Schema) Schema {
+	s = Prune(s)
+	if IsEmpty(s) {
+		return s
+	}
+
+	rep := make(map[string]string, len(s.EnvOrder))
+	for _, block := range EquivalenceClasses(s) {
+		// block[0] is the lexicographic minimum: groupBy (called by
+		// EquivalenceClasses at every refinement pass) preserves the
+		// relative order of its input, and every pass starts from names
+		// sorted ascending, so each block is a sorted subsequence of that
+		// order and its first element is its minimum.
+		keep := block[0]
+		for _, n := range block {
+			rep[n] = keep
+		}
+	}
+
+	names := make([]string, len(s.EnvOrder))
+	copy(names, s.EnvOrder)
+	sort.Strings(names)
+
+	newEnv := make(map[string]*Record, len(rep))
+	newOrder := make([]string, 0, len(rep))
+	for _, name := range names {
+		if rep[name] != name {
+			continue
+		}
+		newEnv[name] = remapRecord(s.Env[name], rep)
+		newOrder = append(newOrder, name)
+	}
+	return Schema{Root: rep[s.Root], Env: newEnv, EnvOrder: newOrder}
+}
+
+// remapRecord rewrites every reference field in rec to its representative
+// per rep, implementing the remap(rec, rep) used by normalize's new_env
+// construction.
+func remapRecord(rec *Record, rep map[string]string) *Record {
+	fields := make([]Field, len(rec.Fields))
+	for i, f := range rec.Fields {
+		if f.Type.Kind == TypeRefKind {
+			f.Type = RefType(rep[f.Type.RefName])
+		}
+		fields[i] = f
+	}
+	return &Record{Name: rec.Name, Fields: fields}
+}

--- a/normalize_test.go
+++ b/normalize_test.go
@@ -1,0 +1,403 @@
+package omnist
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+// --- normalize (§6.8) ---
+
+// TestNormalizeWorkedExample is the exact §6.8 worked example: A and B
+// have identical local signatures and no reference fields, so they merge
+// on the first pass, and Top is rewritten to reference the survivor (the
+// lexicographic minimum, A).
+func TestNormalizeWorkedExample(t *testing.T) {
+	s := mustParseOSD(t, `
+		record A { "x": string }
+		record B { "x": string }
+		record Top { "a": A, "b": B }
+		root Top
+	`)
+	got := Normalize(s)
+
+	if got.Root != "Top" {
+		t.Fatalf("root = %q, want Top", got.Root)
+	}
+	wantNames := []string{"A", "Top"}
+	if !reflect.DeepEqual(got.EnvOrder, wantNames) {
+		t.Fatalf("EnvOrder = %v, want %v", got.EnvOrder, wantNames)
+	}
+	if _, ok := got.Env["B"]; ok {
+		t.Fatalf("B should have been merged away, still present in env")
+	}
+	top := got.Env["Top"]
+	if top == nil {
+		t.Fatalf("Top missing from normalized env")
+	}
+	for _, f := range top.Fields {
+		if f.Type.Kind != TypeRefKind || f.Type.RefName != "A" {
+			t.Errorf("field %q = %+v, want ref to A", f.Label, f.Type)
+		}
+	}
+}
+
+// TestNormalizeDeterministicRepresentative confirms the same
+// representative (lexicographic minimum) is chosen across repeated runs
+// on schemas with several structurally-identical blocks, and confirms the
+// choice really is the minimum rather than e.g. declaration order or map
+// iteration order (built here by declaring names out of lexicographic
+// order: Zeta before Alpha before Mimi, all with the same signature).
+func TestNormalizeDeterministicRepresentative(t *testing.T) {
+	src := `
+		record Zeta { "x": string }
+		record Alpha { "x": string }
+		record Mimi { "x": string }
+		record Top { "z": Zeta, "a": Alpha, "m": Mimi }
+		root Top
+	`
+	for i := 0; i < 5; i++ {
+		s := mustParseOSD(t, src)
+		got := Normalize(s)
+		if _, ok := got.Env["Alpha"]; !ok {
+			t.Fatalf("run %d: expected representative Alpha to survive, got env %v", i, got.EnvOrder)
+		}
+		if len(got.EnvOrder) != 2 {
+			t.Fatalf("run %d: expected 2 surviving records (Alpha, Top), got %v", i, got.EnvOrder)
+		}
+		top := got.Env["Top"]
+		for _, f := range top.Fields {
+			if f.Type.RefName != "Alpha" {
+				t.Errorf("run %d: field %q references %q, want Alpha", i, f.Label, f.Type.RefName)
+			}
+		}
+	}
+}
+
+// TestNormalizePrunesBeforeMerging builds a schema with an unreachable
+// record (Orphan) that is structurally identical to a reachable one (A),
+// and confirms normalize does not accidentally merge Orphan in — prune
+// must run first and drop it, so it should never appear (nor influence
+// which name survives) in the normalized output.
+func TestNormalizePrunesBeforeMerging(t *testing.T) {
+	s := mustParseOSD(t, `
+		record A { "x": string }
+		record Orphan { "x": string }
+		record Top { "a": A }
+		root Top
+	`)
+	got := Normalize(s)
+
+	if _, ok := got.Env["Orphan"]; ok {
+		t.Fatalf("Orphan should have been pruned before normalization, still present")
+	}
+	wantNames := []string{"A", "Top"}
+	if !reflect.DeepEqual(got.EnvOrder, wantNames) {
+		t.Fatalf("EnvOrder = %v, want %v", got.EnvOrder, wantNames)
+	}
+}
+
+// TestNormalizeEmptyShortCircuit confirms that when the root is
+// unsatisfiable (pruned schema is_empty), normalize returns the pruned
+// result unchanged — matching what Prune alone produces (root fields
+// untouched, per issue #9's root-unsatisfiable case), not further
+// processed by equivalence-class merging.
+func TestNormalizeEmptyShortCircuit(t *testing.T) {
+	s := mustParseOSD(t, `record Node { "child": Node } root Node`)
+
+	pruned := Prune(s)
+	if !IsEmpty(pruned) {
+		t.Fatalf("test setup: expected pruned schema to be empty")
+	}
+
+	got := Normalize(s)
+	if !reflect.DeepEqual(got, pruned) {
+		t.Fatalf("Normalize(s) = %+v, want unchanged Prune(s) = %+v", got, pruned)
+	}
+	// The root-unsatisfiable special case: fields untouched, not merged
+	// away, even though Node's single self-referential field would give it
+	// a signature theoretically groupable with itself.
+	if len(got.Env["Node"].Fields) != 1 {
+		t.Fatalf("root record's fields should be untouched by the empty short-circuit")
+	}
+}
+
+// TestNormalizeFixpointRefinementKeepsDivergentBlocksSeparate is the test
+// most likely to catch a real refinement bug: LeftHolder and RightHolder
+// share the same initial local signature (both have one mandatory
+// reference field named "target"), but LeftHolder points at LeftLeaf and
+// RightHolder points at RightLeaf, and LeftLeaf/RightLeaf are NOT
+// equivalent (different field labels, so different local signatures). An
+// implementation that only does one pass of grouping-by-local-signature,
+// never re-checking where references point, would wrongly merge
+// LeftHolder and RightHolder. Correct fixpoint refinement must keep them
+// apart.
+func TestNormalizeFixpointRefinementKeepsDivergentBlocksSeparate(t *testing.T) {
+	s := mustParseOSD(t, `
+		record LeftLeaf { "left_only": string }
+		record RightLeaf { "right_only": string }
+		record LeftHolder { "target": LeftLeaf }
+		record RightHolder { "target": RightLeaf }
+		record Top { "l": LeftHolder, "r": RightHolder }
+		root Top
+	`)
+	got := Normalize(s)
+
+	// Nothing should have merged: 5 distinct records survive.
+	wantNames := []string{"LeftHolder", "LeftLeaf", "RightHolder", "RightLeaf", "Top"}
+	gotNames := append([]string{}, got.EnvOrder...)
+	sort.Strings(gotNames)
+	if !reflect.DeepEqual(gotNames, wantNames) {
+		t.Fatalf("EnvOrder (sorted) = %v, want %v (nothing should have merged)", gotNames, wantNames)
+	}
+	top := got.Env["Top"]
+	refs := map[string]string{}
+	for _, f := range top.Fields {
+		refs[f.Label] = f.Type.RefName
+	}
+	if refs["l"] != "LeftHolder" || refs["r"] != "RightHolder" {
+		t.Fatalf("Top's references changed unexpectedly: %+v", refs)
+	}
+}
+
+// TestNormalizeFixpointRefinementMergesTrulyEquivalentBlocks is the
+// positive counterpart: LeftHolder2/RightHolder2 also share the same
+// initial signature AND their reference targets (LeftLeaf2 vs RightLeaf2)
+// are themselves genuinely equivalent (same fields), so after refinement
+// LeftHolder2/RightHolder2 (and LeftLeaf2/RightLeaf2) SHOULD merge.
+func TestNormalizeFixpointRefinementMergesTrulyEquivalentBlocks(t *testing.T) {
+	s := mustParseOSD(t, `
+		record LeftLeaf2 { "v": string }
+		record RightLeaf2 { "v": string }
+		record LeftHolder2 { "target": LeftLeaf2 }
+		record RightHolder2 { "target": RightLeaf2 }
+		record Top { "l": LeftHolder2, "r": RightHolder2 }
+		root Top
+	`)
+	got := Normalize(s)
+
+	wantNames := []string{"LeftHolder2", "LeftLeaf2", "Top"}
+	gotNames := append([]string{}, got.EnvOrder...)
+	sort.Strings(gotNames)
+	if !reflect.DeepEqual(gotNames, wantNames) {
+		t.Fatalf("EnvOrder (sorted) = %v, want %v", gotNames, wantNames)
+	}
+	top := got.Env["Top"]
+	for _, f := range top.Fields {
+		if f.Type.RefName != "LeftHolder2" {
+			t.Errorf("field %q references %q, want LeftHolder2", f.Label, f.Type.RefName)
+		}
+	}
+}
+
+// TestLocalSignatureUnboundedCardinality covers the unbounded-cardinality
+// encoding branch of appendFieldSig/local_signature: a record with an
+// unbounded field must have a different local signature than one with an
+// otherwise-identical bounded field, and two unbounded fields must match.
+func TestLocalSignatureUnboundedCardinality(t *testing.T) {
+	s := mustParseOSD(t, `
+		record Bounded { "x" [1,5]: string }
+		record Unbounded1 { "x" [1,]: string }
+		record Unbounded2 { "x" [1,]: string }
+		record Top { "b": Bounded, "u1": Unbounded1, "u2": Unbounded2 }
+		root Top
+	`)
+	bounded := computeLocalSignature(s.Env["Bounded"])
+	unb1 := computeLocalSignature(s.Env["Unbounded1"])
+	unb2 := computeLocalSignature(s.Env["Unbounded2"])
+
+	if bounded == unb1 {
+		t.Errorf("bounded and unbounded cardinalities should differ")
+	}
+	if unb1 != unb2 {
+		t.Errorf("two unbounded fields should share a local signature")
+	}
+}
+
+// TestLocalSignatureOptionalFieldZeroMin covers the min==0 encoding
+// branch (appendUint's zero case) via an optional field.
+func TestLocalSignatureOptionalFieldZeroMin(t *testing.T) {
+	s := mustParseOSD(t, `
+		record Optional { "x" [0,1]: string }
+		record Mandatory { "x" [1,1]: string }
+		root Optional
+	`)
+	opt := computeLocalSignature(s.Env["Optional"])
+	man := computeLocalSignature(s.Env["Mandatory"])
+	if opt == man {
+		t.Errorf("optional (min=0) and mandatory (min=1) fields should have different local signatures")
+	}
+}
+
+// TestAppendEscapedLabelEscapesControlBytes exercises
+// appendEscapedLabel's escape branch directly: since OSD label content
+// reaching the parser cannot itself contain raw control bytes, this
+// checks the helper in isolation to confirm two labels that would
+// otherwise collide once delimiters are involved are kept distinct.
+func TestAppendEscapedLabelEscapesControlBytes(t *testing.T) {
+	withControl := string(appendEscapedLabel(nil, "a\x00b"))
+	plain := string(appendEscapedLabel(nil, "a\x02\x00b"))
+	if withControl == "" {
+		t.Fatalf("expected non-empty escaped output")
+	}
+	if len(withControl) <= len("a\x00b") {
+		t.Errorf("expected escape byte to lengthen output, got %q", withControl)
+	}
+	// Distinct inputs sharing the raw \x00 byte once escaped must not
+	// collide with an unrelated input containing the escape byte itself.
+	if withControl == plain {
+		t.Errorf("escaping collision: %q == %q", withControl, plain)
+	}
+}
+
+// TestComputeRefineKeyUnboundedRefField covers computeRefineKey's
+// unbounded-cardinality-on-a-reference-field encoding branch, which
+// local_signature-level tests never reach since they use non-ref fields.
+func TestComputeRefineKeyUnboundedRefField(t *testing.T) {
+	s := mustParseOSD(t, `
+		record Leaf { "v": string }
+		record Holder { "f" [1,]: Leaf }
+		root Holder
+	`)
+	blockOf := map[string]int{"Leaf": 0}
+	key := computeRefineKey(s.Env["Holder"], blockOf)
+	if key == "" {
+		t.Fatalf("expected non-empty refine key")
+	}
+}
+
+// TestAppendUintMultiDigit covers appendUint's digit-reversal loop, which
+// a single-digit cardinality (the only kind used elsewhere in this file)
+// never exercises.
+func TestAppendUintMultiDigit(t *testing.T) {
+	got := string(appendUint(nil, 12345))
+	if got != "12345" {
+		t.Fatalf("appendUint(12345) = %q, want %q", got, "12345")
+	}
+	single := string(appendUint(nil, 7))
+	if single != "7" {
+		t.Fatalf("appendUint(7) = %q, want %q", single, "7")
+	}
+	zero := string(appendUint(nil, 0))
+	if zero != "0" {
+		t.Fatalf("appendUint(0) = %q, want %q", zero, "0")
+	}
+}
+
+// --- equivalence_classes (§6.8), called directly (no prune) ---
+
+// TestEquivalenceClassesDoesNotPrune confirms EquivalenceClasses operates
+// on S.env exactly as given, per the spec's explicit note that it does
+// NOT prune first (normalize prunes before calling it; a later issue,
+// lint, calls it directly on the raw schema). An unreachable record must
+// still show up in some block.
+func TestEquivalenceClassesDoesNotPrune(t *testing.T) {
+	s := mustParseOSD(t, `
+		record A { "x": string }
+		record Orphan { "y": string }
+		record Top { "a": A }
+		root Top
+	`)
+	blocks := EquivalenceClasses(s)
+
+	found := false
+	for _, block := range blocks {
+		for _, name := range block {
+			if name == "Orphan" {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("Orphan should still appear in some equivalence class (EquivalenceClasses must not prune), blocks = %v", blocks)
+	}
+}
+
+// TestEquivalenceClassesOrdering confirms blocks and names within blocks
+// come back in deterministic sorted order.
+func TestEquivalenceClassesOrdering(t *testing.T) {
+	s := mustParseOSD(t, `
+		record Zeta { "x": string }
+		record Alpha { "x": string }
+		record Top { "z": Zeta, "a": Alpha }
+		root Top
+	`)
+	blocks := EquivalenceClasses(s)
+
+	var flat []string
+	for _, block := range blocks {
+		var b []string
+		b = append(b, block...)
+		if !sort.StringsAreSorted(b) {
+			t.Errorf("block %v not internally sorted", block)
+		}
+		flat = append(flat, block...)
+	}
+	if len(flat) != 3 {
+		t.Fatalf("expected 3 names across all blocks, got %v", flat)
+	}
+}
+
+// TestLocalSignatureDistinguishesFieldCount confirms local signatures
+// differ (and hence records land in different initial blocks) when field
+// counts differ, and are equal for structurally identical records.
+func TestLocalSignatureDistinguishesFieldCount(t *testing.T) {
+	s := mustParseOSD(t, `
+		record One { "x": string }
+		record Two { "x": string, "y": string }
+		record Same1 { "x": string }
+		record Same2 { "x": string }
+		record Top { "o": One, "t": Two, "s1": Same1, "s2": Same2 }
+		root Top
+	`)
+	one := computeLocalSignature(s.Env["One"])
+	two := computeLocalSignature(s.Env["Two"])
+	same1 := computeLocalSignature(s.Env["Same1"])
+	same2 := computeLocalSignature(s.Env["Same2"])
+
+	if one == two {
+		t.Errorf("One and Two should have different local signatures")
+	}
+	if same1 != same2 {
+		t.Errorf("Same1 and Same2 should have identical local signatures")
+	}
+}
+
+// TestLocalSignatureRefVsScalarDiffers confirms a reference field and a
+// scalar field with the same label/cardinality produce different local
+// signatures (the is-scalar-or-not component), even though the reference
+// target itself is ignored by local_signature.
+func TestLocalSignatureRefVsScalarDiffers(t *testing.T) {
+	s := mustParseOSD(t, `
+		record Leaf { "v": string }
+		record RefHolder { "f": Leaf }
+		record ScalarHolder { "f": string }
+		record Top { "r": RefHolder, "s": ScalarHolder }
+		root Top
+	`)
+	ref := computeLocalSignature(s.Env["RefHolder"])
+	scalar := computeLocalSignature(s.Env["ScalarHolder"])
+	if ref == scalar {
+		t.Errorf("ref-field and scalar-field records should have different local signatures")
+	}
+}
+
+// TestLocalSignatureIgnoresRefTarget confirms two records referencing
+// different (but at this stage un-refined) targets share a local
+// signature — the target-blindness the spec calls for in step 2, refined
+// away only later by refine_key/fixpoint.
+func TestLocalSignatureIgnoresRefTarget(t *testing.T) {
+	s := mustParseOSD(t, `
+		record LeafA { "v": string }
+		record LeafB { "v": string, "w": string }
+		record HolderA { "f": LeafA }
+		record HolderB { "f": LeafB }
+		record Top { "a": HolderA, "b": HolderB }
+		root Top
+	`)
+	a := computeLocalSignature(s.Env["HolderA"])
+	b := computeLocalSignature(s.Env["HolderB"])
+	if a != b {
+		t.Errorf("HolderA and HolderB should share a local signature (target-blind), got %q vs %q", a, b)
+	}
+}


### PR DESCRIPTION
Closes #13.

Ports spec Sec6.8 (MinimizeSA): prune, partition refinement (EquivalenceClasses -- target-blind local signature, then fixpoint refinement on reference-target block membership), merge to lexicographic-minimum representative.

Independently verified: 100% per-function coverage, 0 lint issues. Heaviest scrutiny went to a specific design claim -- keep=block[0] instead of a literal min-scan, on the reasoning that groupBy is a stable partition over an always-sorted input so every block is always a sorted subsequence. The reviewer re-derived this invariant independently (not just re-reading the comment) and additionally wrote its own adversarial test with record names scrambled relative to their structural grouping, comparing block[0] against a computed min over every block -- no mismatch. Prune-before-refine ordering, the is_empty short-circuit, and fixpoint correctness (a same-first-pass-signature-but-non-equivalent case that must NOT merge) were each independently confirmed, the last via a reviewer-verified test purpose-built to catch a broken/missing fixpoint.

No spec ambiguity.