### PR TITLE
extract

### DIFF
--- a/extract.go
+++ b/extract.go
@@ -1,0 +1,130 @@
+package omnist
+
+import "fmt"
+
+// This file implements §6.9's extract(S, keep) (port-order step 8): given a
+// set of permissible labels, the minimal subschema recognizing only
+// Documents built from those labels. It depends on Prune (issue #9,
+// algebra.go), Normalize (issue #13, normalize.go), and the
+// Schema/Record/Field/Type/Cardinality/EnvOrder types (issue #5).
+
+// firstBad records the first offender (label, record name) encountered
+// during Extract's step 1 declaration-order pass, per §6.9's determinism
+// requirement: "first_bad records the first offender encountered during
+// step 1's single pass over S.env in declaration order — not the first one
+// propagation later discovers."
+type firstBad struct {
+	label  string
+	record string
+}
+
+// Extract implements §6.9's `extract(S, keep)`. keep is the set of
+// permissible labels; a label present as a key with a true value is kept
+// (matching the issue's suggested `map[string]bool` representation).
+//
+// On success, the returned Schema has already been run through Prune then
+// Normalize (step 5's final line), landing in the same canonical form
+// Normalize produces everywhere else — callers MUST NOT re-normalize.
+//
+// On failure (the root ends up invalidated, step 4), the returned error is
+// a Diagnostic with code algebra.extract-invalidates-root naming the first
+// offending label and the record it invalidated.
+func Extract(s Schema, keep map[string]bool) (Schema, error) {
+	trimmed, invalidated, bad := extractFilterFields(s, keep)
+	extractPropagate(s, trimmed, invalidated)
+
+	if invalidated[s.Root] {
+		return Schema{}, Diagnostic{
+			Path:    bad.record,
+			Code:    CodeAlgebraExtractInvalidatesRoot,
+			Message: fmt.Sprintf("removing label %q deletes a mandatory field of %s", bad.label, bad.record),
+			Severity: SeverityError,
+		}
+	}
+
+	newEnv, newOrder := extractBuildEnv(s, trimmed, invalidated)
+	return Normalize(Prune(Schema{Root: s.Root, Env: newEnv, EnvOrder: newOrder})), nil
+}
+
+// extractFilterFields implements §6.9 steps 1+2: for every record (in
+// EnvOrder, for determinism), filter fields to those in keep. A
+// filtered-out mandatory field (min >= 1) invalidates that record and, if
+// this is the first offender seen in this single pass, records it as
+// first_bad. Per the spec's normative "deleting a mandatory field is an
+// error, not a silent relaxation" rule, a deleted mandatory field is never
+// downgraded to optional — the record is invalidated outright instead.
+func extractFilterFields(s Schema, keep map[string]bool) (trimmed map[string]*Record, invalidated map[string]bool, bad firstBad) {
+	trimmed = make(map[string]*Record, len(s.EnvOrder))
+	invalidated = make(map[string]bool)
+	for _, name := range s.EnvOrder {
+		rec := s.Env[name]
+		kept := make([]Field, 0, len(rec.Fields))
+		for _, f := range rec.Fields {
+			if keep[f.Label] {
+				kept = append(kept, f)
+				continue
+			}
+			if f.Cardinality.Min >= 1 {
+				if bad.record == "" && bad.label == "" {
+					bad = firstBad{label: f.Label, record: name}
+				}
+				invalidated[name] = true
+			}
+		}
+		trimmed[name] = &Record{Name: rec.Name, Fields: kept}
+	}
+	return trimmed, invalidated, bad
+}
+
+// extractPropagate implements §6.9 step 3: a record with a mandatory field
+// typed to an invalidated record is itself invalidated. Least fixpoint,
+// same repeat-until-no-change-over-EnvOrder shape as SatisfiableSet
+// (algebra.go) — the fixpoint condition differs (invalidation instead of
+// satisfiability), so the function isn't reused directly.
+func extractPropagate(s Schema, trimmed map[string]*Record, invalidated map[string]bool) {
+	for {
+		changed := false
+		for _, name := range s.EnvOrder {
+			if invalidated[name] {
+				continue
+			}
+			for _, f := range trimmed[name].Fields {
+				if f.Cardinality.Min >= 1 && f.Type.Kind == TypeRefKind && invalidated[f.Type.RefName] {
+					invalidated[name] = true
+					changed = true
+					break
+				}
+			}
+		}
+		if !changed {
+			break
+		}
+	}
+}
+
+// extractBuildEnv implements §6.9 step 5's new_env construction: drop
+// invalidated records, and for surviving records drop any field —
+// mandatory or not — that still points at an invalidated record, so no
+// surviving record is left with a dangling reference. The result is
+// returned unpruned/unnormalized; Extract runs it through Prune then
+// Normalize itself.
+func extractBuildEnv(s Schema, trimmed map[string]*Record, invalidated map[string]bool) (map[string]*Record, []string) {
+	newEnv := make(map[string]*Record, len(s.EnvOrder))
+	newOrder := make([]string, 0, len(s.EnvOrder))
+	for _, name := range s.EnvOrder {
+		if invalidated[name] {
+			continue
+		}
+		rec := trimmed[name]
+		fields := make([]Field, 0, len(rec.Fields))
+		for _, f := range rec.Fields {
+			if f.Type.Kind == TypeRefKind && invalidated[f.Type.RefName] {
+				continue
+			}
+			fields = append(fields, f)
+		}
+		newEnv[name] = &Record{Name: name, Fields: fields}
+		newOrder = append(newOrder, name)
+	}
+	return newEnv, newOrder
+}

