### PR TITLE
Backfill: canonical OML writer, canonical OSD writer

### DIFF
--- a/oml_writer.go
+++ b/oml_writer.go
@@ -1,0 +1,266 @@
+package omnist
+
+import (
+	"fmt"
+	"math"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// reOMLBareLabel matches a label text eligible for bare (unquoted)
+// emission. It is anchored at both ends because a label is a whole token,
+// not a prefix — unlike the lexer's reIdent, which only needs to match a
+// prefix of the remaining source.
+var reOMLBareLabel = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_-]*$`)
+
+// omlQuotedLabelWords is the writer's quote list from spec §4.4: the
+// three parser-level reserved words (null/true/false), plus nan/inf.
+// nan/inf are not parser-level reserved words — the tokenizer claims them
+// before IDENT is ever tried (§4.2 rule 7) — but a bare "nan"/"inf" label
+// would tokenize back as NUMBER, not as a label, so the canonical writer
+// must quote them anyway.
+var omlQuotedLabelWords = map[string]bool{
+	"null": true, "true": true, "false": true, "nan": true, "inf": true,
+}
+
+// WriteOML renders d as OML text (spec ch.4): §4.4's label-quoting rule
+// and §4.5's string-escaping rule are both followed exactly, since those
+// are the two areas spec chapter 4 states as normative MUST/MUST NOT
+// rules for the canonical writer.
+//
+// compact selects the compact form (§4.1: brace-delimited, semicolon
+// separated, one line) over the pretty-printed form (§4.1: brace
+// delimited, newline separated). Spec §4.1 shows an example of the
+// pretty-printed form using two-space indentation but — unlike OSD's
+// §5.9, which pins OSD's canonical pretty-printed layout explicitly
+// (four-space indent, trailing comma, etc.) — chapter 4 never states that
+// OML's pretty-printed indentation is itself part of canonical form. This
+// writer follows §4.1's own example layout (two-space indent, opening
+// brace on the label's line, closing brace aligned with the label) as a
+// reasonable, deterministic, self-consistent choice, documented here per
+// the issue's instruction to flag this as a judgment call rather than a
+// spec requirement.
+func WriteOML(d Document, compact bool) string {
+	var b strings.Builder
+	if d.IsNode {
+		if compact {
+			writeOMLNodeEdgesCompact(&b, d.Node)
+		} else {
+			writeOMLNodeEdgesPretty(&b, d.Node, 0)
+		}
+		return b.String()
+	}
+	writeOMLValue(&b, d.Value)
+	return b.String()
+}
+
+// WriteOMLCompact is a convenience wrapper for WriteOML(d, true).
+func WriteOMLCompact(d Document) string { return WriteOML(d, true) }
+
+const omlIndentUnit = "  "
+
+func writeOMLNodeEdgesPretty(b *strings.Builder, n *Node, level int) {
+	indent := strings.Repeat(omlIndentUnit, level)
+	for i, e := range n.Edges {
+		if i > 0 {
+			b.WriteByte('\n')
+		}
+		b.WriteString(indent)
+		writeOMLLabel(b, e.Label)
+		b.WriteString(": ")
+		writeOMLTargetPretty(b, e.Target, level)
+	}
+}
+
+func writeOMLTargetPretty(b *strings.Builder, t Target, level int) {
+	if node, ok := t.Node(); ok {
+		if len(node.Edges) == 0 {
+			b.WriteString("{}")
+			return
+		}
+		b.WriteString("{\n")
+		writeOMLNodeEdgesPretty(b, node, level+1)
+		b.WriteByte('\n')
+		b.WriteString(strings.Repeat(omlIndentUnit, level))
+		b.WriteByte('}')
+		return
+	}
+	v, _ := t.Value()
+	writeOMLValue(b, v)
+}
+
+func writeOMLNodeEdgesCompact(b *strings.Builder, n *Node) {
+	for i, e := range n.Edges {
+		if i > 0 {
+			b.WriteString("; ")
+		}
+		writeOMLLabel(b, e.Label)
+		b.WriteString(": ")
+		writeOMLTargetCompact(b, e.Target)
+	}
+}
+
+func writeOMLTargetCompact(b *strings.Builder, t Target) {
+	if node, ok := t.Node(); ok {
+		if len(node.Edges) == 0 {
+			b.WriteString("{}")
+			return
+		}
+		b.WriteString("{ ")
+		writeOMLNodeEdgesCompact(b, node)
+		b.WriteString(" }")
+		return
+	}
+	v, _ := t.Value()
+	writeOMLValue(b, v)
+}
+
+// writeOMLLabel implements spec §4.4's canonical label-quoting rule.
+func writeOMLLabel(b *strings.Builder, label string) {
+	if reOMLBareLabel.MatchString(label) && !omlQuotedLabelWords[label] {
+		b.WriteString(label)
+		return
+	}
+	b.WriteByte('"')
+	b.WriteString(escapeOMLString(label))
+	b.WriteByte('"')
+}
+
+func writeOMLValue(b *strings.Builder, v Value) {
+	if v.IsNull {
+		b.WriteString("null")
+		return
+	}
+	writeOMLScalar(b, v.Scalar)
+}
+
+// writeOMLScalar renders a Scalar's canonical text. For KindInteger, s.Int
+// is assumed non-nil: every Scalar of that kind reaching this function was
+// either built by NewIntegerScalar (which always copies a non-nil
+// *big.Int) or produced by ReadOML/ReadOSD, neither of which ever leaves
+// Int nil for KindInteger. This mirrors the same trusted-precondition
+// convention oml_lexer.go's temporal decoders already use.
+func writeOMLScalar(b *strings.Builder, s Scalar) {
+	switch s.Kind {
+	case KindString:
+		b.WriteByte('"')
+		b.WriteString(escapeOMLString(s.Str))
+		b.WriteByte('"')
+	case KindInteger:
+		b.WriteString(s.Int.String())
+	case KindNumber:
+		b.WriteString(formatOMLNumber(s.Num))
+	case KindBoolean:
+		if s.Bool {
+			b.WriteString("true")
+		} else {
+			b.WriteString("false")
+		}
+	case KindDate:
+		b.WriteString(formatOMLDate(s.Date))
+	case KindTime:
+		b.WriteString(formatOMLTime(s.Time))
+	case KindDateTime:
+		b.WriteString(formatOMLDate(s.DateTime.Date))
+		b.WriteByte('T')
+		b.WriteString(formatOMLTime(s.DateTime.Time))
+	}
+}
+
+// formatOMLNumber renders a float64 so it re-lexes as NUMBER (spec §4.2
+// rule 6, or rule 7 for the reserved spellings), never as INTEGER. NaN and
+// the two infinities MUST use the reserved spellings "nan"/"inf"/"-inf"
+// (§4.2 rule 7) since strconv cannot format them at all. Any other value
+// that strconv would render with no '.', 'e', or 'E' (e.g. "5") is exactly
+// the case that would tokenize back as INTEGER instead of NUMBER, so a
+// ".0" is appended to force it into the NUMBER production.
+func formatOMLNumber(f float64) string {
+	switch {
+	case math.IsNaN(f):
+		return "nan"
+	case math.IsInf(f, 1):
+		return "inf"
+	case math.IsInf(f, -1):
+		return "-inf"
+	}
+	s := strconv.FormatFloat(f, 'g', -1, 64)
+	if !strings.ContainsAny(s, ".eE") {
+		s += ".0"
+	}
+	return s
+}
+
+func formatOMLDate(d DateValue) string {
+	return fmt.Sprintf("%04d-%02d-%02d", d.Year, d.Month, d.Day)
+}
+
+// formatOMLTime renders a TimeValue per the TIME production (spec §4.2's
+// reTime). Seconds are emitted only when Second or Nanosecond is nonzero,
+// and the fractional part only when Nanosecond is nonzero — the Document
+// model does not distinguish "seconds explicitly written as :00" from
+// "seconds omitted", so omitting a zero seconds/fraction component is a
+// reasonable, round-trip-safe canonicalization rather than a spec
+// requirement.
+func formatOMLTime(t TimeValue) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%02d:%02d", t.Hour, t.Minute)
+	if t.Second != 0 || t.Nanosecond != 0 {
+		fmt.Fprintf(&b, ":%02d", t.Second)
+		if t.Nanosecond != 0 {
+			b.WriteByte('.')
+			b.WriteString(formatOMLFraction(t.Nanosecond))
+		}
+	}
+	if t.HasOffset {
+		off := t.OffsetSeconds
+		sign := byte('+')
+		if off < 0 {
+			sign = '-'
+			off = -off
+		}
+		fmt.Fprintf(&b, "%c%02d:%02d", sign, off/3600, (off/60)%60)
+	}
+	return b.String()
+}
+
+// formatOMLFraction converts a Nanosecond field back to the shortest 1-6
+// digit fraction string that reproduces it. Nanosecond is always a
+// product of fracToNanos (oml_lexer.go), which right-pads a 1-6 digit
+// source fraction to 9 digits with zeros — so Nanosecond is always an
+// exact multiple of 1000, and trimming trailing zeros from its 6-digit
+// microsecond form can never trim down to nothing given the caller's
+// guard that Nanosecond != 0.
+func formatOMLFraction(ns int) string {
+	micros := ns / 1000
+	s := fmt.Sprintf("%06d", micros)
+	return strings.TrimRight(s, "0")
+}
+
+// escapeOMLString implements spec §4.5's canonical string-escaping rule:
+// only \", \\, \n, \r, \t, and \u00XX (for any other control character)
+// are ever emitted; \/, \b, \f, surrogate pairs, raw strings, and
+// multiline strings are Extended read-only spellings the writer must
+// never produce. Non-ASCII characters pass through literally.
+func escapeOMLString(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		switch {
+		case r == '"':
+			b.WriteString(`\"`)
+		case r == '\\':
+			b.WriteString(`\\`)
+		case r == '\n':
+			b.WriteString(`\n`)
+		case r == '\r':
+			b.WriteString(`\r`)
+		case r == '\t':
+			b.WriteString(`\t`)
+		case r < 0x20:
+			fmt.Fprintf(&b, `\u%04x`, r)
+		default:
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}

