### PR TITLE
JSON codec (reader + writer)

### DIFF
--- a/json_reader.go
+++ b/json_reader.go
@@ -1,0 +1,368 @@
+package omnist
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math/big"
+	"strings"
+)
+
+// ReadJSON parses JSON source text into a Document (spec
+// docs/formats/json.md, "stage 1 only, no schema"). limits configures the
+// safety limits enforced while reading (integer digit count, node/depth
+// counts), via the same LimitChecker OML/OSD reading uses (limits.go) —
+// per the issue's design-continuity note, this file does not reimplement
+// that machinery.
+//
+// encoding/json's json.Decoder is used purely as a JSON tokenizer, read
+// with Token() one token at a time via json.Decoder.UseNumber(). Two
+// properties of that approach matter and are both deliberate:
+//
+//   - UseNumber() preserves each numeric literal's own text (as a
+//     json.Number, effectively a string) instead of collapsing every
+//     number to float64. Without it, `1` and `1.0` would both decode to
+//     the Go float64 1.0 and the integer/number distinction spec
+//     §2.2.1 requires (kind decided by the literal's shape: a decimal
+//     point or exponent, or not — never by magnitude) would be lost.
+//   - Token()-based streaming visits object keys in source order and
+//     surfaces each one individually, unlike unmarshaling into
+//     map[string]interface{} (which would both discard key order,
+//     violating D-1, and collapse the integer/number distinction even
+//     with UseNumber, since a map value slot has no memory of the
+//     literal that filled it).
+func ReadJSON(text string, limits Limits) (Document, error) {
+	dec := json.NewDecoder(strings.NewReader(text))
+	dec.UseNumber()
+	r := &jsonReader{dec: dec, checker: NewLimitChecker(limits), text: text}
+
+	tok, err := r.next()
+	if err != nil {
+		return Document{}, err
+	}
+	doc, err := r.readDocument(tok)
+	if err != nil {
+		return Document{}, err
+	}
+
+	// A single JSON document must not have trailing content after its one
+	// top-level value. dec.Token() returns io.EOF once the stream (including
+	// any trailing whitespace) is exhausted; anything else means more
+	// tokens remain.
+	if _, err := r.dec.Token(); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return Document{}, r.errHere(CodeParseTrailingContent, "content remains after the document")
+		}
+		return Document{}, r.wrapDecodeErr(err)
+	}
+	return doc, nil
+}
+
+// jsonReader holds the streaming-decode state for one ReadJSON call.
+type jsonReader struct {
+	dec     *json.Decoder
+	checker *LimitChecker
+	text    string
+}
+
+// next reads the next raw JSON token, translating any decode error (bad
+// syntax, unterminated string, unexpected EOF mid-value, etc.) into a
+// *ParseError positioned via the decoder's byte offset.
+func (r *jsonReader) next() (json.Token, error) {
+	tok, err := r.dec.Token()
+	if err != nil {
+		return nil, r.wrapDecodeErr(err)
+	}
+	return tok, nil
+}
+
+// wrapDecodeErr converts an error from the underlying json.Decoder into a
+// *ParseError. encoding/json does not expose its own error taxonomy in a
+// way this package's Code values can select between meaningfully, so every
+// low-level decode failure is reported as CodeParseUnexpectedToken with the
+// decoder's own message — the position (derived from InputOffset) is the
+// part worth preserving precisely.
+func (r *jsonReader) wrapDecodeErr(err error) error {
+	if errors.Is(err, io.EOF) {
+		return r.errHere(CodeParseUnexpectedToken, "unexpected end of input")
+	}
+	return r.errHere(CodeParseUnexpectedToken, err.Error())
+}
+
+// errHere builds a *ParseError positioned at the decoder's current byte
+// offset, translated to a 1-based line:col pair against the original text.
+func (r *jsonReader) errHere(code Code, msg string) error {
+	line, col := offsetToLineCol(r.text, r.dec.InputOffset())
+	return &ParseError{Line: line, Col: col, Path: fmt.Sprintf("%d:%d", line, col), Code: code, Message: msg}
+}
+
+// offsetToLineCol converts a 0-based byte offset into a 1-based line:col
+// pair, counting '\n' bytes. This is only used for error reporting, so
+// exactness for exotic line-ending conventions is not load-bearing.
+//
+// offset always comes from json.Decoder.InputOffset(), which is bounded to
+// [0, len(text)] by construction — there is no untrusted caller of this
+// unexported helper — so, per the same no-dead-branch convention used
+// elsewhere in this file, there is no defensive clamp here for a range
+// this function's only caller can never produce.
+func offsetToLineCol(text string, offset int64) (line, col int) {
+	line, col = 1, 1
+	for i := int64(0); i < offset; i++ {
+		if text[i] == '\n' {
+			line++
+			col = 1
+		} else {
+			col++
+		}
+	}
+	return line, col
+}
+
+// readDocument builds the top-level Document from the already-read first
+// token, per the model-mapping table: an object becomes a node document, a
+// bare scalar becomes a value document. A bare top-level array is rejected
+// (see readArrayElements's doc comment for why).
+func (r *jsonReader) readDocument(tok json.Token) (Document, error) {
+	if delim, ok := tok.(json.Delim); ok {
+		switch delim {
+		case '{':
+			node, err := r.readObjectBody()
+			if err != nil {
+				return Document{}, err
+			}
+			return NodeDocument(node), nil
+		case '[':
+			return Document{}, r.errHere(CodeDocumentUnlabeledElement, "a top-level array has no label to attach to")
+		}
+	}
+	v, err := r.scalarToValue(tok)
+	if err != nil {
+		return Document{}, err
+	}
+	return ValueDocument(v), nil
+}
+
+// readObjectBody reads object members up to (and including) the closing
+// '}', with the opening '{' already consumed by the caller. Per the
+// model-mapping table, each key becomes a label; a key whose value is a
+// JSON array expands into one edge per array element sharing that label
+// (the "repeated label" rule) rather than a single list-shaped edge, since
+// the Document model has no list construct (issue #1's design).
+//
+// The caller is responsible for LimitChecker.EnterNode/LeaveNode around
+// this call when the object being read is itself a nested target (a
+// record inside another record, or an array element) — mirroring
+// oml_parser.go's parseBracedNode convention. The top-level object is
+// deliberately NOT wrapped: like OML's brace-less top level, the Document
+// root does not count as one more level of nesting away from itself.
+func (r *jsonReader) readObjectBody() (*Node, error) {
+	node := NewNode()
+	for r.dec.More() {
+		keyTok, err := r.next()
+		if err != nil {
+			return nil, err
+		}
+		// JSON's own grammar requires an object member's key to be a quoted
+		// string; json.Decoder enforces that itself before Token() ever
+		// returns (an unquoted or otherwise malformed key, e.g. `{1:2}`,
+		// fails at the Token() call above, wrapped by r.next()), so a
+		// type-asserted key here is never anything but a string. Asserting
+		// that directly, rather than carrying a second "not a string key"
+		// error branch no input can reach, follows the same
+		// no-dead-branch convention this file uses elsewhere (see
+		// numberToValue's SetString comment).
+		key := keyTok.(string)
+
+		valTok, err := r.next()
+		if err != nil {
+			return nil, err
+		}
+		if err := r.readMember(node, key, valTok); err != nil {
+			return nil, err
+		}
+	}
+	// Consume the closing '}'.
+	if _, err := r.next(); err != nil {
+		return nil, err
+	}
+	return node, nil
+}
+
+// readMember appends the edge(s) for one object member (key already read,
+// valTok is the value's first token) to node.
+func (r *jsonReader) readMember(node *Node, key string, valTok json.Token) error {
+	if delim, ok := valTok.(json.Delim); ok {
+		switch delim {
+		case '{':
+			child, err := r.readNestedObject()
+			if err != nil {
+				return err
+			}
+			node.AddNode(key, child)
+			return nil
+		case '[':
+			targets, err := r.readArrayElements()
+			if err != nil {
+				return err
+			}
+			for _, t := range targets {
+				node.Edges = append(node.Edges, Edge{Label: key, Target: t})
+			}
+			return nil
+		}
+	}
+	v, err := r.scalarToValue(valTok)
+	if err != nil {
+		return err
+	}
+	node.AddValue(key, v)
+	return nil
+}
+
+// readNestedObject reads a '{'-started object that is a target somewhere
+// beneath the root (an object member's value, or an array element),
+// enforcing the depth/node-count limits via the shared LimitChecker
+// around the read, per limits.go's EnterNode/LeaveNode contract.
+func (r *jsonReader) readNestedObject() (*Node, error) {
+	line, col := offsetToLineCol(r.text, r.dec.InputOffset())
+	path := fmt.Sprintf("%d:%d", line, col)
+	if diag := r.checker.EnterNode(path); diag != nil {
+		return nil, &ParseError{Line: line, Col: col, Path: path, Code: diag.Code, Message: diag.Message}
+	}
+	defer r.checker.LeaveNode()
+	return r.readObjectBody()
+}
+
+// readArrayElements reads array elements up to (and including) the
+// closing ']', with the opening '[' already consumed by the caller, and
+// returns one Target per element.
+//
+// A JSON array is sugar for a repeated label (spec docs/formats/json.md's
+// model-mapping table): it is not itself a Document-model construct, so
+// an array element that is itself an array has no label to attach to and
+// is rejected — "Bare nested arrays are rejected... inner elements with no
+// label and therefore no edge to occupy." The taxonomy has no
+// JSON-specific code for this; CodeDocumentUnlabeledElement is the
+// existing code (checked against errors.go, spec §8.3.2) whose own name
+// and description ("unlabeled element") match this situation exactly, so
+// it is reused here rather than minting a new one — the same reasoning
+// readDocument uses for a bare top-level array, which is the same
+// "array with nothing to hold it" situation one level up.
+//
+// An empty array ('[]') is treated the same way OML treats its identical
+// array-as-repeated-label-sugar construct (oml_parser.go's parseArray):
+// rejected with CodeParseEmptyArray, rather than silently producing zero
+// edges for the label. This is a narrow, cosmetic reading rather than a
+// load-bearing one — docs/formats/json.md's model-mapping table has no
+// empty-array row to consult, but JSON's array sugar is explicitly the
+// same mechanism OML's array sugar is ("the array is not a value in the
+// model, it is the same label occurring more than once"), and OML's reader
+// already treats zero repeats of that sugar as an error rather than a
+// silent no-op; this reader follows that existing, in-repo precedent for
+// the identical construct rather than inventing a second behavior for it.
+func (r *jsonReader) readArrayElements() ([]Target, error) {
+	if !r.dec.More() {
+		// Consume the ']' before erroring so callers don't have to.
+		errPos := r.errHere(CodeParseEmptyArray, "'[]' is not a valid value")
+		if _, err := r.next(); err != nil {
+			return nil, err
+		}
+		return nil, errPos
+	}
+
+	var targets []Target
+	for r.dec.More() {
+		tok, err := r.next()
+		if err != nil {
+			return nil, err
+		}
+		if delim, ok := tok.(json.Delim); ok {
+			switch delim {
+			case '{':
+				child, err := r.readNestedObject()
+				if err != nil {
+					return nil, err
+				}
+				targets = append(targets, NodeTarget(child))
+				continue
+			case '[':
+				return nil, r.errHere(CodeDocumentUnlabeledElement, "an array element must not itself be an array")
+			}
+		}
+		v, err := r.scalarToValue(tok)
+		if err != nil {
+			return nil, err
+		}
+		targets = append(targets, ValueTarget(v))
+	}
+	// Consume the closing ']'.
+	if _, err := r.next(); err != nil {
+		return nil, err
+	}
+	return targets, nil
+}
+
+// scalarToValue converts one already-read non-Delim JSON token into a
+// Document Value. Per the "no temporal types" rule (docs/formats/json.md),
+// a date-looking string is never upgraded here — it stays KindString,
+// since stage 1 never consults a schema and JSON strings carry no type tag
+// of their own.
+//
+// Every caller has already excluded json.Delim before reaching here (the
+// top-level, object-member, and array-element call sites each branch on
+// json.Delim first and return/continue before falling through to this
+// function), so the type switch's only remaining possibilities from
+// json.Decoder.UseNumber()'s token set are nil, bool, string, and
+// json.Number — an exhaustive set with no default case needed, matching
+// the no-dead-branch convention oml_lexer.go's temporal decoders already
+// use (see the comment above parseDateValue).
+func (r *jsonReader) scalarToValue(tok json.Token) (Value, error) {
+	switch v := tok.(type) {
+	case nil:
+		return NullValue(), nil
+	case bool:
+		return ScalarValue(NewBooleanScalar(v)), nil
+	case string:
+		return ScalarValue(NewStringScalar(v)), nil
+	default:
+		return r.numberToValue(v.(json.Number))
+	}
+}
+
+// numberToValue implements the integer/number split by literal shape, per
+// spec §2.2.1: a literal with no '.', 'e', or 'E' is an integer; any other
+// numeric literal is a number. json.Number preserves the original literal
+// text (that's the entire reason ReadJSON calls UseNumber()), so this
+// inspects the text directly rather than the decoded magnitude.
+func (r *jsonReader) numberToValue(n json.Number) (Value, error) {
+	s := string(n)
+	if strings.ContainsAny(s, ".eE") {
+		f, err := n.Float64()
+		if err != nil {
+			return Value{}, r.errHere(CodeParseUnexpectedToken, "invalid number literal: "+s)
+		}
+		return ScalarValue(NewNumberScalar(f)), nil
+	}
+
+	digits := strings.TrimPrefix(s, "-")
+	if diag := r.checker.CheckIntDigits(r.pathHere(), len(digits)); diag != nil {
+		line, col := offsetToLineCol(r.text, r.dec.InputOffset())
+		return Value{}, &ParseError{Line: line, Col: col, Path: diag.Path, Code: diag.Code, Message: diag.Message}
+	}
+	// s is a JSON-grammar-valid integer literal (the only kind
+	// json.Decoder.UseNumber() ever hands back for a no-'.'/'e'/'E' token):
+	// -?(0|[1-9]\d*). SetString with base 10 cannot fail on such a string,
+	// so — mirroring oml_lexer.go's parseDateValue/parseTimeValue
+	// convention for a regex-pinned precondition — this does not carry a
+	// permanently-dead "malformed" branch for a case no input can reach.
+	bi, _ := new(big.Int).SetString(s, 10)
+	return ScalarValue(NewIntegerScalar(bi)), nil
+}
+
+// pathHere returns the "line:col" text-position path for the decoder's
+// current byte offset, for use in Diagnostic.Path.
+func (r *jsonReader) pathHere() string {
+	line, col := offsetToLineCol(r.text, r.dec.InputOffset())
+	return fmt.Sprintf("%d:%d", line, col)
+}

