### PR TITLE
infer

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -65,6 +65,19 @@ const (
 	CodeAlgebraInferNoSamples          Code = "algebra.infer-no-samples"
 	CodeAlgebraInferScalarRoot         Code = "algebra.infer-scalar-root"
 	CodeAlgebraInferConflictingScalars Code = "algebra.infer-conflicting-scalars"
+	// CodeAlgebraInferMixedShape is raised when a label is a node in some
+	// samples and a scalar in others (allow_any=false). The spec's §8.3.6
+	// taxonomy table does not list a dedicated code for this failure --
+	// only infer-no-samples, infer-scalar-root, and infer-conflicting-
+	// scalars are enumerated there, even though §6.10's infer_type
+	// pseudocode has two distinct hard-failure branches (mixed shape, and
+	// conflicting scalar kinds). This is the plainly-correct reading of
+	// that gap: mint a fourth algebra.infer-* code following the same
+	// naming convention, rather than overloading infer-conflicting-scalars
+	// (whose taxonomy description is specifically "disagree on a scalar
+	// kind") for a shape mismatch that isn't a scalar-kind disagreement at
+	// all.
+	CodeAlgebraInferMixedShape Code = "algebra.infer-mixed-shape"
 )
 
 // lint.* — schema diagnostics (spec §8.3.7).