--- a/oml_writer_test.go
+++ b/oml_writer_test.go
@@ -1,0 +1,233 @@
+package omnist
+
+import (
+	"math"
+	"math/big"
+	"strings"
+	"testing"
+)
+
+// --- round-trip property: the most valuable test category per the issue ---
+
+func TestOMLRoundTripProperty(t *testing.T) {
+	bigDigits := strings.Repeat("9", 50)
+	bigInt := new(big.Int)
+	bigInt.SetString(bigDigits, 10)
+
+	cases := []struct {
+		name string
+		doc  Document
+	}{
+		{"empty node", NodeDocument(NewNode())},
+		{"bare string scalar", ValueDocument(ScalarValue(NewStringScalar("hi")))},
+		{"bare null", ValueDocument(NullValue())},
+		{"bare integer", ValueDocument(ScalarValue(NewIntegerScalar(big.NewInt(-42))))},
+		{"bare boolean true", ValueDocument(ScalarValue(NewBooleanScalar(true)))},
+		{
+			"all seven scalar kinds",
+			NodeDocument(NewNode().
+				AddValue("str", ScalarValue(NewStringScalar("hello"))).
+				AddValue("int", ScalarValue(NewIntegerScalar(bigInt))).
+				AddValue("num", ScalarValue(NewNumberScalar(3.5))).
+				AddValue("boolT", ScalarValue(NewBooleanScalar(true))).
+				AddValue("boolF", ScalarValue(NewBooleanScalar(false))).
+				AddValue("date", ScalarValue(NewDateScalar(DateValue{Year: 2024, Month: 1, Day: 2}))).
+				AddValue("time", ScalarValue(NewTimeScalar(TimeValue{Hour: 10, Minute: 30}))).
+				AddValue("datetime", ScalarValue(NewDateTimeScalar(DateTimeValue{
+					Date: DateValue{Year: 2024, Month: 1, Day: 2},
+					Time: TimeValue{Hour: 10, Minute: 30, Second: 5, Nanosecond: 123000000, HasOffset: true, OffsetSeconds: -3600},
+				}))).
+				AddValue("null", NullValue()),
+			),
+		},
+		{
+			"nested node two levels",
+			NodeDocument(NewNode().AddNode("address", NewNode().
+				AddValue("city", ScalarValue(NewStringScalar("Zurich"))).
+				AddNode("geo", NewNode().
+					AddValue("lat", ScalarValue(NewNumberScalar(47.37))).
+					AddValue("lon", ScalarValue(NewNumberScalar(8.55)))))),
+		},
+		{
+			"repeated labels",
+			NodeDocument(NewNode().
+				AddValue("tag", ScalarValue(NewStringScalar("x"))).
+				AddValue("tag", ScalarValue(NewStringScalar("y"))).
+				AddValue("tag", ScalarValue(NewStringScalar("z")))),
+		},
+		{
+			"empty child node",
+			NodeDocument(NewNode().AddNode("empty", NewNode())),
+		},
+		{
+			"label needing quoting: hyphen, space, reserved words, nan/inf",
+			NodeDocument(NewNode().
+				AddValue("has space", ScalarValue(NewStringScalar("v1"))).
+				AddValue("null", ScalarValue(NewStringScalar("v2"))).
+				AddValue("true", ScalarValue(NewStringScalar("v3"))).
+				AddValue("false", ScalarValue(NewStringScalar("v4"))).
+				AddValue("nan", ScalarValue(NewStringScalar("v5"))).
+				AddValue("inf", ScalarValue(NewStringScalar("v6"))).
+				AddValue("hyphen-ok", ScalarValue(NewStringScalar("v7")))),
+		},
+		{
+			"string escaping: quote, backslash, control, unicode",
+			NodeDocument(NewNode().
+				AddValue("s", ScalarValue(NewStringScalar("a\"b\\c\nd\re\tf\x01g héllo 世界")))),
+		},
+		{
+			"number kinds: integer-valued float, exponent, nan, inf, -inf",
+			NodeDocument(NewNode().
+				AddValue("whole", ScalarValue(NewNumberScalar(5))).
+				AddValue("frac", ScalarValue(NewNumberScalar(3.25))).
+				AddValue("big", ScalarValue(NewNumberScalar(1e30))).
+				AddValue("nan", ScalarValue(NewNumberScalar(math.NaN()))).
+				AddValue("posinf", ScalarValue(NewNumberScalar(math.Inf(1)))).
+				AddValue("neginf", ScalarValue(NewNumberScalar(math.Inf(-1))))),
+		},
+		{
+			"time without seconds vs with seconds vs with fraction vs with offset",
+			NodeDocument(NewNode().
+				AddValue("t1", ScalarValue(NewTimeScalar(TimeValue{Hour: 1, Minute: 2}))).
+				AddValue("t2", ScalarValue(NewTimeScalar(TimeValue{Hour: 1, Minute: 2, Second: 3}))).
+				AddValue("t3", ScalarValue(NewTimeScalar(TimeValue{Hour: 1, Minute: 2, Second: 3, Nanosecond: 400000000}))).
+				AddValue("t4", ScalarValue(NewTimeScalar(TimeValue{Hour: 1, Minute: 2, HasOffset: true, OffsetSeconds: 0}))).
+				AddValue("t5", ScalarValue(NewTimeScalar(TimeValue{Hour: 1, Minute: 2, HasOffset: true, OffsetSeconds: -1800})))),
+		},
+	}
+
+	for _, tc := range cases {
+		for _, compact := range []bool{false, true} {
+			t.Run(tc.name, func(t *testing.T) {
+				text := WriteOML(tc.doc, compact)
+				got, err := ReadOML(text, DefaultLimits())
+				if err != nil {
+					t.Fatalf("compact=%v ReadOML(WriteOML(doc)) failed: %v\ntext:\n%s", compact, err, text)
+				}
+				if !docEqual(tc.doc, got) {
+					t.Fatalf("compact=%v round-trip mismatch\ntext:\n%s\ngot:  %#v\nwant: %#v", compact, text, got, tc.doc)
+				}
+			})
+		}
+	}
+}
+
+func TestWriteOMLCompactWrapper(t *testing.T) {
+	doc := NodeDocument(NewNode().AddValue("a", ScalarValue(NewStringScalar("b"))))
+	if got, want := WriteOMLCompact(doc), WriteOML(doc, true); got != want {
+		t.Errorf("WriteOMLCompact = %q, want %q", got, want)
+	}
+}
+
+// --- §4.4 label quoting ---
+
+func TestOMLLabelQuoting(t *testing.T) {
+	cases := []struct {
+		label string
+		bare  bool
+	}{
+		{"foo", true},
+		{"foo_bar-9", true},
+		{"_leading", true},
+		{"null", false},
+		{"true", false},
+		{"false", false},
+		{"nan", false},
+		{"inf", false},
+		{"has space", false},
+		{"-inf", false}, // doesn't match IDENT at all (no leading '-')
+		{"", false},
+		{"9start", false}, // IDENT requires a leading letter/underscore
+	}
+	for _, tc := range cases {
+		doc := NodeDocument(NewNode().AddValue(tc.label, ScalarValue(NewStringScalar("v"))))
+		text := WriteOML(doc, true)
+		wantPrefix := tc.label + ":"
+		if tc.bare {
+			if !strings.HasPrefix(text, wantPrefix) {
+				t.Errorf("label %q: want bare prefix %q, got %q", tc.label, wantPrefix, text)
+			}
+		} else {
+			quotedPrefix := `"` + escapeOMLString(tc.label) + `":`
+			if !strings.HasPrefix(text, quotedPrefix) {
+				t.Errorf("label %q: want quoted prefix %q, got %q", tc.label, quotedPrefix, text)
+			}
+		}
+		// Whatever the spelling, it must always read back correctly.
+		reparsed, err := ReadOML(text, DefaultLimits())
+		if err != nil {
+			t.Fatalf("label %q: reparse failed: %v (text: %s)", tc.label, err, text)
+		}
+		if !docEqual(doc, reparsed) {
+			t.Errorf("label %q: round-trip mismatch", tc.label)
+		}
+	}
+}
+
+// --- §4.5 string escaping ---
+
+func TestOMLStringEscapingSanctionedFormsOnly(t *testing.T) {
+	// Every ASCII control character plus the printable escape-relevant
+	// characters, so every branch of escapeOMLString is exercised.
+	s := "\"\\\n\r\t\x00\x01\x1f/\bg\fh世"
+	doc := ValueDocument(ScalarValue(NewStringScalar(s)))
+	text := WriteOML(doc, true)
+
+	for _, forbidden := range []string{`\/`, `\b`, `\f`} {
+		if strings.Contains(text, forbidden) {
+			t.Errorf("output contains forbidden escape %q: %s", forbidden, text)
+		}
+	}
+	for _, required := range []string{`\"`, `\\`, `\n`, `\r`, `\t`, `\u0000`, `\u0001`, `\u001f`} {
+		if !strings.Contains(text, required) {
+			t.Errorf("output missing expected escape %q: %s", required, text)
+		}
+	}
+	if !strings.Contains(text, "世") {
+		t.Errorf("non-ASCII character was escaped, want literal: %s", text)
+	}
+
+	got, err := ReadOML(text, DefaultLimits())
+	if err != nil {
+		t.Fatalf("reparse failed: %v (text: %s)", err, text)
+	}
+	if !docEqual(doc, got) {
+		t.Errorf("round-trip mismatch: got %#v want %#v", got, doc)
+	}
+}
+
+// --- §4.1 shape: compact vs pretty layout, worked example ---
+
+func TestOMLPrettyLayoutMatchesSpecExample(t *testing.T) {
+	doc := NodeDocument(NewNode().
+		AddValue("name", ScalarValue(NewStringScalar("Ann"))).
+		AddNode("address", NewNode().
+			AddValue("city", ScalarValue(NewStringScalar("Zurich"))).
+			AddValue("postcode", ScalarValue(NewStringScalar("8001")))).
+		AddValue("tag", ScalarValue(NewStringScalar("x"))).
+		AddValue("tag", ScalarValue(NewStringScalar("y"))))
+
+	want := "name: \"Ann\"\naddress: {\n  city: \"Zurich\"\n  postcode: \"8001\"\n}\ntag: \"x\"\ntag: \"y\""
+	if got := WriteOML(doc, false); got != want {
+		t.Errorf("pretty form mismatch:\ngot:  %q\nwant: %q", got, want)
+	}
+
+	wantCompact := `name: "Ann"; address: { city: "Zurich"; postcode: "8001" }; tag: "x"; tag: "y"`
+	if got := WriteOML(doc, true); got != wantCompact {
+		t.Errorf("compact form mismatch:\ngot:  %q\nwant: %q", got, wantCompact)
+	}
+}
+
+func TestOMLEmptyDocumentRoundTrips(t *testing.T) {
+	doc := NodeDocument(NewNode())
+	if got := WriteOML(doc, false); got != "" {
+		t.Errorf("empty document should render as empty string, got %q", got)
+	}
+	reparsed, err := ReadOML("", DefaultLimits())
+	if err != nil {
+		t.Fatalf("ReadOML(\"\") failed: %v", err)
+	}
+	if !docEqual(doc, reparsed) {
+		t.Errorf("empty round-trip mismatch")
+	}
+}