--- a/extract_test.go
+++ b/extract_test.go
@@ -1,0 +1,304 @@
+package omnist
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// orderSchemaOSD is the Root/Order/Address/LineItem schema from spec
+// §3.1's mental model, used verbatim by both §6.9 worked examples.
+const orderSchemaOSD = `
+record Address  { "street": string, "city": string }
+record LineItem { "sku": string, "qty": integer, "price": number }
+
+record Order {
+    "id":           string,
+    "status":       string,
+    "total":        number,
+    "address":      Address,
+    "items" [1,]:   LineItem,
+    "coupon" [0,1]: string,
+}
+
+record Root { "order": Order }
+root Root
+`
+
+func keepSet(labels ...string) map[string]bool {
+	m := make(map[string]bool, len(labels))
+	for _, l := range labels {
+		m[l] = true
+	}
+	return m
+}
+
+func hasLabel(rec *Record, label string) bool {
+	for _, f := range rec.Fields {
+		if f.Label == label {
+			return true
+		}
+	}
+	return false
+}
+
+// --- §6.9 worked example 1: coupon dropped, everything else survives ---
+
+func TestExtractSuccessDropsOptionalCoupon(t *testing.T) {
+	s := mustParseOSD(t, orderSchemaOSD)
+	keep := keepSet("order", "id", "status", "total", "address", "street",
+		"city", "items", "sku", "qty", "price")
+
+	out, err := Extract(s, keep)
+	if err != nil {
+		t.Fatalf("Extract() error = %v, want success", err)
+	}
+
+	order := out.Env["Order"]
+	if order == nil {
+		t.Fatalf("Order missing from extracted schema: %+v", out)
+	}
+	if hasLabel(order, "coupon") {
+		t.Errorf("coupon should be gone, got fields = %+v", order.Fields)
+	}
+	for _, label := range []string{"id", "status", "total", "address", "items"} {
+		if !hasLabel(order, label) {
+			t.Errorf("%s should survive, got fields = %+v", label, order.Fields)
+		}
+	}
+	if out.Env["Address"] == nil || out.Env["LineItem"] == nil || out.Env["Root"] == nil {
+		t.Errorf("Address/LineItem/Root should all survive, got env = %+v", out.Env)
+	}
+}
+
+// --- §6.9 worked example 2: total is the first offender, not address/items ---
+//
+// keep leaves Address's and LineItem's own fields (street/city, sku/qty/
+// price) intact, so step 1 never touches those records at all — only
+// Order's total/address/items are dropped, and total is declared first
+// among them.
+
+func TestExtractFailureReportsFirstBadInDeclarationOrder(t *testing.T) {
+	s := mustParseOSD(t, orderSchemaOSD)
+	keep := keepSet("order", "id", "status", "street", "city", "sku", "qty", "price")
+
+	_, err := Extract(s, keep)
+	if err == nil {
+		t.Fatalf("Extract() succeeded, want algebra.extract-invalidates-root error")
+	}
+	var d Diagnostic
+	if !errors.As(err, &d) {
+		t.Fatalf("error = %v (%T), want Diagnostic", err, err)
+	}
+	if d.Code != CodeAlgebraExtractInvalidatesRoot {
+		t.Errorf("Code = %q, want %q", d.Code, CodeAlgebraExtractInvalidatesRoot)
+	}
+	if !strings.Contains(d.Message, `"total"`) {
+		t.Errorf("Message = %q, want it to name total (the first offender in declaration order)", d.Message)
+	}
+	if strings.Contains(d.Message, "address") || strings.Contains(d.Message, "items") {
+		t.Errorf("Message = %q, must not name address/items — total is declared first in Order", d.Message)
+	}
+	if d.Path != "Order" {
+		t.Errorf("Path = %q, want %q", d.Path, "Order")
+	}
+}
+
+// --- §6.9 worked example 2 (cross-record continuation): with keep = {"order"},
+// every field of every record is unkept, so first_bad is decided across the
+// *whole* env in declaration order, not scoped to Order. Address is declared
+// before Order in orderSchemaOSD, so Address is invalidated first and
+// first_bad is street/Address — not anything about Order's own field order.
+
+func TestExtractFirstBadCrossRecordDeclarationOrderBeatsOrder(t *testing.T) {
+	s := mustParseOSD(t, orderSchemaOSD)
+	keep := keepSet("order")
+
+	_, err := Extract(s, keep)
+	if err == nil {
+		t.Fatalf("Extract() succeeded, want algebra.extract-invalidates-root error")
+	}
+	var d Diagnostic
+	if !errors.As(err, &d) {
+		t.Fatalf("error = %v (%T), want Diagnostic", err, err)
+	}
+	if d.Code != CodeAlgebraExtractInvalidatesRoot {
+		t.Errorf("Code = %q, want %q", d.Code, CodeAlgebraExtractInvalidatesRoot)
+	}
+	if !strings.Contains(d.Message, `"street"`) {
+		t.Errorf("Message = %q, want it to name street (Address is declared before Order)", d.Message)
+	}
+	if d.Path != "Address" {
+		t.Errorf("Path = %q, want %q (declared before Order in env)", d.Path, "Address")
+	}
+}
+
+// --- deleting a mandatory field invalidates, never silently relaxes ---
+
+func TestExtractMandatoryDeletionInvalidatesNotRelaxes(t *testing.T) {
+	s := mustParseOSD(t, `
+		record Leaf { "a": string, "b": string }
+		record Root { "leaf" [0,1]: Leaf }
+		root Root
+	`)
+	// Drop "a", a mandatory field of Leaf; Leaf's own field is optional in
+	// Root so Root itself should survive, but Leaf must be genuinely gone
+	// from the output — never present with "a" downgraded to optional.
+	out, err := Extract(s, keepSet("leaf", "b"))
+	if err != nil {
+		t.Fatalf("Extract() error = %v, want success (Root.leaf is optional)", err)
+	}
+	if _, ok := out.Env["Leaf"]; ok {
+		t.Errorf("Leaf should be invalidated and absent, got env = %+v", out.Env)
+	}
+	if hasLabel(out.Env["Root"], "leaf") {
+		t.Errorf("Root.leaf (pointing at invalidated Leaf) should be dropped, got fields = %+v", out.Env["Root"].Fields)
+	}
+}
+
+// --- propagation across more than one hop ---
+
+func TestExtractPropagatesThroughMultipleHops(t *testing.T) {
+	s := mustParseOSD(t, `
+		record Leaf { "v": string }
+		record Mid  { "leaf": Leaf }
+		record Top  { "mid": Mid }
+		record Root { "top": Top }
+		root Root
+	`)
+	// Drop "v", invalidating Leaf directly; that must propagate Leaf -> Mid
+	// -> Top -> Root, three hops of mandatory-ref propagation.
+	_, err := Extract(s, keepSet("top", "mid", "leaf"))
+	if err == nil {
+		t.Fatalf("Extract() succeeded, want root invalidated via 3-hop propagation")
+	}
+	var d Diagnostic
+	if !errors.As(err, &d) {
+		t.Fatalf("error = %v (%T), want Diagnostic", err, err)
+	}
+	if d.Code != CodeAlgebraExtractInvalidatesRoot {
+		t.Errorf("Code = %q, want %q", d.Code, CodeAlgebraExtractInvalidatesRoot)
+	}
+	if !strings.Contains(d.Message, `"v"`) || d.Path != "Leaf" {
+		t.Errorf("Message/Path = %q/%q, want the original offender v/Leaf, not a propagated one", d.Message, d.Path)
+	}
+}
+
+// --- first_bad determinism: declared-first offender wins, not alphabetical/shortest ---
+
+func TestExtractFirstBadIsDeclarationOrderNotAlphabeticalOrShortest(t *testing.T) {
+	s := mustParseOSD(t, `
+		record R { "zeta": string, "beta": string, "alpha": string }
+		record Root { "r": R }
+		root Root
+	`)
+	// All three fields of R are dropped; "zeta" is declared first, so it
+	// must be the reported offender even though it's neither alphabetically
+	// first ("alpha") nor shortest ("beta"/"alpha" tie length before zeta).
+	_, err := Extract(s, keepSet("r"))
+	var d Diagnostic
+	if !errors.As(err, &d) {
+		t.Fatalf("error = %v (%T), want Diagnostic", err, err)
+	}
+	if !strings.Contains(d.Message, `"zeta"`) {
+		t.Errorf("Message = %q, want zeta (declared first in R)", d.Message)
+	}
+	if d.Path != "R" {
+		t.Errorf("Path = %q, want %q", d.Path, "R")
+	}
+}
+
+// --- step 5: a surviving record's field pointing at an invalidated record is dropped ---
+
+func TestExtractDropsSurvivingFieldPointingAtInvalidatedRecord(t *testing.T) {
+	s := mustParseOSD(t, `
+		record Doomed  { "must": string }
+		record Sibling { "x": string }
+		record Root {
+			"doomed"  [0,1]: Doomed,
+			"sibling":        Sibling,
+		}
+		root Root
+	`)
+	// Drop "must" (mandatory in Doomed) -> Doomed invalidated. Root.doomed
+	// is optional so filtering alone doesn't invalidate Root, and Root
+	// survives (via Root.sibling) but must lose the "doomed" field itself,
+	// not keep it dangling at a record no longer in env.
+	out, err := Extract(s, keepSet("doomed", "sibling", "x"))
+	if err != nil {
+		t.Fatalf("Extract() error = %v, want success", err)
+	}
+	if _, ok := out.Env["Doomed"]; ok {
+		t.Errorf("Doomed should be invalidated and absent, got env = %+v", out.Env)
+	}
+	root := out.Env["Root"]
+	if root == nil {
+		t.Fatalf("Root missing: %+v", out)
+	}
+	if hasLabel(root, "doomed") {
+		t.Errorf("Root.doomed (dangling at invalidated Doomed) should be dropped, got fields = %+v", root.Fields)
+	}
+	if !hasLabel(root, "sibling") {
+		t.Errorf("Root.sibling should survive untouched, got fields = %+v", root.Fields)
+	}
+}
+
+// --- success path actually runs prune+normalize, not just the raw intermediate schema ---
+
+func TestExtractSuccessRunsPruneAndNormalize(t *testing.T) {
+	s := mustParseOSD(t, `
+		record Unreachable { "v": string }
+		record Root        { "a": string }
+		root Root
+	`)
+	// Unreachable is never referenced from Root; extract's intermediate
+	// schema (steps 1-4) would still contain it verbatim since nothing
+	// about the keep-set filtering touches it. Only prune removes it.
+	out, err := Extract(s, keepSet("a"))
+	if err != nil {
+		t.Fatalf("Extract() error = %v, want success", err)
+	}
+	if _, ok := out.Env["Unreachable"]; ok {
+		t.Errorf("Unreachable should have been pruned, got env = %+v", out.Env)
+	}
+}
+
+func TestExtractSuccessNormalizesStructurallyIdenticalRecords(t *testing.T) {
+	s := mustParseOSD(t, `
+		record A { "v": string }
+		record B { "v": string, "extra" [0,1]: string }
+		record Root { "a": A, "b": B }
+		root Root
+	`)
+	// Dropping "extra" from B (optional, so no invalidation) leaves A and B
+	// structurally identical. Only normalize would merge them.
+	out, err := Extract(s, keepSet("a", "b", "v"))
+	if err != nil {
+		t.Fatalf("Extract() error = %v, want success", err)
+	}
+	aRef := out.Env["Root"].Fields
+	names := map[string]bool{}
+	for _, f := range aRef {
+		if f.Type.Kind == TypeRefKind {
+			names[f.Type.RefName] = true
+		}
+	}
+	if len(names) != 1 {
+		t.Errorf("expected A and B merged into one record by normalize, Root's ref fields point at %v", names)
+	}
+}
+
+// --- keep everything: no-op besides the canonical prune+normalize pass ---
+
+func TestExtractKeepEverythingSucceeds(t *testing.T) {
+	s := mustParseOSD(t, orderSchemaOSD)
+	keep := keepSet("order", "id", "status", "total", "address", "street",
+		"city", "items", "sku", "qty", "price", "coupon")
+	out, err := Extract(s, keep)
+	if err != nil {
+		t.Fatalf("Extract() error = %v, want success", err)
+	}
+	if !hasLabel(out.Env["Order"], "coupon") {
+		t.Errorf("coupon should survive when kept, got fields = %+v", out.Env["Order"].Fields)
+	}
+}