--- a/infer.go
+++ b/infer.go
@@ -1,0 +1,349 @@
+package omnist
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"unicode"
+)
+
+// This file implements §6.10's infer(samples) (port-order step 10): drafting
+// a Schema from sample Documents. Unlike every other operation in chapter 6,
+// infer is explicitly NOT part of the decidability story -- it is a
+// convenience for getting started, and its output is expected to be
+// hand-edited afterward. It depends on Document/Node/Edge/Target/Scalar
+// (issue #1) as its input type and Schema/Record/Field/Type/Cardinality/
+// EnvOrder (issue #5) as its output type. It does NOT depend on any of the
+// schema-to-schema algebra functions (Prune, CompatibleWith, Normalize,
+// Extract, Lint) -- infer is a separate, independent traversal over
+// Documents.
+
+// AnyFallback records one field infer_with_report opened to `any` under
+// allow_any=true: a "RecordName.label" Location and a Reason drawn from one
+// of the two exact phrasings §6.10 specifies ("mixes objects and values", or
+// "values of more than one scalar kind (k1, k2, ...)" with kind names sorted
+// and comma-joined). allow_any=false never produces any AnyFallback values;
+// the corresponding condition is a hard failure instead.
+type AnyFallback struct {
+	Location string
+	Reason   string
+}
+
+// InferWithReport implements §6.10's infer_with_report(samples, root_name,
+// allow_any) exactly: drafts a Schema from samples, returning both the
+// Schema and the list of AnyFallback openings (empty, never nil, on
+// success when allow_any opened nothing).
+//
+// rootName is the pseudocode's defaultable root_name argument; passing ""
+// selects the spec's default, "Root".
+//
+// The returned Schema is NOT normalized and MAY contain structurally
+// duplicate records -- §6.10 requires this, since infer's whole value is a
+// one-to-one, hand-editable correspondence between sample labels and
+// generated record names. A caller wanting canonical form calls Normalize
+// explicitly.
+//
+// Errors: zero samples is CodeAlgebraInferNoSamples; a scalar-rooted sample
+// is CodeAlgebraInferScalarRoot; a label disagreeing on scalar kind (other
+// than the sanctioned integer/number collapse) with allow_any=false is
+// CodeAlgebraInferConflictingScalars; a label mixing nodes and scalars
+// with allow_any=false is CodeAlgebraInferMixedShape (see errors.go for why
+// that fourth code exists despite not appearing in the spec's taxonomy
+// table).
+func InferWithReport(samples []Document, rootName string, allowAny bool) (Schema, []AnyFallback, error) {
+	if len(samples) == 0 {
+		return Schema{}, nil, Diagnostic{
+			Path:     "",
+			Code:     CodeAlgebraInferNoSamples,
+			Message:  "cannot infer a schema from zero samples",
+			Severity: SeverityError,
+		}
+	}
+	if rootName == "" {
+		rootName = "Root"
+	}
+
+	nodes := make([]*Node, len(samples))
+	for i, s := range samples {
+		if !s.IsNode {
+			return Schema{}, nil, Diagnostic{
+				Path:     fmt.Sprintf("samples[%d]", i),
+				Code:     CodeAlgebraInferScalarRoot,
+				Message:  "infer expects object (record) samples at the root",
+				Severity: SeverityError,
+			}
+		}
+		nodes[i] = s.Node
+	}
+
+	env := map[string]*Record{}
+	envOrder := []string{}
+	used := map[string]bool{}
+	fallbacks := []AnyFallback{}
+
+	if err := inferRecord(nodes, rootName, env, &envOrder, used, allowAny, &fallbacks); err != nil {
+		return Schema{}, nil, err
+	}
+
+	return Schema{Root: rootName, Env: env, EnvOrder: envOrder}, fallbacks, nil
+}
+
+// Infer implements §6.10's infer(samples, root_name, allow_any): the plain
+// convenience wrapper around InferWithReport that discards the fallback
+// list. A caller who needs to know what allow_any opened MUST call
+// InferWithReport directly.
+func Infer(samples []Document, rootName string, allowAny bool) (Schema, error) {
+	s, _, err := InferWithReport(samples, rootName, allowAny)
+	return s, err
+}
+
+// inferRecord implements §6.10's infer_record(nodes, name, env, used,
+// allow_any, fallbacks). It reserves name in used immediately (mirroring
+// the pseudocode's "add name to used" as its first line), then runs the
+// normative two-pass label collection: pass 1 walks every sample's edges to
+// collect the set of labels seen anywhere, in first-seen order across
+// samples; pass 2 walks every sample again, counting each pass-1 label's
+// occurrences in that sample and defaulting to 0 if the label is absent.
+// Two passes -- not one -- so a label missing from sample 1 but present in
+// sample 5 comes out with the same [0,1] cardinality regardless of which
+// sample the walk happens to reach first; a single combined pass would make
+// the result depend on iteration order.
+func inferRecord(
+	nodes []*Node,
+	name string,
+	env map[string]*Record,
+	envOrder *[]string,
+	used map[string]bool,
+	allowAny bool,
+	fallbacks *[]AnyFallback,
+) error {
+	used[name] = true
+
+	// Pass 1: every label seen in any sample, first-seen order.
+	order := []string{}
+	seenLabel := map[string]bool{}
+	for _, node := range nodes {
+		for _, e := range node.Edges {
+			if !seenLabel[e.Label] {
+				seenLabel[e.Label] = true
+				order = append(order, e.Label)
+			}
+		}
+	}
+
+	children := make(map[string][]Target, len(order))
+	perSampleCounts := make(map[string][]int, len(order))
+	for _, label := range order {
+		children[label] = []Target{}
+		perSampleCounts[label] = []int{}
+	}
+
+	// Pass 2: per-sample counts, defaulting to 0.
+	for _, node := range nodes {
+		countsHere := map[string]int{}
+		for _, e := range node.Edges {
+			children[e.Label] = append(children[e.Label], e.Target)
+			countsHere[e.Label]++
+		}
+		for _, label := range order {
+			perSampleCounts[label] = append(perSampleCounts[label], countsHere[label])
+		}
+	}
+
+	fields := make([]Field, 0, len(order))
+	for _, label := range order {
+		counts := perSampleCounts[label]
+		maxCount := counts[0]
+		minCount := counts[0]
+		for _, c := range counts[1:] {
+			if c > maxCount {
+				maxCount = c
+			}
+			if c < minCount {
+				minCount = c
+			}
+		}
+
+		var card Cardinality
+		if maxCount > 1 {
+			// Array: permissive by design -- min is always 0, never the
+			// observed minimum count. See the rule this file's package
+			// comment quotes from §6.10.
+			card = Cardinality{Min: 0, Unbounded: true}
+		} else {
+			card = Cardinality{Min: uint64(minCount), Max: 1}
+		}
+
+		typ, err := inferType(children[label], label, name, env, envOrder, used, allowAny, fallbacks)
+		if err != nil {
+			return err
+		}
+		fields = append(fields, Field{Label: label, Type: typ, Cardinality: card})
+	}
+
+	env[name] = &Record{Name: name, Fields: fields}
+	*envOrder = append(*envOrder, name)
+	return nil
+}
+
+// inferType implements §6.10's infer_type(child_values, label, record_name,
+// env, used, allow_any, fallbacks). It branches on how many of the
+// label's occurrences (across all samples) are nodes: all of them recurse
+// into a nested record; none of them resolve a single scalar kind (with
+// null tracked separately as nullability, and the one integer/number
+// subtype collapse applied); some but not all is the mixed-shape case.
+func inferType(
+	targets []Target,
+	label, recordName string,
+	env map[string]*Record,
+	envOrder *[]string,
+	used map[string]bool,
+	allowAny bool,
+	fallbacks *[]AnyFallback,
+) (Type, error) {
+	nodeCount := 0
+	for _, t := range targets {
+		if t.IsNode() {
+			nodeCount++
+		}
+	}
+
+	switch {
+	case nodeCount == len(targets):
+		// All nodes: recurse into a nested named record.
+		recName := uniqueNameFrom(label, used)
+		childNodes := make([]*Node, len(targets))
+		for i, t := range targets {
+			n, _ := t.Node()
+			childNodes[i] = n
+		}
+		if err := inferRecord(childNodes, recName, env, envOrder, used, allowAny, fallbacks); err != nil {
+			return Type{}, err
+		}
+		return RefType(recName), nil
+
+	case nodeCount > 0:
+		// Some but not all nodes: mixes objects and values.
+		if allowAny {
+			*fallbacks = append(*fallbacks, AnyFallback{
+				Location: recordName + "." + label,
+				Reason:   "mixes objects and values",
+			})
+			return AnyType(), nil
+		}
+		return Type{}, Diagnostic{
+			Path:     recordName + "." + label,
+			Code:     CodeAlgebraInferMixedShape,
+			Message:  fmt.Sprintf("label %q mixes objects and values; cannot infer one type", label),
+			Severity: SeverityError,
+		}
+
+	default:
+		// No nodes: every occurrence is a value (scalar or null).
+		kindsSeen := map[ScalarKind]bool{}
+		sawNull := false
+		for _, t := range targets {
+			v, _ := t.Value()
+			if v.IsNull {
+				sawNull = true
+				continue
+			}
+			kindsSeen[v.Scalar.Kind] = true
+		}
+		// The one subtyping relation (§6.3): integer mixed with number
+		// collapses to number.
+		if kindsSeen[KindNumber] {
+			delete(kindsSeen, KindInteger)
+		}
+
+		if len(kindsSeen) == 0 {
+			// No non-null sample: default to a nullable string, per the
+			// pseudocode's fallback.
+			return ScalarType(KindString, sawNull), nil
+		}
+
+		if len(kindsSeen) > 1 {
+			names := make([]string, 0, len(kindsSeen))
+			for k := range kindsSeen {
+				names = append(names, k.String())
+			}
+			sort.Strings(names)
+			if allowAny {
+				reason := fmt.Sprintf("values of more than one scalar kind (%s)", strings.Join(names, ", "))
+				*fallbacks = append(*fallbacks, AnyFallback{
+					Location: recordName + "." + label,
+					Reason:   reason,
+				})
+				return AnyType(), nil
+			}
+			return Type{}, Diagnostic{
+				Path:     recordName + "." + label,
+				Code:     CodeAlgebraInferConflictingScalars,
+				Message:  fmt.Sprintf("label %q has values of more than one scalar kind", label),
+				Severity: SeverityError,
+			}
+		}
+
+		var only ScalarKind
+		for k := range kindsSeen {
+			only = k
+		}
+		return ScalarType(only, sawNull), nil
+	}
+}
+
+// uniqueNameFrom implements §6.10's unique_name_from(label, used): derives a
+// generated record name from a label and disambiguates it against the
+// already-used set. The spec leaves the exact naming/disambiguation scheme
+// to the implementation, requiring only that it be deterministic given the
+// same input samples (no randomness, no map-iteration-order dependence).
+//
+// This implementation: sanitize the label into an exported-style Go
+// identifier (letters/digits/underscore only, non-identifier runes replaced
+// with '_', a leading digit prefixed with '_', first letter uppercased,
+// empty label falls back to "Field"), then, if that name is already used,
+// append the smallest integer suffix (2, 3, ...) that is not. Both steps
+// are pure functions of (label, used) with no map-iteration-order
+// dependence: used is consulted only via direct key lookups, in a fixed
+// increasing-suffix order.
+func uniqueNameFrom(label string, used map[string]bool) string {
+	base := sanitizeIdentifier(label)
+	if base == "" {
+		base = "Field"
+	}
+	if !used[base] {
+		return base
+	}
+	for n := 2; ; n++ {
+		candidate := fmt.Sprintf("%s%d", base, n)
+		if !used[candidate] {
+			return candidate
+		}
+	}
+}
+
+// sanitizeIdentifier turns an arbitrary label into a Go-identifier-shaped,
+// capitalized name: non letter/digit/underscore runes become '_', a
+// leading digit is prefixed with '_', and the first rune is upper-cased.
+// An empty or all-non-identifier label produces "".
+func sanitizeIdentifier(label string) string {
+	var b strings.Builder
+	for i, r := range label {
+		switch {
+		case unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_':
+			if i == 0 && unicode.IsDigit(r) {
+				b.WriteByte('_')
+			}
+			b.WriteRune(r)
+		default:
+			b.WriteByte('_')
+		}
+	}
+	s := b.String()
+	if s == "" {
+		return ""
+	}
+	r := []rune(s)
+	r[0] = unicode.ToUpper(r[0])
+	return string(r)
+}