--- a/osd_writer.go
+++ b/osd_writer.go
@@ -1,0 +1,143 @@
+package omnist
+
+import (
+	"fmt"
+	"strings"
+)
+
+// WriteOSD renders s as OSD text per spec §5.9's canonical-output rules,
+// which — unlike OML's chapter 4 — are fully normative for the
+// pretty-printed layout: one record per block, fields one per line,
+// four-space indent, a trailing comma after every field including the
+// last, root last, cardinality omitted when [1,1], labels always quoted,
+// types never quoted.
+//
+// compact selects the compact mode §5.9 explicitly permits ("A compact
+// mode with no indentation is permitted and MUST round-trip"). The exact
+// spacing chosen for compact mode (single spaces, ", " between fields) is
+// this writer's own reasonable, deterministic, self-consistent choice —
+// §5.9 gives one worked example of compact mode and does not otherwise
+// pin its whitespace.
+func WriteOSD(s Schema, compact bool) string {
+	var b strings.Builder
+	if compact {
+		writeOSDCompact(&b, s)
+	} else {
+		writeOSDPretty(&b, s)
+	}
+	return b.String()
+}
+
+func writeOSDPretty(b *strings.Builder, s Schema) {
+	for _, name := range s.EnvOrder {
+		rec := s.Env[name]
+		fmt.Fprintf(b, "record %s {\n", rec.Name)
+		for _, f := range rec.Fields {
+			b.WriteString("    ")
+			writeOSDField(b, f)
+			b.WriteString(",\n")
+		}
+		b.WriteString("}\n")
+	}
+	fmt.Fprintf(b, "root %s\n", s.Root)
+}
+
+func writeOSDCompact(b *strings.Builder, s Schema) {
+	for _, name := range s.EnvOrder {
+		rec := s.Env[name]
+		fmt.Fprintf(b, "record %s {", rec.Name)
+		if len(rec.Fields) > 0 {
+			b.WriteByte(' ')
+			for j, f := range rec.Fields {
+				if j > 0 {
+					b.WriteString(", ")
+				}
+				writeOSDField(b, f)
+			}
+			b.WriteByte(' ')
+		}
+		b.WriteString("} ")
+	}
+	fmt.Fprintf(b, "root %s", s.Root)
+}
+
+func writeOSDField(b *strings.Builder, f Field) {
+	b.WriteByte('"')
+	b.WriteString(escapeOSDLabel(f.Label))
+	b.WriteByte('"')
+	b.WriteString(osdCardinalityString(f.Cardinality))
+	b.WriteString(": ")
+	b.WriteString(osdTypeString(f.Type))
+}
+
+// osdCardinalityString implements §5.9's "cardinality omitted when [1,1]"
+// rule. When not omitted, this always emits the two-bound bracket form
+// ("[min,max]" or, for an unbounded field, "[min,]") rather than trying to
+// reproduce whichever of the grammar's five equivalent bracketed spellings
+// (spec §5.5's table) produced the original Cardinality — the Schema model
+// only records (Min, Max, Unbounded), not which spelling was parsed, and
+// every one of those forms is losslessly reconstructible from that triple
+// alone, so there is exactly one canonical spelling to pick per triple.
+// The leading space is part of this string (or the empty string when
+// omitted) so callers can concatenate it directly after the label.
+func osdCardinalityString(c Cardinality) string {
+	if !c.Unbounded && c.Min == 1 && c.Max == 1 {
+		return ""
+	}
+	if c.Unbounded {
+		return fmt.Sprintf(" [%d,]", c.Min)
+	}
+	if c.Min == c.Max {
+		return fmt.Sprintf(" [%d]", c.Min)
+	}
+	return fmt.Sprintf(" [%d,%d]", c.Min, c.Max)
+}
+
+func osdTypeString(t Type) string {
+	switch t.Kind {
+	case TypeAnyKind:
+		return "any"
+	case TypeRefKind:
+		return t.RefName
+	default: // TypeScalarKind
+		s := t.ScalarKind.String()
+		if t.Nullable {
+			s += "?"
+		}
+		return s
+	}
+}
+
+// escapeOSDLabel implements the writer-side half of spec §5.3.1's weak
+// string-unescaping rule. This is the genuine trap the issue calls out:
+// the reader recognizes exactly two meaningful escapes, \\ -> \ and
+// \" -> ", and otherwise writes whatever character follows a backslash
+// verbatim (including a literal newline or other control character) —
+// there is no named-escape table, so a writer that (wrongly) emitted
+// "\n" for a literal newline byte would round-trip it back as the two
+// characters 'n', not a newline.
+//
+// So this function escapes only backslash and double-quote using the two
+// meaningful escapes, and escapes any other control character (< 0x20,
+// which the reader's tokenizer rejects unescaped as
+// parse.control-character) by emitting a backslash followed by that exact
+// control character byte — relying on the reader's "whatever follows a
+// backslash is written verbatim" rule to reproduce it exactly. Every other
+// character, ASCII or not, passes through completely literally.
+func escapeOSDLabel(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		switch {
+		case r == '\\':
+			b.WriteString(`\\`)
+		case r == '"':
+			b.WriteString(`\"`)
+		case r < 0x20:
+			b.WriteByte('\\')
+			b.WriteRune(r)
+		default:
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}

--- a/osd_writer_test.go
+++ b/osd_writer_test.go
@@ -1,0 +1,276 @@
+package omnist
+
+import (
+	"strings"
+	"testing"
+)
+
+// --- round-trip property: the most valuable test category per the issue ---
+
+func TestOSDRoundTripProperty(t *testing.T) {
+	cases := []struct {
+		name   string
+		schema Schema
+	}{
+		{
+			"single record, default cardinality, all scalar kinds plus any",
+			Schema{
+				Root: "R",
+				Env: map[string]*Record{
+					"R": {Name: "R", Fields: []Field{
+						{Label: "a", Type: ScalarType(KindString, false)},
+						{Label: "b", Type: ScalarType(KindInteger, true)},
+						{Label: "c", Type: ScalarType(KindNumber, false)},
+						{Label: "d", Type: ScalarType(KindBoolean, false)},
+						{Label: "e", Type: ScalarType(KindDate, false)},
+						{Label: "f", Type: ScalarType(KindTime, false)},
+						{Label: "g", Type: ScalarType(KindDateTime, false)},
+						{Label: "h", Type: AnyType()},
+					}},
+				},
+				EnvOrder: []string{"R"},
+			},
+		},
+		{
+			"empty record",
+			Schema{
+				Root:     "R",
+				Env:      map[string]*Record{"R": {Name: "R"}},
+				EnvOrder: []string{"R"},
+			},
+		},
+		{
+			"nested references, mutual recursion",
+			Schema{
+				Root: "A",
+				Env: map[string]*Record{
+					"A": {Name: "A", Fields: []Field{
+						{Label: "b", Type: RefType("B"), Cardinality: Cardinality{Min: 0, Unbounded: true}},
+					}},
+					"B": {Name: "B", Fields: []Field{
+						{Label: "a", Type: RefType("A"), Cardinality: Cardinality{Min: 0, Max: 1}},
+					}},
+				},
+				EnvOrder: []string{"A", "B"},
+			},
+		},
+		{
+			"every cardinality shape",
+			Schema{
+				Root: "R",
+				Env: map[string]*Record{
+					"R": {Name: "R", Fields: []Field{
+						{Label: "default", Type: ScalarType(KindString, false), Cardinality: DefaultCardinality()},
+						{Label: "exact", Type: ScalarType(KindString, false), Cardinality: Cardinality{Min: 3, Max: 3}},
+						{Label: "range", Type: ScalarType(KindString, false), Cardinality: Cardinality{Min: 1, Max: 5}},
+						{Label: "atleast", Type: ScalarType(KindString, false), Cardinality: Cardinality{Min: 5, Unbounded: true}},
+						{Label: "atmost", Type: ScalarType(KindString, false), Cardinality: Cardinality{Min: 0, Max: 5}},
+						{Label: "any_count", Type: ScalarType(KindString, false), Cardinality: Cardinality{Min: 0, Unbounded: true}},
+					}},
+				},
+				EnvOrder: []string{"R"},
+			},
+		},
+		{
+			"label needing escaping: quote, backslash, control char",
+			Schema{
+				Root: "R",
+				Env: map[string]*Record{
+					"R": {Name: "R", Fields: []Field{
+						{Label: `a"b\c` + "\n" + "d", Type: ScalarType(KindString, false)},
+					}},
+				},
+				EnvOrder: []string{"R"},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		for _, compact := range []bool{false, true} {
+			t.Run(tc.name, func(t *testing.T) {
+				text := WriteOSD(tc.schema, compact)
+				got, err := ReadOSD(text)
+				if err != nil {
+					t.Fatalf("compact=%v ReadOSD(WriteOSD(schema)) failed: %v\ntext:\n%s", compact, err, text)
+				}
+				if !schemaEqual(tc.schema, got) {
+					t.Fatalf("compact=%v round-trip mismatch\ntext:\n%s\ngot:  %#v\nwant: %#v", compact, text, got, tc.schema)
+				}
+			})
+		}
+	}
+}
+
+// --- §5.9 canonical form: the worked example, byte-for-byte ---
+
+func TestOSDCanonicalFormMatchesWorkedExample(t *testing.T) {
+	schema := Schema{
+		Root: "R",
+		Env: map[string]*Record{
+			"R": {Name: "R", Fields: []Field{
+				{Label: "a", Type: ScalarType(KindString, true), Cardinality: Cardinality{Min: 0, Max: 3}},
+			}},
+		},
+		EnvOrder: []string{"R"},
+	}
+	want := "record R {\n    \"a\" [0,3]: string?,\n}\nroot R\n"
+	if got := WriteOSD(schema, false); got != want {
+		t.Errorf("got %q want %q", got, want)
+	}
+}
+
+func TestOSDCardinalityOneOneOmitted(t *testing.T) {
+	schema := Schema{
+		Root: "R",
+		Env: map[string]*Record{
+			"R": {Name: "R", Fields: []Field{
+				{Label: "a", Type: ScalarType(KindString, false), Cardinality: DefaultCardinality()},
+			}},
+		},
+		EnvOrder: []string{"R"},
+	}
+	text := WriteOSD(schema, false)
+	if strings.Contains(text, "[") {
+		t.Errorf("default [1,1] cardinality should be omitted entirely, got %q", text)
+	}
+	want := "record R {\n    \"a\": string,\n}\nroot R\n"
+	if text != want {
+		t.Errorf("got %q want %q", text, want)
+	}
+}
+
+func TestOSDRootAlwaysLast(t *testing.T) {
+	// EnvOrder deliberately does not put the root record first, to check
+	// that "root" is emitted last regardless of EnvOrder.
+	schema := Schema{
+		Root: "Second",
+		Env: map[string]*Record{
+			"First":  {Name: "First"},
+			"Second": {Name: "Second"},
+		},
+		EnvOrder: []string{"First", "Second"},
+	}
+	text := WriteOSD(schema, false)
+	rootIdx := strings.Index(text, "root Second")
+	if rootIdx == -1 {
+		t.Fatalf("root declaration not found: %q", text)
+	}
+	firstIdx := strings.Index(text, "record First")
+	secondIdx := strings.Index(text, "record Second")
+	if rootIdx < firstIdx || rootIdx < secondIdx {
+		t.Errorf("root must be emitted last: %q", text)
+	}
+}
+
+// --- §5.9 compact mode ---
+
+func TestOSDCompactModeMatchesSpecExample(t *testing.T) {
+	schema := Schema{
+		Root: "R",
+		Env: map[string]*Record{
+			"R": {Name: "R", Fields: []Field{
+				{Label: "a", Type: ScalarType(KindString, false), Cardinality: DefaultCardinality()},
+			}},
+		},
+		EnvOrder: []string{"R"},
+	}
+	want := `record R { "a": string } root R`
+	if got := WriteOSD(schema, true); got != want {
+		t.Errorf("got %q want %q", got, want)
+	}
+	got, err := ReadOSD(want)
+	if err != nil {
+		t.Fatalf("ReadOSD(compact example) failed: %v", err)
+	}
+	if !schemaEqual(schema, got) {
+		t.Errorf("compact example did not round-trip: got %#v want %#v", got, schema)
+	}
+}
+
+func TestOSDCompactEmptyRecord(t *testing.T) {
+	schema := Schema{
+		Root:     "R",
+		Env:      map[string]*Record{"R": {Name: "R"}},
+		EnvOrder: []string{"R"},
+	}
+	want := `record R {} root R`
+	if got := WriteOSD(schema, true); got != want {
+		t.Errorf("got %q want %q", got, want)
+	}
+}
+
+// --- §5.3.1 weak-unescape-in-reverse trap ---
+
+func TestOSDLabelEscapingBackslashAndQuote(t *testing.T) {
+	label := `contains \ backslash and " quote`
+	schema := Schema{
+		Root: "R",
+		Env: map[string]*Record{
+			"R": {Name: "R", Fields: []Field{{Label: label, Type: ScalarType(KindString, false)}}},
+		},
+		EnvOrder: []string{"R"},
+	}
+	text := WriteOSD(schema, false)
+	got, err := ReadOSD(text)
+	if err != nil {
+		t.Fatalf("ReadOSD failed: %v\ntext:\n%s", err, text)
+	}
+	if got.Env["R"].Fields[0].Label != label {
+		t.Errorf("got label %q, want %q (text: %s)", got.Env["R"].Fields[0].Label, label, text)
+	}
+}
+
+// TestOSDLabelEscapingControlCharacterTrap directly exercises the trap the
+// issue calls out: escaping a literal newline as the two-character
+// sequence \n would (per §5.3.1's weak, non-named-escape unescaping rule)
+// read back as the literal letter 'n', not a newline. The correct
+// approach — what escapeOSDLabel actually does — is to escape a raw
+// control character as a backslash immediately followed by that same
+// literal control byte, relying on the reader's "whatever follows a
+// backslash is written verbatim" behavior.
+//
+// The OSD STRING token's ABNF does permit a literal newline after a
+// backslash (any escaped code point is accepted per §5.3.1), so this
+// case does apply and is not a "doesn't exist in this grammar" edge case
+// to merely note.
+func TestOSDLabelEscapingControlCharacterTrap(t *testing.T) {
+	label := "line one\nline two"
+	escaped := escapeOSDLabel(label)
+
+	if strings.Contains(escaped, `\n`) {
+		t.Fatalf("escapeOSDLabel used the named-escape spelling \\n, which the OSD reader "+
+			"decodes as the literal letter 'n' per §5.3.1, not a newline: %q", escaped)
+	}
+	if !strings.Contains(escaped, "\\\n") {
+		t.Fatalf("escapeOSDLabel should emit a backslash immediately followed by the literal "+
+			"newline byte, got %q", escaped)
+	}
+
+	schema := Schema{
+		Root: "R",
+		Env: map[string]*Record{
+			"R": {Name: "R", Fields: []Field{{Label: label, Type: ScalarType(KindString, false)}}},
+		},
+		EnvOrder: []string{"R"},
+	}
+	text := WriteOSD(schema, false)
+	got, err := ReadOSD(text)
+	if err != nil {
+		t.Fatalf("ReadOSD failed: %v\ntext:\n%s", err, text)
+	}
+	if got.Env["R"].Fields[0].Label != label {
+		t.Errorf("got label %q, want %q (text: %s)", got.Env["R"].Fields[0].Label, label, text)
+	}
+}
+
+// --- §5.10 worked example: label containing \n unescapes to "anb" ---
+
+func TestOSDReaderWeakUnescapeWorkedExample(t *testing.T) {
+	s, err := ReadOSD(`record R { "a\nb": string } root R`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := s.Env["R"].Fields[0].Label; got != "anb" {
+		t.Errorf("got %q, want %q", got, "anb")
+	}
+}

--- a/writer_testutil_test.go
+++ b/writer_testutil_test.go
@@ -1,0 +1,129 @@
+package omnist
+
+import "math"
+
+// This file holds structural-equality helpers shared by oml_writer_test.go
+// and osd_writer_test.go. Neither Document/Node nor Schema/Record exposes
+// a public Equal method (only Scalar does), so the round-trip property
+// tests — "ReadOML(WriteOML(d)) == d" — need their own deep-equality walk.
+// reflect.DeepEqual is deliberately not used: it would treat two
+// KindNumber NaN scalars as unequal (NaN != NaN under ==, which is what
+// DeepEqual falls back to for float64), which is exactly the case the nan
+// round-trip test below needs to treat as equal.
+
+func valueEqual(a, b Value) bool {
+	if a.IsNull != b.IsNull {
+		return false
+	}
+	if a.IsNull {
+		return true
+	}
+	return scalarEqual(a.Scalar, b.Scalar)
+}
+
+// scalarEqual defers to Scalar.Equal for every kind except KindNumber,
+// where it additionally treats two NaNs as equal (Scalar.Equal uses plain
+// ==, under which NaN != NaN) so round-trip tests covering the "nan"
+// reserved spelling can assert equality in the normal way.
+func scalarEqual(a, b Scalar) bool {
+	if a.Kind != b.Kind {
+		return false
+	}
+	if a.Kind == KindNumber && math.IsNaN(a.Num) && math.IsNaN(b.Num) {
+		return true
+	}
+	return a.Equal(b)
+}
+
+func targetEqual(a, b Target) bool {
+	an, aok := a.Node()
+	bn, bok := b.Node()
+	if aok != bok {
+		return false
+	}
+	if aok {
+		return nodeEqual(an, bn)
+	}
+	av, _ := a.Value()
+	bv, _ := b.Value()
+	return valueEqual(av, bv)
+}
+
+func nodeEqual(a, b *Node) bool {
+	if len(a.Edges) != len(b.Edges) {
+		return false
+	}
+	for i := range a.Edges {
+		if a.Edges[i].Label != b.Edges[i].Label {
+			return false
+		}
+		if !targetEqual(a.Edges[i].Target, b.Edges[i].Target) {
+			return false
+		}
+	}
+	return true
+}
+
+func docEqual(a, b Document) bool {
+	if a.IsNode != b.IsNode {
+		return false
+	}
+	if a.IsNode {
+		return nodeEqual(a.Node, b.Node)
+	}
+	return valueEqual(a.Value, b.Value)
+}
+
+func typeEqual(a, b Type) bool {
+	if a.Kind != b.Kind {
+		return false
+	}
+	switch a.Kind {
+	case TypeScalarKind:
+		return a.ScalarKind == b.ScalarKind && a.Nullable == b.Nullable
+	case TypeRefKind:
+		return a.RefName == b.RefName
+	default: // TypeAnyKind
+		return true
+	}
+}
+
+func fieldEqual(a, b Field) bool {
+	return a.Label == b.Label && typeEqual(a.Type, b.Type) && a.Cardinality == b.Cardinality
+}
+
+func recordEqual(a, b *Record) bool {
+	if a.Name != b.Name || len(a.Fields) != len(b.Fields) {
+		return false
+	}
+	for i := range a.Fields {
+		if !fieldEqual(a.Fields[i], b.Fields[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func schemaEqual(a, b Schema) bool {
+	if a.Root != b.Root {
+		return false
+	}
+	if len(a.EnvOrder) != len(b.EnvOrder) {
+		return false
+	}
+	for i := range a.EnvOrder {
+		if a.EnvOrder[i] != b.EnvOrder[i] {
+			return false
+		}
+	}
+	if len(a.Env) != len(b.Env) {
+		return false
+	}
+	for name, rec := range a.Env {
+		other, ok := b.Env[name]
+		if !ok || !recordEqual(rec, other) {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
Closes #21.

Backfills the canonical OML writer (§4.4/§4.5) and canonical OSD writer (§5.9) — port order calls for "reader, then canonical writer" for both formats, but only the readers landed with issues #3/#5. This closes that gap before codec work begins.

Independently verified: 100% per-function coverage, 0 lint issues. Round-trip correctness (the primary test category per the issue) held under both the committed suite and the reviewer's own independently-constructed adversarial fixtures — raw control bytes embedded directly as OSD labels, OML bare-vs-quoted disambiguation for `nan`/`inf`/`null`/`true`/`false` (confirmed case-sensitive), `any` types, self-referential refs, and large integers.

The highest-risk claim in this issue — OSD's writer escapes control characters as backslash + literal byte, not a named escape, because `osd.abnf`'s `string` production forbids raw bytes below 0x20 as literal content and the reader's unescaping is `\X -> X` for any X — was checked directly against the ABNF by me before dispatching review, and independently re-derived by the reviewer against the same grammar and §5.10's worked example. Holds.

No spec ambiguity. Two documented judgment calls where the spec leaves the choice open: OML's pretty-print indentation (2-space; §4.1 doesn't pin one the way §5.9 does for OSD) and OSD's cardinality re-encoding (multiple equivalent bracketed spellings exist for one (min,max) triple; the writer always emits one canonical spelling per triple, since `Cardinality` doesn't remember which spelling was originally parsed).
