### PR TITLE
lint

### DIFF
--- a/lint.go
+++ b/lint.go
@@ -1,0 +1,150 @@
+package omnist
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// This file implements §6.11's lint(S) (port-order step 9): schema
+// diagnostics for structures that parse fine but can never do anything.
+// lint reports and MUST NOT mutate its input Schema. It depends on
+// SatisfiableSet (issue #9, algebra.go) and EquivalenceClasses (issue #13,
+// normalize.go), plus the Schema/Record/Field/Type/EnvOrder types (issue
+// #5).
+//
+// lint's own reachability walk (reachablePlain, below) is deliberately a
+// SEPARATE, simpler function from algebra.go's reachableFromRoot used by
+// Prune: §6.11's reachable(S) follows every Ref-typed field unconditionally
+// regardless of cardinality or satisfiability, while Prune's walk is
+// language-aware (it only follows the fields that would survive
+// prune_record, with a root-unsatisfiable special case). A record reached
+// only through an optional field, or only through a field whose target
+// turns out unsatisfiable, still counts as referenced for lint's purposes
+// even though Prune might have dropped that same path. Reusing
+// reachableFromRoot here would silently change lint's semantics, so this
+// file builds its own walk straight from §6.11's own pseudocode instead.
+
+// Finding is one diagnostic lint(S) reports: a Code from the lint.*
+// family (errors.go), its Severity (warning or info per §6.11's table),
+// a Location string (a record name, or for duplicate-record a
+// comma-joined sorted list of names, or for any-field a
+// "RecordName.label" string), and a human-readable Message.
+type Finding struct {
+	Code     Code
+	Severity Severity
+	Location string
+	Message  string
+}
+
+// reachablePlain implements §6.11's own reachable(S) pseudocode: a
+// stack-based walk from the root following every Ref-typed field
+// unconditionally, regardless of cardinality or satisfiability. This is
+// intentionally not algebra.go's reachableFromRoot (used by Prune), which
+// computes a genuinely different, language-aware set — see the file
+// comment above.
+func reachablePlain(s Schema) map[string]bool {
+	seen := make(map[string]bool)
+	stack := []string{s.Root}
+	for len(stack) > 0 {
+		name := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		if seen[name] {
+			continue
+		}
+		rec, ok := s.Env[name]
+		if !ok {
+			continue
+		}
+		seen[name] = true
+		for _, f := range rec.Fields {
+			if f.Type.Kind == TypeRefKind {
+				stack = append(stack, f.Type.RefName)
+			}
+		}
+	}
+	return seen
+}
+
+// Lint implements §6.11's lint(S) exactly: the four finding categories in
+// the order the pseudocode gives them, followed by a final deterministic
+// sort by (code, location). Lint never mutates s — it only reads Env,
+// EnvOrder, and Root.
+func Lint(s Schema) []Finding {
+	findings := []Finding{}
+
+	reach := reachablePlain(s)
+	sat := SatisfiableSet(s)
+
+	// unsatisfiable-record: reach - sat. Iterate EnvOrder for determinism
+	// (the final sort makes this immaterial for the returned order, but
+	// every prior algebra issue iterates EnvOrder rather than native map
+	// iteration for any per-record walk, and this file follows suit).
+	for _, name := range s.EnvOrder {
+		if reach[name] && !sat[name] {
+			findings = append(findings, Finding{
+				Code:     CodeLintUnsatisfiableRecord,
+				Severity: SeverityWarning,
+				Location: name,
+				Message:  fmt.Sprintf("record %q is reachable from root but no finite Document can ever match it", name),
+			})
+		}
+	}
+
+	// unreachable-record: env.keys - reach.
+	for _, name := range s.EnvOrder {
+		if !reach[name] {
+			findings = append(findings, Finding{
+				Code:     CodeLintUnreachableRecord,
+				Severity: SeverityWarning,
+				Location: name,
+				Message:  fmt.Sprintf("record %q is defined but not reachable from root by any reference", name),
+			})
+		}
+	}
+
+	// duplicate-record: equivalence_classes on the RAW schema (never
+	// pruned first) -- one finding per oversized block, not per name.
+	for _, block := range EquivalenceClasses(s) {
+		if len(block) <= 1 {
+			continue
+		}
+		group := make([]string, len(block))
+		copy(group, block)
+		sort.Strings(group)
+		location := strings.Join(group, ", ")
+		keep := group[0]
+		others := strings.Join(group[1:], ", ")
+		findings = append(findings, Finding{
+			Code:     CodeLintDuplicateRecord,
+			Severity: SeverityWarning,
+			Location: location,
+			Message:  fmt.Sprintf("records %s are structurally identical to %q; merge them with normalize", others, keep),
+		})
+	}
+
+	// any-field: an inventory entry for every any-typed field, walking
+	// records-then-fields in EnvOrder for determinism.
+	for _, name := range s.EnvOrder {
+		rec := s.Env[name]
+		for _, f := range rec.Fields {
+			if f.Type.Kind == TypeAnyKind {
+				findings = append(findings, Finding{
+					Code:     CodeLintAnyField,
+					Severity: SeverityInfo,
+					Location: name + "." + f.Label,
+					Message:  fmt.Sprintf("field %q of record %q is `any`-typed", f.Label, name),
+				})
+			}
+		}
+	}
+
+	sort.Slice(findings, func(i, j int) bool {
+		if findings[i].Code != findings[j].Code {
+			return findings[i].Code < findings[j].Code
+		}
+		return findings[i].Location < findings[j].Location
+	})
+
+	return findings
+}