--- a/infer_test.go
+++ b/infer_test.go
@@ -1,0 +1,511 @@
+package omnist
+
+import (
+	"math/big"
+	"testing"
+)
+
+// --- helpers -----------------------------------------------------------
+
+func strDoc(fields ...Edge) Document {
+	n := NewNode()
+	n.Edges = append(n.Edges, fields...)
+	return NodeDocument(n)
+}
+
+func strEdge(label, s string) Edge {
+	return Edge{Label: label, Target: ValueTarget(ScalarValue(NewStringScalar(s)))}
+}
+
+func intEdge(label string, i int64) Edge {
+	return Edge{Label: label, Target: ValueTarget(ScalarValue(NewIntegerScalar(big.NewInt(i))))}
+}
+
+func nullEdge(label string) Edge {
+	return Edge{Label: label, Target: ValueTarget(NullValue())}
+}
+
+func nodeEdge(label string, n *Node) Edge {
+	return Edge{Label: label, Target: NodeTarget(n)}
+}
+
+func mustField(t *testing.T, s Schema, recName, label string) Field {
+	t.Helper()
+	rec, ok := s.Env[recName]
+	if !ok {
+		t.Fatalf("record %q not found in env %v", recName, s.EnvOrder)
+	}
+	for _, f := range rec.Fields {
+		if f.Label == label {
+			return f
+		}
+	}
+	t.Fatalf("field %q not found in record %q (fields=%+v)", label, recName, rec.Fields)
+	return Field{}
+}
+
+// --- worked example, §6.10 ----------------------------------------------
+
+func TestInferWorkedExampleDefaultFails(t *testing.T) {
+	samples := []Document{
+		strDoc(intEdge("id", 7)),
+		strDoc(strEdge("id", "seven")),
+	}
+	_, err := Infer(samples, "", false)
+	if err == nil {
+		t.Fatal("expected infer to fail on conflicting scalar kinds")
+	}
+	diag, ok := err.(Diagnostic)
+	if !ok {
+		t.Fatalf("expected a Diagnostic, got %T: %v", err, err)
+	}
+	if diag.Code != CodeAlgebraInferConflictingScalars {
+		t.Fatalf("expected CodeAlgebraInferConflictingScalars, got %s", diag.Code)
+	}
+}
+
+func TestInferWorkedExampleAllowAnySucceedsWithReport(t *testing.T) {
+	samples := []Document{
+		strDoc(intEdge("id", 7)),
+		strDoc(strEdge("id", "seven")),
+	}
+	schema, fallbacks, err := InferWithReport(samples, "", true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	f := mustField(t, schema, "Root", "id")
+	if f.Type.Kind != TypeAnyKind {
+		t.Fatalf("expected id field to be any, got %+v", f.Type)
+	}
+	if len(fallbacks) != 1 {
+		t.Fatalf("expected exactly one fallback, got %+v", fallbacks)
+	}
+	want := AnyFallback{Location: "Root.id", Reason: "values of more than one scalar kind (integer, string)"}
+	if fallbacks[0] != want {
+		t.Fatalf("fallback mismatch: got %+v, want %+v", fallbacks[0], want)
+	}
+}
+
+func TestInferPlainWrapperAllowAnyDiscardsReport(t *testing.T) {
+	samples := []Document{
+		strDoc(intEdge("id", 7)),
+		strDoc(strEdge("id", "seven")),
+	}
+	schema, err := Infer(samples, "", true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	f := mustField(t, schema, "Root", "id")
+	if f.Type.Kind != TypeAnyKind {
+		t.Fatalf("expected id field to be any, got %+v", f.Type)
+	}
+	// No way to retrieve fallbacks from Infer's return signature -- this
+	// is asserted by the function signature itself (single Schema return,
+	// no fallback slot) rather than by any runtime check.
+}
+
+// --- [0,] array rule ------------------------------------------------------
+
+func TestInferRepeatedLabelBecomesUnboundedMinZero(t *testing.T) {
+	// Every sample has >=2 occurrences of "tag" -- min must still be 0,
+	// not the observed minimum count (2).
+	samples := []Document{
+		strDoc(strEdge("tag", "a"), strEdge("tag", "b")),
+		strDoc(strEdge("tag", "x"), strEdge("tag", "y"), strEdge("tag", "z")),
+	}
+	schema, err := Infer(samples, "", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	f := mustField(t, schema, "Root", "tag")
+	if !f.Cardinality.Unbounded {
+		t.Fatalf("expected unbounded cardinality, got %+v", f.Cardinality)
+	}
+	if f.Cardinality.Min != 0 {
+		t.Fatalf("expected min=0 (not observed min), got %d", f.Cardinality.Min)
+	}
+}
+
+// --- two-pass order independence ------------------------------------------
+
+func TestInferMissingLabelOrderIndependence(t *testing.T) {
+	forward := []Document{
+		strDoc(strEdge("a", "1")),
+		strDoc(strEdge("a", "1"), strEdge("b", "2")),
+	}
+	reverse := []Document{
+		strDoc(strEdge("a", "1"), strEdge("b", "2")),
+		strDoc(strEdge("a", "1")),
+	}
+
+	sf, err := Infer(forward, "", false)
+	if err != nil {
+		t.Fatalf("forward: unexpected error: %v", err)
+	}
+	sr, err := Infer(reverse, "", false)
+	if err != nil {
+		t.Fatalf("reverse: unexpected error: %v", err)
+	}
+
+	fb := mustField(t, sf, "Root", "b")
+	if fb.Cardinality.Min != 0 || fb.Cardinality.Max != 1 || fb.Cardinality.Unbounded {
+		t.Fatalf("expected b to be [0,1], got %+v", fb.Cardinality)
+	}
+
+	recF := sf.Env["Root"]
+	recR := sr.Env["Root"]
+	if len(recF.Fields) != len(recR.Fields) {
+		t.Fatalf("field count differs: forward=%d reverse=%d", len(recF.Fields), len(recR.Fields))
+	}
+	for i := range recF.Fields {
+		ff, fr := recF.Fields[i], recR.Fields[i]
+		if ff.Label != fr.Label {
+			t.Fatalf("field order differs at %d: forward=%s reverse=%s", i, ff.Label, fr.Label)
+		}
+		if ff.Cardinality != fr.Cardinality {
+			t.Fatalf("cardinality differs for %s: forward=%+v reverse=%+v", ff.Label, ff.Cardinality, fr.Cardinality)
+		}
+	}
+}
+
+// --- integer/number collapse ----------------------------------------------
+
+func TestInferIntegerNumberCollapse(t *testing.T) {
+	samples := []Document{
+		strDoc(intEdge("n", 3)),
+		strDoc(Edge{Label: "n", Target: ValueTarget(ScalarValue(NewNumberScalar(3.5)))}),
+	}
+	schema, err := Infer(samples, "", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	f := mustField(t, schema, "Root", "n")
+	if f.Type.Kind != TypeScalarKind || f.Type.ScalarKind != KindNumber {
+		t.Fatalf("expected number scalar, got %+v", f.Type)
+	}
+	if f.Type.Nullable {
+		t.Fatalf("expected non-nullable, got nullable")
+	}
+}
+
+// --- null handling ----------------------------------------------------
+
+func TestInferNullableScalar(t *testing.T) {
+	samples := []Document{
+		strDoc(strEdge("name", "alice")),
+		strDoc(nullEdge("name")),
+	}
+	schema, err := Infer(samples, "", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	f := mustField(t, schema, "Root", "name")
+	if f.Type.Kind != TypeScalarKind || f.Type.ScalarKind != KindString {
+		t.Fatalf("expected string scalar, got %+v", f.Type)
+	}
+	if !f.Type.Nullable {
+		t.Fatalf("expected nullable, got non-nullable")
+	}
+}
+
+func TestInferAllNullDefaultsToNullableString(t *testing.T) {
+	samples := []Document{
+		strDoc(nullEdge("x")),
+		strDoc(nullEdge("x")),
+	}
+	schema, err := Infer(samples, "", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	f := mustField(t, schema, "Root", "x")
+	if f.Type.Kind != TypeScalarKind || f.Type.ScalarKind != KindString || !f.Type.Nullable {
+		t.Fatalf("expected nullable string, got %+v", f.Type)
+	}
+}
+
+// --- mixed objects and values -----------------------------------------
+
+func TestInferMixedShapeFailsByDefault(t *testing.T) {
+	samples := []Document{
+		strDoc(nodeEdge("thing", NewNode().AddValue("inner", ScalarValue(NewStringScalar("v"))))),
+		strDoc(strEdge("thing", "scalar")),
+	}
+	_, err := Infer(samples, "", false)
+	if err == nil {
+		t.Fatal("expected mixed-shape failure")
+	}
+	diag, ok := err.(Diagnostic)
+	if !ok {
+		t.Fatalf("expected Diagnostic, got %T", err)
+	}
+	if diag.Code != CodeAlgebraInferMixedShape {
+		t.Fatalf("expected CodeAlgebraInferMixedShape, got %s", diag.Code)
+	}
+}
+
+func TestInferMixedShapeAllowAnyOpensWithReason(t *testing.T) {
+	samples := []Document{
+		strDoc(nodeEdge("thing", NewNode().AddValue("inner", ScalarValue(NewStringScalar("v"))))),
+		strDoc(strEdge("thing", "scalar")),
+	}
+	schema, fallbacks, err := InferWithReport(samples, "", true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	f := mustField(t, schema, "Root", "thing")
+	if f.Type.Kind != TypeAnyKind {
+		t.Fatalf("expected any, got %+v", f.Type)
+	}
+	want := AnyFallback{Location: "Root.thing", Reason: "mixes objects and values"}
+	found := false
+	for _, fb := range fallbacks {
+		if fb == want {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected fallback %+v, got %+v", want, fallbacks)
+	}
+}
+
+// --- nested records + name uniqueness -----------------------------------
+
+func TestInferNestedRecordsAndNameCollisionsMadeUnique(t *testing.T) {
+	// Two different labels ("address") appear at two different points in
+	// the tree, both node-valued: top-level "address" and
+	// "office.address". Both would naturally generate the base name
+	// "Address" -- confirm they're disambiguated.
+	office := NewNode().AddNode("address", NewNode().AddValue("city", ScalarValue(NewStringScalar("nyc"))))
+	samples := []Document{
+		strDoc(
+			nodeEdge("address", NewNode().AddValue("city", ScalarValue(NewStringScalar("sf")))),
+			nodeEdge("office", office),
+		),
+	}
+	schema, err := Infer(samples, "", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	rootRec := schema.Env["Root"]
+	var addrRef, officeRef string
+	for _, f := range rootRec.Fields {
+		if f.Label == "address" {
+			addrRef = f.Type.RefName
+		}
+		if f.Label == "office" {
+			officeRef = f.Type.RefName
+		}
+	}
+	if addrRef == "" || officeRef == "" {
+		t.Fatalf("expected both address and office to be refs: %+v", rootRec.Fields)
+	}
+	officeRec := schema.Env[officeRef]
+	var nestedAddrRef string
+	for _, f := range officeRec.Fields {
+		if f.Label == "address" {
+			nestedAddrRef = f.Type.RefName
+		}
+	}
+	if nestedAddrRef == "" {
+		t.Fatalf("expected office.address to be a ref: %+v", officeRec.Fields)
+	}
+	if addrRef == nestedAddrRef {
+		t.Fatalf("expected distinct generated names for the two 'address' records, both got %q", addrRef)
+	}
+}
+
+// --- infer does not normalize -------------------------------------------
+
+func TestInferDoesNotNormalizeDuplicateRecordsSurvive(t *testing.T) {
+	// "a" and "b" are two different labels whose node values are
+	// structurally identical (same single scalar field "v"). infer must
+	// generate two SEPARATE records (A, B), not merge them the way
+	// Normalize would.
+	samples := []Document{
+		strDoc(
+			nodeEdge("a", NewNode().AddValue("v", ScalarValue(NewStringScalar("x")))),
+			nodeEdge("b", NewNode().AddValue("v", ScalarValue(NewStringScalar("y")))),
+		),
+	}
+	schema, err := Infer(samples, "", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	rootRec := schema.Env["Root"]
+	var aRef, bRef string
+	for _, f := range rootRec.Fields {
+		if f.Label == "a" {
+			aRef = f.Type.RefName
+		}
+		if f.Label == "b" {
+			bRef = f.Type.RefName
+		}
+	}
+	if aRef == "" || bRef == "" {
+		t.Fatalf("expected both a and b to be refs: %+v", rootRec.Fields)
+	}
+	if aRef == bRef {
+		t.Fatalf("expected two distinct structurally-identical records, got one shared %q", aRef)
+	}
+	if len(schema.Env) != 3 { // Root, A-ish, B-ish
+		t.Fatalf("expected 3 records (Root + 2 structurally-identical), got %d: %v", len(schema.Env), schema.EnvOrder)
+	}
+}
+
+// --- error cases -----------------------------------------------------
+
+func TestInferZeroSamplesErrors(t *testing.T) {
+	_, err := Infer(nil, "", false)
+	if err == nil {
+		t.Fatal("expected error for zero samples")
+	}
+	diag, ok := err.(Diagnostic)
+	if !ok {
+		t.Fatalf("expected Diagnostic, got %T", err)
+	}
+	if diag.Code != CodeAlgebraInferNoSamples {
+		t.Fatalf("expected CodeAlgebraInferNoSamples, got %s", diag.Code)
+	}
+}
+
+func TestInferScalarRootErrors(t *testing.T) {
+	samples := []Document{ValueDocument(ScalarValue(NewStringScalar("bare")))}
+	_, err := Infer(samples, "", false)
+	if err == nil {
+		t.Fatal("expected error for scalar-rooted sample")
+	}
+	diag, ok := err.(Diagnostic)
+	if !ok {
+		t.Fatalf("expected Diagnostic, got %T", err)
+	}
+	if diag.Code != CodeAlgebraInferScalarRoot {
+		t.Fatalf("expected CodeAlgebraInferScalarRoot, got %s", diag.Code)
+	}
+}
+
+func TestInferScalarRootAmongMultipleSamplesErrors(t *testing.T) {
+	samples := []Document{
+		strDoc(strEdge("a", "1")),
+		ValueDocument(ScalarValue(NewStringScalar("bare"))),
+	}
+	_, err := Infer(samples, "", false)
+	if err == nil {
+		t.Fatal("expected error for scalar-rooted sample")
+	}
+	diag, ok := err.(Diagnostic)
+	if !ok {
+		t.Fatalf("expected Diagnostic, got %T", err)
+	}
+	if diag.Code != CodeAlgebraInferScalarRoot {
+		t.Fatalf("expected CodeAlgebraInferScalarRoot, got %s", diag.Code)
+	}
+}
+
+// --- root name default + custom -----------------------------------------
+
+func TestInferDefaultRootName(t *testing.T) {
+	samples := []Document{strDoc(strEdge("a", "1"))}
+	schema, err := Infer(samples, "", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if schema.Root != "Root" {
+		t.Fatalf("expected default root name 'Root', got %q", schema.Root)
+	}
+}
+
+func TestInferCustomRootName(t *testing.T) {
+	samples := []Document{strDoc(strEdge("a", "1"))}
+	schema, err := Infer(samples, "Custom", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if schema.Root != "Custom" {
+		t.Fatalf("expected root name 'Custom', got %q", schema.Root)
+	}
+}
+
+// --- required vs optional (non-array) ------------------------------------
+
+func TestInferRequiredWhenPresentInEverySample(t *testing.T) {
+	samples := []Document{
+		strDoc(strEdge("a", "1")),
+		strDoc(strEdge("a", "2")),
+	}
+	schema, err := Infer(samples, "", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	f := mustField(t, schema, "Root", "a")
+	if f.Cardinality.Min != 1 || f.Cardinality.Max != 1 || f.Cardinality.Unbounded {
+		t.Fatalf("expected [1,1], got %+v", f.Cardinality)
+	}
+}
+
+// --- nested record error propagation -------------------------------------
+
+func TestInferErrorPropagatesFromNestedRecord(t *testing.T) {
+	// The error occurs inside the nested "child" record's own field, not
+	// at the root -- confirms inferType's recursive inferRecord error path
+	// (not just inferRecord's own top-level field loop) surfaces the
+	// error to the caller.
+	samples := []Document{
+		strDoc(nodeEdge("child", NewNode().AddValue("v", ScalarValue(NewIntegerScalar(big.NewInt(1)))))),
+		strDoc(nodeEdge("child", NewNode().AddValue("v", ScalarValue(NewStringScalar("s"))))),
+	}
+	_, err := Infer(samples, "", false)
+	if err == nil {
+		t.Fatal("expected error to propagate from nested record")
+	}
+	diag, ok := err.(Diagnostic)
+	if !ok {
+		t.Fatalf("expected Diagnostic, got %T", err)
+	}
+	if diag.Code != CodeAlgebraInferConflictingScalars {
+		t.Fatalf("expected CodeAlgebraInferConflictingScalars, got %s", diag.Code)
+	}
+}
+
+// --- sanitizeIdentifier edge cases (for 100% coverage of uniqueNameFrom) --
+
+func TestInferLabelSanitizedToValidRecordName(t *testing.T) {
+	samples := []Document{
+		strDoc(nodeEdge("9-strange label!", NewNode().AddValue("v", ScalarValue(NewStringScalar("x"))))),
+	}
+	schema, err := Infer(samples, "", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	rootRec := schema.Env["Root"]
+	if len(rootRec.Fields) != 1 {
+		t.Fatalf("expected 1 field, got %+v", rootRec.Fields)
+	}
+	refName := rootRec.Fields[0].Type.RefName
+	if refName == "" {
+		t.Fatalf("expected a generated ref name, got %+v", rootRec.Fields[0])
+	}
+	if _, ok := schema.Env[refName]; !ok {
+		t.Fatalf("generated name %q not present in env", refName)
+	}
+}
+
+func TestInferEmptyLabelFallsBackToFieldName(t *testing.T) {
+	// A label with nothing identifier-shaped in it (here, the empty
+	// string) sanitizes to "" and must fall back to the "Field" base name.
+	samples := []Document{
+		strDoc(nodeEdge("", NewNode().AddValue("v", ScalarValue(NewStringScalar("x"))))),
+	}
+	schema, err := Infer(samples, "", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	rootRec := schema.Env["Root"]
+	if len(rootRec.Fields) != 1 {
+		t.Fatalf("expected 1 field, got %+v", rootRec.Fields)
+	}
+	refName := rootRec.Fields[0].Type.RefName
+	if refName != "Field" {
+		t.Fatalf("expected generated name 'Field', got %q", refName)
+	}
+}


### PR DESCRIPTION
Closes #19.

Ports spec §6.10: two-pass label collection (order-independent), the `[0,]`-not-observed-minimum array rule, integer/number as the sole scalar-collapse exception, `allow_any` two-mode behavior with exact spec-matching reason strings, no internal normalization, no default `any` emission.

Independently verified: 100% per-function coverage, 0 lint issues. The three sharpest edges in this operation — cardinality-minimum, sample-order independence, and the exact `allow_any` reason-string formats — were each re-derived from scratch with the reviewer's own test constructions (a 3-occurrences-in-every-sample case, forward/reversed sample-order runs, a 3-way scalar-kind conflict), not just re-run against the committed suite.

Found and filed a fourth real spec taxonomy gap this session: omnist-spec#37 (§8.3.6 has no code for `infer_type`'s "mixes objects and values" failure branch, distinct from the existing `infer-conflicting-scalars`). Narrow/cosmetic — minted `algebra.infer-mixed-shape` following the existing naming convention, documented inline, proceeded rather than blocking. Reviewer independently confirmed this is a genuinely distinct failure case, not a redundant addition.