--- a/json_reader_test.go
+++ b/json_reader_test.go
@@ -1,0 +1,486 @@
+package omnist
+
+import (
+	"math"
+	"math/big"
+	"strings"
+	"testing"
+)
+
+// --- model-mapping table (docs/formats/json.md) ---
+
+func TestJSONModelMappingTable(t *testing.T) {
+	cases := []struct {
+		name string
+		json string
+		want Document
+	}{
+		{
+			`{"a":1,"b":2} -> [(a,1),(b,2)]`,
+			`{"a":1,"b":2}`,
+			NodeDocument(NewNode().
+				AddValue("a", ScalarValue(NewIntegerScalar(big.NewInt(1)))).
+				AddValue("b", ScalarValue(NewIntegerScalar(big.NewInt(2))))),
+		},
+		{
+			`{"m":["A","B"]} -> [(m,A),(m,B)]`,
+			`{"m":["A","B"]}`,
+			NodeDocument(NewNode().
+				AddValue("m", ScalarValue(NewStringScalar("A"))).
+				AddValue("m", ScalarValue(NewStringScalar("B")))),
+		},
+		{
+			`{"m":["A"]} -> [(m,A)] (one edge)`,
+			`{"m":["A"]}`,
+			NodeDocument(NewNode().AddValue("m", ScalarValue(NewStringScalar("A")))),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ReadJSON(tc.json, DefaultLimits())
+			if err != nil {
+				t.Fatalf("ReadJSON(%s) failed: %v", tc.json, err)
+			}
+			if !docEqual(tc.want, got) {
+				t.Errorf("ReadJSON(%s) = %#v, want %#v", tc.json, got, tc.want)
+			}
+		})
+	}
+}
+
+// The count-1 asymmetry called out explicitly in §7.3: {"m":["A"]} reads to
+// one edge, and that one-edge Document, written back, produces {"m":"A"}
+// NOT {"m":["A"]}.
+func TestJSONCountOneAsymmetry(t *testing.T) {
+	doc, err := ReadJSON(`{"m":["A"]}`, DefaultLimits())
+	if err != nil {
+		t.Fatalf("ReadJSON failed: %v", err)
+	}
+	got, err := WriteJSON(doc)
+	if err != nil {
+		t.Fatalf("WriteJSON failed: %v", err)
+	}
+	if want := `{"m":"A"}`; got != want {
+		t.Errorf("WriteJSON(ReadJSON(%q)) = %q, want %q", `{"m":["A"]}`, got, want)
+	}
+}
+
+// --- worked example from docs/formats/json.md ---
+
+func TestJSONWorkedExample(t *testing.T) {
+	text := `{"order": {"id": "A1", "status": "shipped", "total": 29.97,
+  "address": {"street": "1 Main", "city": "London"},
+  "items": [{"sku": "W", "qty": 3, "price": 9.99},
+            {"sku": "G", "qty": 1, "price": 9.99}]}}`
+
+	item := func(sku string, qty int64, price float64) *Node {
+		return NewNode().
+			AddValue("sku", ScalarValue(NewStringScalar(sku))).
+			AddValue("qty", ScalarValue(NewIntegerScalar(big.NewInt(qty)))).
+			AddValue("price", ScalarValue(NewNumberScalar(price)))
+	}
+	want := NodeDocument(NewNode().AddNode("order", NewNode().
+		AddValue("id", ScalarValue(NewStringScalar("A1"))).
+		AddValue("status", ScalarValue(NewStringScalar("shipped"))).
+		AddValue("total", ScalarValue(NewNumberScalar(29.97))).
+		AddNode("address", NewNode().
+			AddValue("street", ScalarValue(NewStringScalar("1 Main"))).
+			AddValue("city", ScalarValue(NewStringScalar("London")))).
+		AddNode("items", item("W", 3, 9.99)).
+		AddNode("items", item("G", 1, 9.99))))
+
+	got, err := ReadJSON(text, DefaultLimits())
+	if err != nil {
+		t.Fatalf("ReadJSON failed: %v", err)
+	}
+	if !docEqual(want, got) {
+		t.Fatalf("worked example mismatch:\ngot:  %#v\nwant: %#v", got, want)
+	}
+}
+
+// --- integer vs. number preservation ---
+
+func TestJSONIntegerVsNumberKind(t *testing.T) {
+	cases := []struct {
+		json     string
+		wantKind ScalarKind
+	}{
+		{`1`, KindInteger},
+		{`-1`, KindInteger},
+		{`0`, KindInteger},
+		{`1.0`, KindNumber},
+		{`1e0`, KindNumber},
+		{`1E0`, KindNumber},
+		{`-1.5`, KindNumber},
+		{`100000000000000000000000000000000000000`, KindInteger}, // beyond float precision
+	}
+	for _, tc := range cases {
+		t.Run(tc.json, func(t *testing.T) {
+			doc, err := ReadJSON(tc.json, DefaultLimits())
+			if err != nil {
+				t.Fatalf("ReadJSON(%s) failed: %v", tc.json, err)
+			}
+			if doc.IsNode {
+				t.Fatalf("ReadJSON(%s) produced a node document, want a bare value", tc.json)
+			}
+			if doc.Value.IsNull {
+				t.Fatalf("ReadJSON(%s) produced null, want a scalar", tc.json)
+			}
+			if got := doc.Value.Scalar.Kind; got != tc.wantKind {
+				t.Errorf("ReadJSON(%s).Value.Scalar.Kind = %v, want %v", tc.json, got, tc.wantKind)
+			}
+		})
+	}
+}
+
+func TestJSONHugeIntegerPreservesExactDigits(t *testing.T) {
+	digits := strings.Repeat("9", 60)
+	doc, err := ReadJSON(digits, DefaultLimits())
+	if err != nil {
+		t.Fatalf("ReadJSON failed: %v", err)
+	}
+	want := new(big.Int)
+	want.SetString(digits, 10)
+	if doc.Value.Scalar.Int.Cmp(want) != 0 {
+		t.Errorf("integer value mismatch: got %s, want %s", doc.Value.Scalar.Int.String(), digits)
+	}
+}
+
+// --- no temporal auto-detection ---
+
+func TestJSONNoTemporalAutoDetection(t *testing.T) {
+	cases := []string{
+		`"2024-01-01"`,
+		`"12:30:00"`,
+		`"2024-01-01T12:30:00"`,
+	}
+	for _, json := range cases {
+		t.Run(json, func(t *testing.T) {
+			doc, err := ReadJSON(json, DefaultLimits())
+			if err != nil {
+				t.Fatalf("ReadJSON(%s) failed: %v", json, err)
+			}
+			if doc.Value.Scalar.Kind != KindString {
+				t.Errorf("ReadJSON(%s).Value.Scalar.Kind = %v, want KindString (stage 1 never consults a schema)", json, doc.Value.Scalar.Kind)
+			}
+		})
+	}
+}
+
+// --- bare nested arrays rejected ---
+
+func TestJSONBareNestedArrayRejected(t *testing.T) {
+	cases := []struct {
+		name string
+		json string
+	}{
+		{"nested inside labeled array", `{"m":[[1,2],[3,4]]}`},
+		{"top-level bare array", `[[1,2],[3,4]]`},
+		{"top-level single-element bare array", `[1]`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ReadJSON(tc.json, DefaultLimits())
+			if err == nil {
+				t.Fatalf("ReadJSON(%s) succeeded, want a rejection error", tc.json)
+			}
+			pe, ok := err.(*ParseError)
+			if !ok {
+				t.Fatalf("ReadJSON(%s) error is %T, want *ParseError", tc.json, err)
+			}
+			if pe.Code != CodeDocumentUnlabeledElement {
+				t.Errorf("ReadJSON(%s) error code = %s, want %s", tc.json, pe.Code, CodeDocumentUnlabeledElement)
+			}
+		})
+	}
+}
+
+func TestJSONEmptyArrayRejected(t *testing.T) {
+	_, err := ReadJSON(`{"m":[]}`, DefaultLimits())
+	if err == nil {
+		t.Fatal("ReadJSON(`{\"m\":[]}`) succeeded, want a rejection error")
+	}
+	pe, ok := err.(*ParseError)
+	if !ok {
+		t.Fatalf("error is %T, want *ParseError", err)
+	}
+	if pe.Code != CodeParseEmptyArray {
+		t.Errorf("error code = %s, want %s", pe.Code, CodeParseEmptyArray)
+	}
+}
+
+// --- round-trip property ---
+
+func TestJSONRoundTripProperty(t *testing.T) {
+	bigDigits := strings.Repeat("9", 50)
+	bigInt := new(big.Int)
+	bigInt.SetString(bigDigits, 10)
+
+	cases := []struct {
+		name string
+		doc  Document
+	}{
+		{"empty node", NodeDocument(NewNode())},
+		{"bare string scalar", ValueDocument(ScalarValue(NewStringScalar("hi")))},
+		{"bare null", ValueDocument(NullValue())},
+		{"bare integer", ValueDocument(ScalarValue(NewIntegerScalar(big.NewInt(-42))))},
+		{"bare boolean true", ValueDocument(ScalarValue(NewBooleanScalar(true)))},
+		{"bare number", ValueDocument(ScalarValue(NewNumberScalar(3.5)))},
+		{
+			"mixed scalar kinds (JSON has no native temporal, so those are excluded here)",
+			NodeDocument(NewNode().
+				AddValue("str", ScalarValue(NewStringScalar("hello"))).
+				AddValue("int", ScalarValue(NewIntegerScalar(bigInt))).
+				AddValue("num", ScalarValue(NewNumberScalar(3.5))).
+				AddValue("boolT", ScalarValue(NewBooleanScalar(true))).
+				AddValue("boolF", ScalarValue(NewBooleanScalar(false))).
+				AddValue("null", NullValue()),
+			),
+		},
+		{
+			"nested node two levels",
+			NodeDocument(NewNode().AddNode("address", NewNode().
+				AddValue("city", ScalarValue(NewStringScalar("Zurich"))).
+				AddNode("geo", NewNode().
+					AddValue("lat", ScalarValue(NewNumberScalar(47.37))).
+					AddValue("lon", ScalarValue(NewNumberScalar(8.55)))))),
+		},
+		{
+			"repeated labels (adjacent, since JSON grouping loses interleaving)",
+			NodeDocument(NewNode().
+				AddValue("tag", ScalarValue(NewStringScalar("x"))).
+				AddValue("tag", ScalarValue(NewStringScalar("y"))).
+				AddValue("tag", ScalarValue(NewStringScalar("z")))),
+		},
+		{
+			"empty child node",
+			NodeDocument(NewNode().AddNode("empty", NewNode())),
+		},
+		{
+			"string escaping: quote, backslash, control, unicode",
+			NodeDocument(NewNode().
+				AddValue("s", ScalarValue(NewStringScalar("a\"b\\c\nd\re\tf\x01g héllo 世界")))),
+		},
+		{
+			"number kinds: integer-valued float, exponent, big",
+			NodeDocument(NewNode().
+				AddValue("whole", ScalarValue(NewNumberScalar(5))).
+				AddValue("frac", ScalarValue(NewNumberScalar(3.25))).
+				AddValue("big", ScalarValue(NewNumberScalar(1e30)))),
+		},
+		{
+			"labels needing JSON string escaping",
+			NodeDocument(NewNode().
+				AddValue("has space", ScalarValue(NewStringScalar("v1"))).
+				AddValue("has\"quote", ScalarValue(NewStringScalar("v2")))),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			text, err := WriteJSON(tc.doc)
+			if err != nil {
+				t.Fatalf("WriteJSON failed: %v", err)
+			}
+			got, err := ReadJSON(text, DefaultLimits())
+			if err != nil {
+				t.Fatalf("ReadJSON(WriteJSON(doc)) failed: %v\ntext: %s", err, text)
+			}
+			if !docEqual(tc.doc, got) {
+				t.Fatalf("round-trip mismatch\ntext: %s\ngot:  %#v\nwant: %#v", text, got, tc.doc)
+			}
+		})
+	}
+}
+
+// NaN/Infinity survive a write(lenient)->null->read round trip only in the
+// sense that reading the null back gives NullValue, not the original NaN
+// (that data is genuinely lost by design) — covered separately below, not
+// as part of the round-trip property (which is explicitly scoped to things
+// JSON CAN represent, per the issue's test list).
+func TestJSONNaNInfinityWriteThenReadBecomesNull(t *testing.T) {
+	doc := NodeDocument(NewNode().
+		AddValue("n", ScalarValue(NewNumberScalar(math.NaN()))).
+		AddValue("ok", ScalarValue(NewStringScalar("still here"))))
+	text, err := WriteJSON(doc)
+	if err != nil {
+		t.Fatalf("WriteJSON failed: %v", err)
+	}
+	got, err := ReadJSON(text, DefaultLimits())
+	if err != nil {
+		t.Fatalf("ReadJSON failed: %v", err)
+	}
+	want := NodeDocument(NewNode().
+		AddValue("n", NullValue()).
+		AddValue("ok", ScalarValue(NewStringScalar("still here"))))
+	if !docEqual(want, got) {
+		t.Errorf("got %#v, want %#v", got, want)
+	}
+}
+
+// --- cross-format structural equality (JSON vs OML) ---
+
+func TestJSONCrossFormatStructuralEqualityWithOML(t *testing.T) {
+	omlText := `id: "A1"; total: 29.97; count: 3; ok: true; nothing: null; address: { street: "1 Main"; city: "London" }; items: "W"; items: "G"`
+	jsonText := `{"id":"A1","total":29.97,"count":3,"ok":true,"nothing":null,"address":{"street":"1 Main","city":"London"},"items":["W","G"]}`
+
+	omlDoc, err := ReadOML(omlText, DefaultLimits())
+	if err != nil {
+		t.Fatalf("ReadOML failed: %v", err)
+	}
+	jsonDoc, err := ReadJSON(jsonText, DefaultLimits())
+	if err != nil {
+		t.Fatalf("ReadJSON failed: %v", err)
+	}
+	if !docEqual(omlDoc, jsonDoc) {
+		t.Fatalf("format-independence violated:\nOML:  %#v\nJSON: %#v", omlDoc, jsonDoc)
+	}
+}
+
+// --- limits (shared LimitChecker, same as OML) ---
+
+func TestJSONLimitDepth(t *testing.T) {
+	limits := DefaultLimits()
+	limits.MaxDepth = 2
+	// {"a":{"b":{"c":{"d":1}}}} nests three levels of objects beneath the
+	// (uncounted) root ("a", "b", "c" each open a nested object), so
+	// depth 3 exceeds a MaxDepth of 2.
+	_, err := ReadJSON(`{"a":{"b":{"c":{"d":1}}}}`, limits)
+	if err == nil {
+		t.Fatal("expected depth limit error")
+	}
+	pe, ok := err.(*ParseError)
+	if !ok || pe.Code != CodeDocumentLimitDepth {
+		t.Errorf("error = %#v, want CodeDocumentLimitDepth", err)
+	}
+}
+
+func TestJSONLimitDepthInsideArray(t *testing.T) {
+	limits := DefaultLimits()
+	limits.MaxDepth = 1
+	_, err := ReadJSON(`{"a":[{"b":1},{"c":{"d":1}}]}`, limits)
+	if err == nil {
+		t.Fatal("expected depth limit error")
+	}
+	pe, ok := err.(*ParseError)
+	if !ok || pe.Code != CodeDocumentLimitDepth {
+		t.Errorf("error = %#v, want CodeDocumentLimitDepth", err)
+	}
+}
+
+func TestJSONLimitNodes(t *testing.T) {
+	limits := DefaultLimits()
+	limits.MaxNodes = 2
+	_, err := ReadJSON(`{"a":{},"b":{},"c":{}}`, limits)
+	if err == nil {
+		t.Fatal("expected node-count limit error")
+	}
+	pe, ok := err.(*ParseError)
+	if !ok || pe.Code != CodeDocumentLimitNodes {
+		t.Errorf("error = %#v, want CodeDocumentLimitNodes", err)
+	}
+}
+
+func TestJSONLimitIntDigits(t *testing.T) {
+	limits := DefaultLimits()
+	limits.MaxIntDigits = 5
+	_, err := ReadJSON(`123456`, limits)
+	if err == nil {
+		t.Fatal("expected int-digits limit error")
+	}
+	pe, ok := err.(*ParseError)
+	if !ok || pe.Code != CodeDocumentLimitIntDigits {
+		t.Errorf("error = %#v, want CodeDocumentLimitIntDigits", err)
+	}
+}
+
+func TestJSONLimitIntDigitsWithinObject(t *testing.T) {
+	limits := DefaultLimits()
+	limits.MaxIntDigits = 3
+	_, err := ReadJSON(`{"n":12345}`, limits)
+	if err == nil {
+		t.Fatal("expected int-digits limit error")
+	}
+	pe, ok := err.(*ParseError)
+	if !ok || pe.Code != CodeDocumentLimitIntDigits {
+		t.Errorf("error = %#v, want CodeDocumentLimitIntDigits", err)
+	}
+}
+
+// --- malformed input / error paths ---
+
+func TestJSONMalformedInputs(t *testing.T) {
+	cases := []struct {
+		name string
+		json string
+	}{
+		{"empty input", ``},
+		{"truncated object", `{"a":1`},
+		{"truncated bare array", `[1,2`},
+		{"stray closing brace", `}`},
+		{"stray closing bracket", `]`},
+		{"trailing comma in object", `{"a":1,}`},
+		{"non-string key", `{1:2}`},
+		{"trailing content after object", `{"a":1} garbage`},
+		{"trailing content after scalar", `1 2`},
+		{"unterminated string", `"abc`},
+		{"huge exponent overflows float64", `1e400`},
+		{"nan token is not valid JSON", `NaN`},
+		{"infinity token is not valid JSON", `Infinity`},
+		{"truncated labeled array right after '['", `{"a":[`},
+		{"truncated labeled array after an element", `{"a":[1,2`},
+		{"malformed element mid-array", `{"a":[1,"ab}`},
+		{"huge exponent inside array element", `{"a":[1e400]}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ReadJSON(tc.json, DefaultLimits())
+			if err == nil {
+				t.Fatalf("ReadJSON(%q) succeeded, want an error", tc.json)
+			}
+			if _, ok := err.(*ParseError); !ok {
+				t.Errorf("ReadJSON(%q) error is %T, want *ParseError", tc.json, err)
+			}
+		})
+	}
+}
+
+func TestJSONMultilinePositionReporting(t *testing.T) {
+	text := "{\n  \"a\": 1,\n  \"b\": ]\n}"
+	_, err := ReadJSON(text, DefaultLimits())
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	pe, ok := err.(*ParseError)
+	if !ok {
+		t.Fatalf("error is %T, want *ParseError", err)
+	}
+	if pe.Line != 3 {
+		t.Errorf("Line = %d, want 3", pe.Line)
+	}
+	if pe.Error() == "" {
+		t.Error("ParseError.Error() returned empty string")
+	}
+}
+
+// --- offsetToLineCol helper ---
+
+func TestOffsetToLineCol(t *testing.T) {
+	text := "ab\ncd\nef"
+	cases := []struct {
+		offset   int64
+		wantLine int
+		wantCol  int
+	}{
+		{0, 1, 1},
+		{2, 1, 3},
+		{3, 2, 1},
+		{6, 3, 1},
+	}
+	for _, tc := range cases {
+		line, col := offsetToLineCol(text, tc.offset)
+		if line != tc.wantLine || col != tc.wantCol {
+			t.Errorf("offsetToLineCol(%q, %d) = (%d,%d), want (%d,%d)", text, tc.offset, line, col, tc.wantLine, tc.wantCol)
+		}
+	}
+}

--- a/json_writer.go
+++ b/json_writer.go
@@ -1,0 +1,287 @@
+package omnist
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+)
+
+// WriteJSON renders d as JSON text (spec §7.3, docs/formats/json.md),
+// schema-free: a writer MUST NOT accept a schema (§7.3), and this one
+// doesn't. It applies §7.3's two rules (grouping by label, the count-1
+// bare-value-vs-list rule) via writeJSONNode/writeJSONGroup below, plus
+// JSON-specific leaf rendering: temporal leaves are stringified to
+// ISO-8601, and NaN/Infinity — not valid JSON tokens — are substituted
+// with `null` at the leaf (docs/formats/json.md's default lenient mode).
+//
+// The signature returns an error because a NaN/Infinity substitution is a
+// reportable adjustment, not always a silent one (spec §7.4: "a reader or
+// writer SHOULD be able to report the adjustments... this is what makes
+// lossiness auditable"). In lenient mode (this function) the write itself
+// never fails — substitution always succeeds — so the error return is
+// currently always nil; it exists so the signature doesn't have to change
+// later when full format-report plumbing lands, and so a caller reading
+// only the signature sees, correctly, that writing JSON can have something
+// to report. Full diagnostic-collection wiring is a TODO (spec §7.4 says
+// only SHOULD, and no `format.*` adjustment-reporting mechanism exists
+// elsewhere in this repo yet to hook into) — this is called out explicitly
+// per the issue's instruction not to silently drop the requirement.
+//
+// See WriteJSONStrict for the spec's optional MAY: failing instead of
+// substituting.
+func WriteJSON(d Document) (string, error) {
+	return writeJSONDocument(d, false)
+}
+
+// WriteJSONStrict renders d as JSON text like WriteJSON, except a
+// NaN/Infinity leaf is a hard failure instead of a `null` substitution —
+// the strict mode docs/formats/json.md's "no NaN or Infinity" rule
+// describes as a spec MAY ("A strict mode MAY instead fail"). The
+// returned error is a Diagnostic (code write.unsupported-value, spec
+// §8.3.9), positioned by the Document path to the offending leaf.
+func WriteJSONStrict(d Document) (string, error) {
+	return writeJSONDocument(d, true)
+}
+
+func writeJSONDocument(d Document, strict bool) (string, error) {
+	var b strings.Builder
+	if d.IsNode {
+		if err := writeJSONNode(&b, d.Node, "$", strict); err != nil {
+			return "", err
+		}
+		return b.String(), nil
+	}
+	if err := writeJSONValue(&b, d.Value, "$", strict); err != nil {
+		return "", err
+	}
+	return b.String(), nil
+}
+
+// jsonGroup is one label's worth of grouped edges, in the order
+// write(node, format)'s pseudocode (spec §7.3.1) builds `groups`: keyed by
+// label, first-seen label order, and — within a label — original edge
+// order.
+type jsonGroup struct {
+	label    string
+	children []Target
+}
+
+// writeJSONNode implements §7.3.1's write(node, format) for the JSON
+// format: group edges sharing a label (grouping rule), then render each
+// group as a bare value when it has exactly one child or as a list
+// otherwise (count-1 rule).
+func writeJSONNode(b *strings.Builder, n *Node, path string, strict bool) error {
+	groups := groupJSONEdges(n)
+
+	b.WriteByte('{')
+	for i, g := range groups {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		writeJSONString(b, g.label)
+		b.WriteByte(':')
+		childPath := path + "." + g.label
+
+		if len(g.children) == 1 {
+			if err := writeJSONTarget(b, g.children[0], childPath, strict); err != nil {
+				return err
+			}
+			continue
+		}
+		b.WriteByte('[')
+		for j, t := range g.children {
+			if j > 0 {
+				b.WriteByte(',')
+			}
+			if err := writeJSONTarget(b, t, fmt.Sprintf("%s[%d]", childPath, j), strict); err != nil {
+				return err
+			}
+		}
+		b.WriteByte(']')
+	}
+	b.WriteByte('}')
+	return nil
+}
+
+// groupJSONEdges implements §7.3.1's `groups` construction: edges sharing
+// a label collapse into one group, in first-seen label order, preserving
+// each label's own children in their original edge order. Cross-label
+// interleaving (e.g. [(m,A),(x,X),(m,B)]) is lost here, exactly as §7.3
+// states JSON must ("no format in the JSON family can express it").
+func groupJSONEdges(n *Node) []jsonGroup {
+	var groups []jsonGroup
+	index := make(map[string]int, len(n.Edges))
+	for _, e := range n.Edges {
+		if i, ok := index[e.Label]; ok {
+			groups[i].children = append(groups[i].children, e.Target)
+			continue
+		}
+		index[e.Label] = len(groups)
+		groups = append(groups, jsonGroup{label: e.Label, children: []Target{e.Target}})
+	}
+	return groups
+}
+
+func writeJSONTarget(b *strings.Builder, t Target, path string, strict bool) error {
+	if node, ok := t.Node(); ok {
+		return writeJSONNode(b, node, path, strict)
+	}
+	v, _ := t.Value()
+	return writeJSONValue(b, v, path, strict)
+}
+
+func writeJSONValue(b *strings.Builder, v Value, path string, strict bool) error {
+	if v.IsNull {
+		b.WriteString("null")
+		return nil
+	}
+	return writeJSONScalar(b, v.Scalar, path, strict)
+}
+
+// writeJSONScalar renders one leaf. Per docs/formats/json.md: "a writer
+// MUST stringify a temporal leaf to ISO-8601" (KindDate/KindTime/
+// KindDateTime), and NaN/Infinity (KindNumber only — JSON's only floating
+// kind) substitute to `null` unless strict, in which case they fail
+// instead. For KindInteger, s.Int is assumed non-nil, mirroring
+// oml_writer.go's writeOMLScalar precondition: every Scalar of that kind
+// reaching this function was built by NewIntegerScalar (which always
+// copies a non-nil *big.Int) or produced by ReadJSON, neither of which
+// ever leaves Int nil for KindInteger.
+func writeJSONScalar(b *strings.Builder, s Scalar, path string, strict bool) error {
+	switch s.Kind {
+	case KindString:
+		writeJSONString(b, s.Str)
+	case KindInteger:
+		b.WriteString(s.Int.String())
+	case KindNumber:
+		return writeJSONNumber(b, s.Num, path, strict)
+	case KindBoolean:
+		if s.Bool {
+			b.WriteString("true")
+		} else {
+			b.WriteString("false")
+		}
+	case KindDate:
+		writeJSONString(b, formatISODate(s.Date))
+	case KindTime:
+		writeJSONString(b, formatISOTime(s.Time))
+	case KindDateTime:
+		writeJSONString(b, formatISODate(s.DateTime.Date)+"T"+formatISOTime(s.DateTime.Time))
+	}
+	return nil
+}
+
+// writeJSONNumber renders a KindNumber leaf. A finite value always gets a
+// decimal point or exponent (never a bare integer-looking spelling) so
+// that ReadJSON's own integer/number split — decided purely by the
+// literal's shape — reads it back as a number, not an integer; without
+// this, writing 5.0 as the JSON text `5` would silently flip its kind on
+// round-trip. NaN/Infinity have no valid JSON spelling at all (spec: "not
+// valid JSON... a writer MUST NOT emit them"); the default lenient mode
+// substitutes `null`, strict mode fails with write.unsupported-value.
+func writeJSONNumber(b *strings.Builder, f float64, path string, strict bool) error {
+	if math.IsNaN(f) || math.IsInf(f, 0) {
+		if strict {
+			return Diagnostic{
+				Path:     path,
+				Code:     CodeWriteUnsupportedValue,
+				Message:  "NaN/Infinity has no JSON representation",
+				Severity: SeverityError,
+			}
+		}
+		b.WriteString("null")
+		return nil
+	}
+	s := strconv.FormatFloat(f, 'g', -1, 64)
+	if !strings.ContainsAny(s, ".eE") {
+		s += ".0"
+	}
+	b.WriteString(s)
+	return nil
+}
+
+// formatISODate renders a DateValue per ISO-8601's calendar-date form
+// (YYYY-MM-DD), matching oml_writer.go's formatOMLDate exactly — the same
+// spelling is both OML's canonical date form and ISO-8601's, so there is
+// no JSON-specific variation to introduce.
+func formatISODate(d DateValue) string {
+	return fmt.Sprintf("%04d-%02d-%02d", d.Year, d.Month, d.Day)
+}
+
+// formatISOTime renders a TimeValue per ISO-8601's time-of-day form.
+// Seconds are emitted only when Second or Nanosecond is nonzero, and the
+// fractional part only when Nanosecond is nonzero, mirroring
+// oml_writer.go's formatOMLTime — the Document model doesn't distinguish
+// "seconds explicitly written as :00" from "seconds omitted" for either
+// format, so this is the same reasonable, round-trip-safe
+// canonicalization, not a spec requirement, applied consistently with
+// OML's writer.
+func formatISOTime(t TimeValue) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%02d:%02d", t.Hour, t.Minute)
+	if t.Second != 0 || t.Nanosecond != 0 {
+		fmt.Fprintf(&b, ":%02d", t.Second)
+		if t.Nanosecond != 0 {
+			b.WriteByte('.')
+			b.WriteString(formatISOFraction(t.Nanosecond))
+		}
+	}
+	if t.HasOffset {
+		off := t.OffsetSeconds
+		sign := byte('+')
+		if off < 0 {
+			sign = '-'
+			off = -off
+		}
+		fmt.Fprintf(&b, "%c%02d:%02d", sign, off/3600, (off/60)%60)
+	}
+	return b.String()
+}
+
+// formatISOFraction converts a Nanosecond field to the shortest 1-6 digit
+// fraction string that reproduces it, mirroring oml_writer.go's
+// formatOMLFraction. Nanosecond is always a product of a source fraction
+// decoder that right-pads to 9 digits (oml_lexer.go's fracToNanos is the
+// only producer of TimeValue.Nanosecond in this repo), so it is always an
+// exact multiple of 1000, and trimming trailing zeros from its 6-digit
+// microsecond form can never trim down to nothing given the caller's
+// guard that Nanosecond != 0.
+func formatISOFraction(ns int) string {
+	micros := ns / 1000
+	s := fmt.Sprintf("%06d", micros)
+	return strings.TrimRight(s, "0")
+}
+
+// writeJSONString renders s as a JSON string literal, escaping exactly
+// what the JSON grammar requires: '"', '\\', the named short escapes for
+// backspace/formfeed/newline/CR/tab, and \u00XX for every other control
+// character. Non-ASCII characters pass through as literal UTF-8 — valid
+// JSON strings are UTF-8 text, and JSON has no requirement to \u-escape
+// non-ASCII content.
+func writeJSONString(b *strings.Builder, s string) {
+	b.WriteByte('"')
+	for _, r := range s {
+		switch {
+		case r == '"':
+			b.WriteString(`\"`)
+		case r == '\\':
+			b.WriteString(`\\`)
+		case r == '\b':
+			b.WriteString(`\b`)
+		case r == '\f':
+			b.WriteString(`\f`)
+		case r == '\n':
+			b.WriteString(`\n`)
+		case r == '\r':
+			b.WriteString(`\r`)
+		case r == '\t':
+			b.WriteString(`\t`)
+		case r < 0x20:
+			fmt.Fprintf(b, `\u%04x`, r)
+		default:
+			b.WriteRune(r)
+		}
+	}
+	b.WriteByte('"')
+}