### PR DESCRIPTION
Closes #15.

Ports spec Sec6.9: filter fields against keep, invalidate records losing a mandatory field, propagate invalidation via least-fixpoint, fail with algebra.extract-invalidates-root on root invalidation (naming the first offender in true declaration order), otherwise run the result through Prune then Normalize.

Notable backstory: the implementer hit a genuine contradiction in Sec6.9s own worked example mid-implementation and correctly stopped rather than guessing -- filed as omnist-spec#36, confirmed as a real spec bug (the pseudocodes global declaration-order rule was right, the worked example was wrong), fixed upstream and pinned here (submodule now at 47941f2). No code change was needed once the spec was corrected, only the test fixture.

Independently verified: 100% per-function coverage, 0 lint issues. first_bad determinism was checked from three independent angles -- the corrected within-record case, a new cross-record case matching the spec fix, and a reviewer-constructed third schema specifically engineered so alphabetical-order or root-first traversal would pick the wrong record, confirming true declaration order is what the code actually uses. Mandatory-deletion-invalidates-not-relaxes, 3-hop propagation fixpoint, and prune+normalize actually running (not just field-dropping) were each verified with dedicated tests.

No spec ambiguity remaining. One deferred, documented, low-risk item: schema.quoted-type (omnist-spec#35s new code) not yet swapped into osd_parser.go -- out of scope here, no test currently pins the old code, safe to pick up in a dedicated issue.