--- a/lint_test.go
+++ b/lint_test.go
@@ -1,0 +1,318 @@
+package omnist
+
+import (
+	"reflect"
+	"testing"
+)
+
+// --- reachablePlain / unsatisfiable-record, unreachable-record (§6.11) ---
+
+func TestLintUnsatisfiableRecordReachableNotRoot(t *testing.T) {
+	// Root -> Mid -> Bad (mandatory self-cycle, unsatisfiable). Bad is
+	// reachable from root (through Mid) but not the root itself.
+	s := mustParseOSD(t, `
+		record Root { "mid": Mid }
+		record Mid { "bad": Bad }
+		record Bad { "self": Bad }
+		root Root
+	`)
+	findings := Lint(s)
+	found := false
+	for _, f := range findings {
+		if f.Code == CodeLintUnsatisfiableRecord && f.Location == "Bad" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected unsatisfiable-record for Bad, got %+v", findings)
+	}
+}
+
+func TestLintUnreachableAndUnsatisfiableNotDoubleReported(t *testing.T) {
+	// Orphan is unsatisfiable AND unreachable from root. It must show up
+	// only as unreachable-record, never also as unsatisfiable-record,
+	// since unsatisfiable-record = reach - sat and Orphan isn't in reach.
+	s := mustParseOSD(t, `
+		record Root { "a": string }
+		record Orphan { "self": Orphan }
+		root Root
+	`)
+	findings := Lint(s)
+	sawUnsat := false
+	sawUnreach := false
+	for _, f := range findings {
+		if f.Location != "Orphan" {
+			continue
+		}
+		if f.Code == CodeLintUnsatisfiableRecord {
+			sawUnsat = true
+		}
+		if f.Code == CodeLintUnreachableRecord {
+			sawUnreach = true
+		}
+	}
+	if sawUnsat {
+		t.Fatalf("Orphan should NOT be reported as unsatisfiable-record (not reachable): %+v", findings)
+	}
+	if !sawUnreach {
+		t.Fatalf("Orphan should be reported as unreachable-record: %+v", findings)
+	}
+}
+
+func TestLintUnreachableRecordNeverReferenced(t *testing.T) {
+	s := mustParseOSD(t, `
+		record Root { "a": string }
+		record Dangling { "a": string }
+		root Root
+	`)
+	findings := Lint(s)
+	found := false
+	for _, f := range findings {
+		if f.Code == CodeLintUnreachableRecord && f.Location == "Dangling" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected unreachable-record for Dangling, got %+v", findings)
+	}
+}
+
+func TestLintPlainWalkDiffersFromPruneOptionalField(t *testing.T) {
+	// Target is reachable ONLY through an optional field. Prune's
+	// reachability would still count it as reachable too (optional fields
+	// aren't stripped from reachability unless they point at an
+	// unsatisfiable record) -- so instead construct the sharper case: a
+	// field whose target is unsatisfiable, reached only via that
+	// optional+unsatisfiable field. Prune's pruneRecord strips such a
+	// field (min==0 and target unsatisfiable), so Prune's reachability
+	// walk never follows it -- but lint's plain walk always does.
+	s := mustParseOSD(t, `
+		record Root { "maybe" [0,1]: Bad }
+		record Bad { "self": Bad }
+		root Root
+	`)
+
+	// Confirm Prune actually drops Bad (proving the two walks differ).
+	pruned := Prune(s)
+	if _, stillThere := pruned.Env["Bad"]; stillThere {
+		t.Fatalf("test setup invalid: Prune should have dropped Bad, env = %+v", pruned.Env)
+	}
+
+	// lint's plain walk must still count Bad as reached (reach), so it
+	// must NOT appear as unreachable-record.
+	findings := Lint(s)
+	for _, f := range findings {
+		if f.Code == CodeLintUnreachableRecord && f.Location == "Bad" {
+			t.Fatalf("Bad reached via optional+unsatisfiable field should NOT be unreachable-record under lint's plain walk: %+v", findings)
+		}
+	}
+	// It's still unsatisfiable, and (per the plain walk) reachable, so it
+	// must appear as unsatisfiable-record.
+	found := false
+	for _, f := range findings {
+		if f.Code == CodeLintUnsatisfiableRecord && f.Location == "Bad" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected unsatisfiable-record for Bad (reached via plain walk): %+v", findings)
+	}
+}
+
+// --- duplicate-record (§6.11 / §6.8) ---
+
+func TestLintDuplicateRecordOneFindingPerBlock(t *testing.T) {
+	s := mustParseOSD(t, `
+		record Root { "a": A, "b": B }
+		record A { "x": string }
+		record B { "x": string }
+		root Root
+	`)
+	findings := Lint(s)
+	count := 0
+	var loc string
+	for _, f := range findings {
+		if f.Code == CodeLintDuplicateRecord {
+			count++
+			loc = f.Location
+		}
+	}
+	if count != 1 {
+		t.Fatalf("expected exactly one duplicate-record finding, got %d: %+v", count, findings)
+	}
+	if loc != "A, B" {
+		t.Fatalf("expected location %q, got %q", "A, B", loc)
+	}
+}
+
+func TestLintDuplicateRecordFiresOnRawSchemaEvenIfUnreachable(t *testing.T) {
+	// C is unreachable from root, and is a structural duplicate of A
+	// (which IS reachable). normalize/prune would drop C entirely (it's
+	// unreachable), but lint calls equivalence_classes on the schema as
+	// authored, so the duplicate must still be reported.
+	s := mustParseOSD(t, `
+		record Root { "a": A }
+		record A { "x": string }
+		record C { "x": string }
+		root Root
+	`)
+	// Confirm C really is unreachable (test setup sanity check).
+	normalized := Normalize(s)
+	if _, stillThere := normalized.Env["C"]; stillThere {
+		t.Fatalf("test setup invalid: Normalize should have dropped unreachable C")
+	}
+
+	findings := Lint(s)
+	found := false
+	for _, f := range findings {
+		if f.Code == CodeLintDuplicateRecord && f.Location == "A, C" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected duplicate-record for unreachable-but-duplicate A, C: %+v", findings)
+	}
+}
+
+func TestLintDuplicateRecordBlockOfThreeIsOneFinding(t *testing.T) {
+	s := mustParseOSD(t, `
+		record Root { "a": A, "b": B, "c": C }
+		record A { "x": string }
+		record B { "x": string }
+		record C { "x": string }
+		root Root
+	`)
+	findings := Lint(s)
+	count := 0
+	var loc string
+	for _, f := range findings {
+		if f.Code == CodeLintDuplicateRecord {
+			count++
+			loc = f.Location
+		}
+	}
+	if count != 1 {
+		t.Fatalf("expected exactly one duplicate-record finding for a 3-block, got %d: %+v", count, findings)
+	}
+	if loc != "A, B, C" {
+		t.Fatalf("expected location %q, got %q", "A, B, C", loc)
+	}
+}
+
+// --- any-field (§6.11) ---
+
+func TestLintAnyFieldMultipleAcrossRecords(t *testing.T) {
+	s := mustParseOSD(t, `
+		record Root { "child": Child, "x": any }
+		record Child { "y": any }
+		root Root
+	`)
+	findings := Lint(s)
+	locs := map[string]bool{}
+	for _, f := range findings {
+		if f.Code == CodeLintAnyField {
+			locs[f.Location] = true
+		}
+	}
+	want := map[string]bool{"Root.x": true, "Child.y": true}
+	if !reflect.DeepEqual(locs, want) {
+		t.Fatalf("any-field locations = %+v, want %+v", locs, want)
+	}
+}
+
+// --- determinism ---
+
+func TestLintFindingsSortedByCodeThenLocation(t *testing.T) {
+	s := mustParseOSD(t, `
+		record Root { "a": A, "b": B, "orphanRef": Orphan }
+		record A { "x": string, "opener": any }
+		record B { "x": string }
+		record Orphan { "self": Orphan }
+		record Dangling { "y": string }
+		root Root
+	`)
+	findings := Lint(s)
+	if len(findings) < 2 {
+		t.Fatalf("expected multiple findings to exercise sort, got %+v", findings)
+	}
+	for i := 1; i < len(findings); i++ {
+		prev, cur := findings[i-1], findings[i]
+		if prev.Code > cur.Code {
+			t.Fatalf("findings not sorted by code: %+v then %+v", prev, cur)
+		}
+		if prev.Code == cur.Code && prev.Location > cur.Location {
+			t.Fatalf("findings not sorted by location within code: %+v then %+v", prev, cur)
+		}
+	}
+}
+
+// --- zero findings ---
+
+func TestLintZeroFindingsReturnsEmptySlice(t *testing.T) {
+	s := mustParseOSD(t, `record R { "a": string } root R`)
+	findings := Lint(s)
+	if findings == nil {
+		t.Fatalf("expected a non-nil empty slice, got nil")
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected zero findings for a clean schema, got %+v", findings)
+	}
+}
+
+// --- no mutation ---
+
+func TestLintDoesNotMutateInput(t *testing.T) {
+	s := mustParseOSD(t, `
+		record Root { "a": A, "b": B }
+		record A { "x": string }
+		record B { "x": string }
+		root Root
+	`)
+	envBefore := make(map[string]*Record, len(s.Env))
+	for k, v := range s.Env {
+		envBefore[k] = v
+	}
+	orderBefore := make([]string, len(s.EnvOrder))
+	copy(orderBefore, s.EnvOrder)
+	rootBefore := s.Root
+
+	_ = Lint(s)
+
+	if s.Root != rootBefore {
+		t.Fatalf("Lint mutated Root: got %q, want %q", s.Root, rootBefore)
+	}
+	if !reflect.DeepEqual(s.EnvOrder, orderBefore) {
+		t.Fatalf("Lint mutated EnvOrder: got %+v, want %+v", s.EnvOrder, orderBefore)
+	}
+	if len(s.Env) != len(envBefore) {
+		t.Fatalf("Lint mutated Env size: got %d entries, want %d", len(s.Env), len(envBefore))
+	}
+	for k, v := range envBefore {
+		if s.Env[k] != v {
+			t.Fatalf("Lint mutated Env[%q]: pointer changed", k)
+		}
+	}
+}
+
+// --- reachablePlain directly (for 100% per-function coverage of the
+// "not in env" skip branch, which a well-formed schema never triggers
+// through Lint alone) ---
+
+func TestReachablePlainSkipsUnresolvedRef(t *testing.T) {
+	s := Schema{
+		Root: "Root",
+		Env: map[string]*Record{
+			"Root": {Name: "Root", Fields: []Field{
+				{Label: "dangling", Type: RefType("Ghost"), Cardinality: DefaultCardinality()},
+			}},
+		},
+		EnvOrder: []string{"Root"},
+	}
+	reach := reachablePlain(s)
+	if !reach["Root"] {
+		t.Fatalf("Root should be reached")
+	}
+	if reach["Ghost"] {
+		t.Fatalf("Ghost does not resolve in env and must not appear in reach")
+	}
+}


### PR DESCRIPTION
Closes #17.

Ports spec Sec6.11: four finding types (unsatisfiable-record, unreachable-record, duplicate-record, any-field), read-only. Uses a genuinely separate reachablePlain walk (follows every ref field unconditionally) distinct from Prunes cardinality/satisfiability-aware reachableFromRoot -- lints unreachable-record and prunes reachability compute deliberately different sets per spec. duplicate-record runs EquivalenceClasses on the raw schema, never pruned/normalized first.

Independently verified: 100% per-function coverage, 0 lint issues. The reachablePlain-vs-Prune divergence (the single most important thing to get right in this issue) was verified with the reviewers own independently-constructed test topology, not just the committed one -- confirmed Prune genuinely drops a record that reachablePlain still reaches, and that Lint correctly reports it as unsatisfiable-record rather than unreachable-record. duplicate-record firing on an unreachable pair that Normalize would have merged was similarly sanity-checked against Normalizes actual output first. Determinism (final (code,location) sort) and no-input-mutation were each independently confirmed.

No spec ambiguity. One additive, non-normative choice: Finding carries a Message field (spec only requires Code/Severity/Location) for consistency with this codebases existing Diagnostic/ParseError shape.