--- a/json_writer_test.go
+++ b/json_writer_test.go
@@ -1,0 +1,291 @@
+package omnist
+
+import (
+	"math"
+	"math/big"
+	"strings"
+	"testing"
+)
+
+// --- §7.3 grouping + count-1 rule ---
+
+func TestWriteJSONGroupingAndCountOne(t *testing.T) {
+	doc := NodeDocument(NewNode().
+		AddValue("m", ScalarValue(NewStringScalar("A"))).
+		AddValue("x", ScalarValue(NewStringScalar("X"))).
+		AddValue("m", ScalarValue(NewStringScalar("B"))))
+	got, err := WriteJSON(doc)
+	if err != nil {
+		t.Fatalf("WriteJSON failed: %v", err)
+	}
+	// Cross-label interleaving is lost: m's two edges group together
+	// regardless of x sitting between them in the edge list.
+	want := `{"m":["A","B"],"x":"X"}`
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestWriteJSONSingleLabelIsBareValueNotList(t *testing.T) {
+	doc := NodeDocument(NewNode().AddValue("tag", ScalarValue(NewStringScalar("x"))))
+	got, err := WriteJSON(doc)
+	if err != nil {
+		t.Fatalf("WriteJSON failed: %v", err)
+	}
+	if want := `{"tag":"x"}`; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// --- temporal leaves stringified to ISO-8601 ---
+
+func TestWriteJSONTemporalStringified(t *testing.T) {
+	doc := NodeDocument(NewNode().
+		AddValue("d", ScalarValue(NewDateScalar(DateValue{Year: 2024, Month: 1, Day: 2}))).
+		AddValue("t", ScalarValue(NewTimeScalar(TimeValue{Hour: 10, Minute: 30}))).
+		AddValue("dt", ScalarValue(NewDateTimeScalar(DateTimeValue{
+			Date: DateValue{Year: 2024, Month: 1, Day: 2},
+			Time: TimeValue{Hour: 10, Minute: 30, Second: 5, Nanosecond: 250000000},
+		}))))
+	got, err := WriteJSON(doc)
+	if err != nil {
+		t.Fatalf("WriteJSON failed: %v", err)
+	}
+	want := `{"d":"2024-01-02","t":"10:30","dt":"2024-01-02T10:30:05.25"}`
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+
+	// A writer MUST stringify; the result is plain KindString on read back
+	// (JSON has no native temporal types), which is exactly what the "no
+	// temporal auto-detection" rule in json_reader_test.go asserts too.
+	reread, err := ReadJSON(got, DefaultLimits())
+	if err != nil {
+		t.Fatalf("ReadJSON failed: %v", err)
+	}
+	for _, label := range []string{"d", "t", "dt"} {
+		for _, e := range reread.Node.Edges {
+			if e.Label == label {
+				v, _ := e.Target.Value()
+				if v.Scalar.Kind != KindString {
+					t.Errorf("label %q read back as %v, want KindString", label, v.Scalar.Kind)
+				}
+			}
+		}
+	}
+}
+
+func TestWriteJSONTimeVariants(t *testing.T) {
+	cases := []struct {
+		name string
+		tv   TimeValue
+		want string
+	}{
+		{"no seconds", TimeValue{Hour: 1, Minute: 2}, "01:02"},
+		{"with seconds", TimeValue{Hour: 1, Minute: 2, Second: 3}, "01:02:03"},
+		{"with fraction", TimeValue{Hour: 1, Minute: 2, Second: 3, Nanosecond: 400000000}, "01:02:03.4"},
+		{"with positive offset", TimeValue{Hour: 1, Minute: 2, HasOffset: true, OffsetSeconds: 3600}, "01:02+01:00"},
+		{"with negative offset", TimeValue{Hour: 1, Minute: 2, HasOffset: true, OffsetSeconds: -1800}, "01:02-00:30"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			doc := ValueDocument(ScalarValue(NewTimeScalar(tc.tv)))
+			got, err := WriteJSON(doc)
+			if err != nil {
+				t.Fatalf("WriteJSON failed: %v", err)
+			}
+			want := `"` + tc.want + `"`
+			if got != want {
+				t.Errorf("got %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+// --- NaN/Infinity: default lenient substitution ---
+
+func TestWriteJSONNaNInfinitySubstitutesNull(t *testing.T) {
+	cases := []struct {
+		name string
+		num  float64
+	}{
+		{"nan", math.NaN()},
+		{"+inf", math.Inf(1)},
+		{"-inf", math.Inf(-1)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			doc := NodeDocument(NewNode().
+				AddValue("before", ScalarValue(NewStringScalar("kept"))).
+				AddValue("n", ScalarValue(NewNumberScalar(tc.num))).
+				AddValue("after", ScalarValue(NewIntegerScalar(big.NewInt(7)))))
+			got, err := WriteJSON(doc)
+			if err != nil {
+				t.Fatalf("WriteJSON failed: %v", err)
+			}
+			want := `{"before":"kept","n":null,"after":7}`
+			if got != want {
+				t.Errorf("got %q, want %q (rest of the document must be otherwise unaffected)", got, want)
+			}
+		})
+	}
+}
+
+// --- NaN/Infinity: optional strict mode ---
+
+func TestWriteJSONStrictFailsOnNaNInfinity(t *testing.T) {
+	cases := []float64{math.NaN(), math.Inf(1), math.Inf(-1)}
+	for _, num := range cases {
+		doc := NodeDocument(NewNode().AddValue("n", ScalarValue(NewNumberScalar(num))))
+		_, err := WriteJSONStrict(doc)
+		if err == nil {
+			t.Fatalf("WriteJSONStrict(%v) succeeded, want an error", num)
+		}
+		diag, ok := err.(Diagnostic)
+		if !ok {
+			t.Fatalf("error is %T, want Diagnostic", err)
+		}
+		if diag.Code != CodeWriteUnsupportedValue {
+			t.Errorf("Diagnostic.Code = %s, want %s", diag.Code, CodeWriteUnsupportedValue)
+		}
+		if diag.Path != "$.n" {
+			t.Errorf("Diagnostic.Path = %s, want $.n", diag.Path)
+		}
+		if diag.Error() == "" {
+			t.Error("Diagnostic.Error() returned empty string")
+		}
+	}
+}
+
+func TestWriteJSONStrictFailsOnNaNInfinityInsideList(t *testing.T) {
+	doc := NodeDocument(NewNode().
+		AddValue("n", ScalarValue(NewNumberScalar(1))).
+		AddValue("n", ScalarValue(NewNumberScalar(math.NaN()))))
+	_, err := WriteJSONStrict(doc)
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	diag, ok := err.(Diagnostic)
+	if !ok || diag.Code != CodeWriteUnsupportedValue {
+		t.Errorf("error = %#v, want write.unsupported-value Diagnostic", err)
+	}
+	if diag.Path != "$.n[1]" {
+		t.Errorf("Diagnostic.Path = %s, want $.n[1]", diag.Path)
+	}
+}
+
+func TestWriteJSONStrictSucceedsOnFiniteValues(t *testing.T) {
+	doc := NodeDocument(NewNode().AddValue("n", ScalarValue(NewNumberScalar(3.5))))
+	got, err := WriteJSONStrict(doc)
+	if err != nil {
+		t.Fatalf("WriteJSONStrict failed: %v", err)
+	}
+	if want := `{"n":3.5}`; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestWriteJSONStrictFailsOnBareValueDocument(t *testing.T) {
+	_, err := WriteJSONStrict(ValueDocument(ScalarValue(NewNumberScalar(math.NaN()))))
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	diag, ok := err.(Diagnostic)
+	if !ok || diag.Code != CodeWriteUnsupportedValue {
+		t.Errorf("error = %#v, want write.unsupported-value Diagnostic", err)
+	}
+}
+
+// --- number formatting preserves the integer/number distinction on write ---
+
+func TestWriteJSONNumberAlwaysDistinctFromInteger(t *testing.T) {
+	doc := ValueDocument(ScalarValue(NewNumberScalar(5)))
+	got, err := WriteJSON(doc)
+	if err != nil {
+		t.Fatalf("WriteJSON failed: %v", err)
+	}
+	if got == "5" {
+		t.Fatalf("WriteJSON(number 5) = %q, which would re-read as an integer, losing the number kind", got)
+	}
+	reread, err := ReadJSON(got, DefaultLimits())
+	if err != nil {
+		t.Fatalf("ReadJSON failed: %v", err)
+	}
+	if reread.Value.Scalar.Kind != KindNumber {
+		t.Errorf("round-tripped kind = %v, want KindNumber", reread.Value.Scalar.Kind)
+	}
+}
+
+// --- string escaping ---
+
+func TestWriteJSONStringEscaping(t *testing.T) {
+	s := "\"\\\n\r\t\x00\x01\x1f\bg\fh世"
+	doc := ValueDocument(ScalarValue(NewStringScalar(s)))
+	text, err := WriteJSON(doc)
+	if err != nil {
+		t.Fatalf("WriteJSON failed: %v", err)
+	}
+	required := []string{"\\\"", "\\\\", "\\n", "\\r", "\\t", "\\u0000", "\\u0001", "\\u001f", "\\b", "\\f"}
+	for _, esc := range required {
+		if !strings.Contains(text, esc) {
+			t.Errorf("output missing expected escape %q: %s", esc, text)
+		}
+	}
+	if !strings.Contains(text, "世") {
+		t.Errorf("non-ASCII character was escaped, want literal: %s", text)
+	}
+	got, err := ReadJSON(text, DefaultLimits())
+	if err != nil {
+		t.Fatalf("reparse failed: %v (text: %s)", err, text)
+	}
+	if !docEqual(doc, got) {
+		t.Errorf("round-trip mismatch: got %#v want %#v", got, doc)
+	}
+}
+
+// --- bare-value document writing ---
+
+func TestWriteJSONBareValueDocument(t *testing.T) {
+	cases := []struct {
+		name string
+		doc  Document
+		want string
+	}{
+		{"null", ValueDocument(NullValue()), "null"},
+		{"string", ValueDocument(ScalarValue(NewStringScalar("hi"))), `"hi"`},
+		{"integer", ValueDocument(ScalarValue(NewIntegerScalar(big.NewInt(-7)))), "-7"},
+		{"boolean", ValueDocument(ScalarValue(NewBooleanScalar(true))), "true"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := WriteJSON(tc.doc)
+			if err != nil {
+				t.Fatalf("WriteJSON failed: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestWriteJSONEmptyNode(t *testing.T) {
+	got, err := WriteJSON(NodeDocument(NewNode()))
+	if err != nil {
+		t.Fatalf("WriteJSON failed: %v", err)
+	}
+	if want := "{}"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestWriteJSONNestedNode(t *testing.T) {
+	doc := NodeDocument(NewNode().AddNode("a", NewNode().AddValue("b", ScalarValue(NewIntegerScalar(big.NewInt(1))))))
+	got, err := WriteJSON(doc)
+	if err != nil {
+		t.Fatalf("WriteJSON failed: %v", err)
+	}
+	if want := `{"a":{"b":1}}`; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
Closes #23.

Implements the JSON codec: stage-1 reader (§7.1, §formats/json.md) and schema-free writer (§7.3), including a strict mode for NaN/Infinity beyond the spec's default lenient substitution.

Independently verified: 100% per-function coverage, 0 lint issues. The two highest-risk correctness claims — integer/number kind preservation (using `json.Decoder.UseNumber()` and classifying purely by literal shape, never magnitude) and source key-order preservation (D-1) — were re-derived with the reviewer's own adversarial test cases (a 21-digit big integer, the genuinely tricky `1.5e10` case, a 20-iteration key-order stress loop), not just the committed suite. Count-1 write asymmetry, bare/nested-array rejection, NaN/Infinity lenient+strict behavior, no-temporal-autodetection, and cross-format (OML/JSON) structural equality were each independently confirmed.

Found a fifth real (narrow) spec gap this session: omnist-spec#38 -- formats/json.md never states whether an empty-array value (`{"m":[]}`) is an error, unlike OML's explicit `[]`-is-an-error rule in Sec4.3.1. Implemented by analogy to OML's precedent (error, `parse.empty-array`), reviewed and agreed with, though flagged as a closer call than a first read suggests since the spec is genuinely silent on this specific case rather than just terse. Batched with the other open spec issue from this session (#37) rather than blocking.

No load-bearing spec ambiguity.