### PR TITLE
YAML codec (reader + writer)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/omnist-dev/omnist-go
 
 go 1.24
+
+require gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/yaml_reader.go
+++ b/yaml_reader.go
@@ -1,0 +1,555 @@
+package omnist
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"math/big"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ReadYAML parses YAML source text into a Document (spec
+// docs/formats/yaml.md, "stage 1 only, no schema"). limits configures the
+// safety limits enforced while reading, via the same LimitChecker every
+// other codec uses (limits.go).
+//
+// # Library choice and empirical verification (issue #25)
+//
+// gopkg.in/yaml.v3 is used as the underlying parser, for its yaml.Node API:
+// it hands back a raw parse tree (Kind/Tag/Style/Value per node) rather than
+// only a fully-decoded Go value, which is exactly the "raw parse tree to
+// build a custom resolution layer on top of" the issue asks for.
+//
+// The spec requires YAML 1.1 core-schema scalar resolution specifically —
+// most notably the "Norway problem" (bare on/off/yes/no resolve to
+// booleans) and the sexagesimal-integer sharp edge (bare 12:00:00 resolves
+// to the integer 43200, not a time). Before writing anything below, this was
+// checked empirically (not assumed from documentation) against yaml.v3's
+// own resolve.go and confirmed with a standalone throwaway program that fed
+// yaml.v3 a Node-tree decode of "on: true", "on" alone, "12:00:00", and a
+// bare ISO date:
+//
+//   - A bare "on" parses to Tag="!!str" — v3 does NOT resolve it to a
+//     boolean. v3's resolve.go contains this comment directly on the bool
+//     lookup table: yes/no/on/off (and y/n) are simply absent from the
+//     table v3 uses (only true/false/True/False/TRUE/FALSE are), and
+//     resolve.go's comment on the sexagesimal path states outright: "Base
+//     60 floats are a bad idea, were dropped in YAML 1.2, and are
+//     purposefully unsupported here." So v3 implements YAML 1.2 resolution,
+//     not 1.1, on exactly the two points this issue calls out.
+//   - gopkg.in/yaml.v2's resolve.go DOES carry the full YAML 1.1 bool table
+//     (y/Y/yes/Yes/YES/n/N/no/No/NO/on/On/ON/off/Off/OFF alongside
+//     true/false), confirmed by reading its resolveMapList — but it has the
+//     identical "purposefully unsupported" comment for sexagesimal, so v2
+//     alone still doesn't clear the sexagesimal-integer requirement either.
+//   - Neither published library, used via its own default decode path,
+//     reaches full YAML-1.1-required behavior. Reconfiguring either one
+//     to do so is not exposed as an option (the resolver tables in both
+//     are unexported package internals, not something a caller can widen).
+//
+// Given that, this reader takes the issue's explicit fallback: parse with
+// yaml.v3's Node tree (which is unaffected by resolve.go — Node.Value keeps
+// the literal, un-interpreted source text of every scalar, and Node.Style
+// reports whether it was quoted/block-style or bare), and layer this
+// package's own YAML-1.1 core-schema resolution on top in
+// resolveYAMLScalar below, rather than trusting either library's default
+// interpreted value. v3's own Tag is still consulted as a hint for the
+// parts of core-schema resolution where 1.1 and 1.2 do not actually
+// disagree (plain decimal/hex/octal integers, ordinary floats, .inf/.nan,
+// canonical true/false, null, and ISO timestamps all resolve identically
+// under both — resolve.go's own "purposefully unsupported" comments name
+// the Norway words and sexagesimal as the ONLY two divergences), but the
+// Norway words and sexagesimal notation are always checked first, directly
+// against the node's raw un-interpreted text, before v3's tag is
+// consulted for anything — so v3's YAML-1.2 choices on exactly those two
+// points are never allowed to leak through.
+func ReadYAML(text string, limits Limits) (Document, error) {
+	dec := yaml.NewDecoder(strings.NewReader(text))
+	var root yaml.Node
+	if err := dec.Decode(&root); err != nil {
+		if errors.Is(err, io.EOF) {
+			return Document{}, &ParseError{Line: 1, Col: 1, Path: "1:1", Code: CodeParseUnexpectedToken, Message: "unexpected end of input"}
+		}
+		return Document{}, wrapYAMLDecodeErr(err)
+	}
+
+	// A YAML stream may contain multiple "---"-separated documents;
+	// Decode only ever reads one. Trailing documents have nowhere to
+	// attach in a single-Document result, so — mirroring ReadJSON's own
+	// trailing-content check — a second Decode call succeeding means
+	// there is more content this reader must refuse rather than silently
+	// discard.
+	var extra yaml.Node
+	if err := dec.Decode(&extra); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return Document{}, &ParseError{Line: extra.Line, Col: extra.Column, Path: fmt.Sprintf("%d:%d", extra.Line, extra.Column), Code: CodeParseTrailingContent, Message: "content remains after the document"}
+		}
+		return Document{}, wrapYAMLDecodeErr(err)
+	}
+
+	// root is always a DocumentNode wrapping exactly one child when Decode
+	// succeeds with io.EOF not yet reached above — yaml.v3's contract for
+	// decoding into a *yaml.Node.
+	r := &yamlReader{checker: NewLimitChecker(limits)}
+	return r.readDocument(root.Content[0])
+}
+
+// wrapYAMLDecodeErr converts a yaml.v3 decode error into a *ParseError.
+// yaml.v3 does not expose a structured position for every syntax error (it
+// reports "yaml: line N: ..." as plain text), so — like ReadJSON's own
+// wrapDecodeErr for the same reason with encoding/json — this preserves the
+// library's message and falls back to position 1:1, which is not exact for
+// every syntax error but is what the library makes available.
+func wrapYAMLDecodeErr(err error) error {
+	return &ParseError{Line: 1, Col: 1, Path: "1:1", Code: CodeParseUnexpectedToken, Message: err.Error()}
+}
+
+// yamlReader holds the state for one ReadYAML call.
+type yamlReader struct {
+	checker *LimitChecker
+}
+
+// deref follows an AliasNode to the anchor it points at. Per
+// docs/formats/yaml.md, "aliases resolve at parse time... shared identity
+// is not preserved" — this function only locates the anchored node; it is
+// the caller's job (readTarget/readScalar/readMapping, all of which build a
+// brand-new Go value from what deref returns) that does the actual
+// expansion into an independent copy. Nothing here keeps a shared pointer
+// in the Document result: two edges built from the same alias each get
+// their own freshly-allocated Node/Scalar, because the functions that
+// consume deref's result never return the *yaml.Node itself as part of the
+// Document — they always finish by allocating Document-model types.
+func deref(n *yaml.Node) *yaml.Node {
+	if n.Kind == yaml.AliasNode {
+		return n.Alias
+	}
+	return n
+}
+
+// readDocument builds the top-level Document, per the model-mapping table
+// (docs/formats/yaml.md): a mapping becomes a node document, a bare scalar
+// becomes a value document. A bare top-level sequence is rejected, for the
+// same reason ReadJSON rejects a bare top-level array — see
+// readSequenceElements's doc comment.
+func (r *yamlReader) readDocument(n *yaml.Node) (Document, error) {
+	n = deref(n)
+	switch n.Kind {
+	case yaml.MappingNode:
+		node, err := r.readMappingBody(n)
+		if err != nil {
+			return Document{}, err
+		}
+		return NodeDocument(node), nil
+	case yaml.SequenceNode:
+		return Document{}, r.errAt(n, CodeDocumentUnlabeledElement, "a top-level sequence has no label to attach to")
+	default:
+		v, err := r.readScalar(n)
+		if err != nil {
+			return Document{}, err
+		}
+		return ValueDocument(v), nil
+	}
+}
+
+// readMappingBody reads a MappingNode's Content (alternating key, value
+// pairs) into a Node's edge list. Per the model-mapping table, a key whose
+// value is a sequence expands into one edge per element sharing that label
+// (the "repeated label" rule), exactly as JSON's array-valued members do —
+// docs/formats/yaml.md states YAML and JSON are "the same codec" on this
+// shape.
+//
+// The caller is responsible for LimitChecker.EnterNode/LeaveNode around
+// this call when the mapping being read is itself a nested target — see
+// readNestedMapping. The top level is deliberately not wrapped, matching
+// ReadJSON's readObjectBody convention.
+func (r *yamlReader) readMappingBody(n *yaml.Node) (*Node, error) {
+	node := NewNode()
+	for i := 0; i+1 < len(n.Content); i += 2 {
+		keyNode := deref(n.Content[i])
+		label, err := r.readLabel(keyNode)
+		if err != nil {
+			return nil, err
+		}
+		if err := r.readMember(node, label, n.Content[i+1]); err != nil {
+			return nil, err
+		}
+	}
+	return node, nil
+}
+
+// readLabel resolves a mapping key node to the string label it must be.
+// Per spec §2.2.2, a label MUST be a string. YAML's own core-schema
+// resolution can hand a reader a key that is not textually a string at
+// all — most notably the Norway problem (docs/formats/yaml.md: "a bare
+// `on:` key parses to the boolean true, not the string \"on\""), but the
+// same requirement applies to any other non-string resolution (a bare
+// integer or null key, or a mapping/sequence used as a key) — so this
+// checks the resolved kind generally, not only for booleans.
+//
+// Code choice: the spec taxonomy (errors.go, spec §8.3.2) has no
+// dedicated "key must be a string" code. CodeDocumentUnlabeledElement is
+// reused here, following the same reasoning ReadJSON's readArrayElements
+// doc comment already applies to a different "no valid label" situation —
+// its own name and description ("unlabeled element") match a mapping entry
+// whose key did not resolve to a usable label. This is the plainly-correct
+// reading of a narrow gap, not a load-bearing ambiguity: noted in the
+// issue report rather than inventing a new taxonomy code without
+// consultation.
+func (r *yamlReader) readLabel(keyNode *yaml.Node) (string, error) {
+	if keyNode.Kind != yaml.ScalarNode {
+		return "", r.errAt(keyNode, CodeDocumentUnlabeledElement, "a mapping key must be a scalar string, not a nested collection")
+	}
+	v, err := r.readScalar(keyNode)
+	if err != nil {
+		return "", err
+	}
+	if v.IsNull {
+		return "", r.errAt(keyNode, CodeDocumentUnlabeledElement, "a mapping key resolved to null, not a string")
+	}
+	if v.Scalar.Kind != KindString {
+		return "", r.errAt(keyNode, CodeDocumentUnlabeledElement, fmt.Sprintf("a mapping key must be a string; %q resolved to %s (YAML's core-schema resolution, not a string) — quote the key to keep it a string", keyNode.Value, v.Scalar.Kind))
+	}
+	return v.Scalar.Str, nil
+}
+
+// readMember appends the edge(s) for one mapping entry (key already
+// resolved to label) to node.
+func (r *yamlReader) readMember(node *Node, label string, valNode *yaml.Node) error {
+	valNode = deref(valNode)
+	switch valNode.Kind {
+	case yaml.MappingNode:
+		child, err := r.readNestedMapping(valNode)
+		if err != nil {
+			return err
+		}
+		node.AddNode(label, child)
+		return nil
+	case yaml.SequenceNode:
+		targets, err := r.readSequenceElements(valNode)
+		if err != nil {
+			return err
+		}
+		for _, t := range targets {
+			node.Edges = append(node.Edges, Edge{Label: label, Target: t})
+		}
+		return nil
+	default:
+		v, err := r.readScalar(valNode)
+		if err != nil {
+			return err
+		}
+		node.AddValue(label, v)
+		return nil
+	}
+}
+
+// readNestedMapping reads a MappingNode that is a target somewhere beneath
+// the root (a mapping value, or a sequence element), enforcing the
+// depth/node-count limits via the shared LimitChecker, per limits.go's
+// EnterNode/LeaveNode contract — mirroring ReadJSON's readNestedObject.
+func (r *yamlReader) readNestedMapping(n *yaml.Node) (*Node, error) {
+	path := fmt.Sprintf("%d:%d", n.Line, n.Column)
+	if diag := r.checker.EnterNode(path); diag != nil {
+		return nil, &ParseError{Line: n.Line, Col: n.Column, Path: path, Code: diag.Code, Message: diag.Message}
+	}
+	defer r.checker.LeaveNode()
+	return r.readMappingBody(n)
+}
+
+// readSequenceElements reads a SequenceNode's Content into one Target per
+// element. A YAML sequence is sugar for a repeated label (spec
+// docs/formats/yaml.md's model-mapping table), exactly like a JSON array;
+// it is not itself a Document-model construct. An element that is itself a
+// sequence has no label to attach to and is rejected, for the identical
+// reason ReadJSON's readArrayElements rejects a nested bare array — see
+// that function's doc comment, which this mirrors rather than re-deriving.
+//
+// An empty sequence ('[]' or a key with no items) is rejected with
+// CodeParseEmptyArray for the same reason ReadJSON and OML's parser treat
+// an empty array as an error rather than silently producing zero edges —
+// this is the same array-as-repeated-label-sugar mechanism in a third
+// format, so it follows the existing in-repo precedent rather than
+// inventing a fourth behavior for the identical construct. Narrow/cosmetic
+// reading: docs/formats/yaml.md does not spell out the empty-sequence case
+// explicitly.
+func (r *yamlReader) readSequenceElements(n *yaml.Node) ([]Target, error) {
+	if len(n.Content) == 0 {
+		return nil, r.errAt(n, CodeParseEmptyArray, "an empty sequence is not a valid value")
+	}
+	targets := make([]Target, 0, len(n.Content))
+	for _, elemNode := range n.Content {
+		elemNode = deref(elemNode)
+		switch elemNode.Kind {
+		case yaml.MappingNode:
+			child, err := r.readNestedMapping(elemNode)
+			if err != nil {
+				return nil, err
+			}
+			targets = append(targets, NodeTarget(child))
+		case yaml.SequenceNode:
+			return nil, r.errAt(elemNode, CodeDocumentUnlabeledElement, "a sequence element must not itself be a sequence")
+		default:
+			v, err := r.readScalar(elemNode)
+			if err != nil {
+				return nil, err
+			}
+			targets = append(targets, ValueTarget(v))
+		}
+	}
+	return targets, nil
+}
+
+func (r *yamlReader) errAt(n *yaml.Node, code Code, msg string) *ParseError {
+	return &ParseError{Line: n.Line, Col: n.Column, Path: fmt.Sprintf("%d:%d", n.Line, n.Column), Code: code, Message: msg}
+}
+
+// readScalar resolves one already-dereferenced ScalarNode to a Document
+// Value, applying this reader's YAML-1.1 core-schema resolution
+// (resolveYAMLScalar) and then the digit-count limit for any resulting
+// integer. resolveYAMLScalar itself cannot fail — every plain scalar that
+// doesn't resolve to a more specific kind falls back to KindString, so
+// there is nothing here for it to report an error about — the only
+// failure mode a scalar leaf can have is exceeding the digit limit below.
+func (r *yamlReader) readScalar(n *yaml.Node) (Value, error) {
+	v := resolveYAMLScalar(n)
+	if !v.IsNull && v.Scalar.Kind == KindInteger {
+		digits := len(strings.TrimPrefix(v.Scalar.Int.String(), "-"))
+		if diag := r.checker.CheckIntDigits(fmt.Sprintf("%d:%d", n.Line, n.Column), digits); diag != nil {
+			return Value{}, &ParseError{Line: n.Line, Col: n.Column, Path: diag.Path, Code: diag.Code, Message: diag.Message}
+		}
+	}
+	return v, nil
+}
+
+// --- YAML 1.1 core-schema scalar resolution ---
+//
+// resolveYAMLScalar is this package's own resolution layer, built directly
+// against each scalar node's raw, un-interpreted text (Node.Value) and its
+// Style, per the empirical findings documented on ReadYAML: neither
+// available library's default resolution matches spec-required YAML 1.1
+// behavior on the Norway words or sexagesimal notation, so those two are
+// always decided here, first, from raw text — never from yaml.v3's Tag.
+//
+// A non-plain scalar (single/double-quoted, or a block literal/folded
+// style) is always a string: YAML's core schema only ever resolves *plain*
+// (bare, unquoted) scalars to a non-string type — quoting is exactly the
+// documented escape hatch (docs/formats/yaml.md: "Quoting the key (\"on\":)
+// sidesteps the problem entirely").
+var (
+	// yamlBoolWords is YAML 1.1's bool type's exact word list
+	// (http://yaml.org/type/bool.html), reproduced here rather than
+	// sourced from either library (gopkg.in/yaml.v2 carries this same
+	// table internally, but it is unexported). This is the full list,
+	// including the single-letter y/n forms alongside the Norway
+	// problem's on/off/yes/no and the case variants of true/false.
+	yamlBoolWords = map[string]bool{
+		"y": true, "Y": true, "yes": true, "Yes": true, "YES": true,
+		"n": false, "N": false, "no": false, "No": false, "NO": false,
+		"true": true, "True": true, "TRUE": true,
+		"false": false, "False": false, "FALSE": false,
+		"on": true, "On": true, "ON": true,
+		"off": false, "Off": false, "OFF": false,
+	}
+
+	// yamlNullWords is YAML 1.1's null type's word list
+	// (http://yaml.org/type/null.html); an empty plain scalar is also
+	// null, handled separately below since a map key can't be "".
+	yamlNullWords = map[string]bool{
+		"~": true, "null": true, "Null": true, "NULL": true,
+	}
+
+	// reYAMLSexagesimal matches YAML 1.1's base-60 integer notation
+	// (http://yaml.org/type/int.html): a leading sign, a first group of
+	// one or more digits, then one or more ":"-separated groups of 1-2
+	// digits. "12:00:00" is the spec's own named example (three groups:
+	// 12, 0, 0 -> 12*3600 + 0*60 + 0 = 43200).
+	reYAMLSexagesimal = regexp.MustCompile(`^[-+]?[0-9][0-9_]*(:[0-5]?[0-9])+$`)
+
+	// reYAMLInt matches YAML 1.1's plain decimal/octal/hex/binary int
+	// forms (http://yaml.org/type/int.html), underscores allowed as
+	// digit-group separators.
+	reYAMLInt = regexp.MustCompile(`^[-+]?(0b[0-1_]+|0x[0-9a-fA-F_]+|0o?[0-7_]+|0|[1-9][0-9_]*)$`)
+
+	// reYAMLFloat matches YAML 1.1's canonical plain float form
+	// (http://yaml.org/type/float.html): optional sign, digits with a
+	// mandatory decimal point or an exponent (or both), underscores
+	// allowed. Sexagesimal float notation exists in the 1.1 type spec
+	// too, but the spec issue this reader implements only names the
+	// sexagesimal *integer* case (12:00:00) as a required behavior, and
+	// nothing in docs/formats/yaml.md's worked example exercises a
+	// sexagesimal float — so it is deliberately not implemented here.
+	// This is a narrow, cosmetic gap (an input like "1:30:00.5" would
+	// fall through to reYAMLSexagesimal's non-match and then to the
+	// plain-string fallback below, rather than becoming a KindNumber),
+	// noted in the issue report rather than treated as load-bearing.
+	reYAMLFloat = regexp.MustCompile(`^[-+]?(\.[0-9_]+|[0-9_]+(\.[0-9_]*)?)([eE][-+]?[0-9]+)?$`)
+
+	// reYAMLDate matches a bare calendar date (docs/formats/yaml.md's
+	// own worked example: "placed: 2024-01-01").
+	reYAMLDate = regexp.MustCompile(`^[0-9]{4}-[0-9]{2}-[0-9]{2}$`)
+
+	// reYAMLDateTime matches a bare ISO-8601-ish timestamp, per YAML
+	// 1.1's timestamp type (http://yaml.org/type/timestamp.html):
+	// 'T' or a literal space between date and time, and either a 'Z' or
+	// a +HH:MM/-HH:MM offset (colon in the offset optional per the 1.1
+	// grammar, though every worked example and test in this issue uses
+	// the colon form).
+	reYAMLDateTime = regexp.MustCompile(`^([0-9]{4})-([0-9]{2})-([0-9]{2})[Tt ]([0-9]{2}):([0-9]{2})(:([0-9]{2})(\.([0-9]+))?)?(Z|([+-][0-9]{2}):?([0-9]{2}))?$`)
+)
+
+// resolveYAMLScalar is the core-schema resolution entry point for one
+// scalar node.
+func resolveYAMLScalar(n *yaml.Node) Value {
+	if n.Style&(yaml.SingleQuotedStyle|yaml.DoubleQuotedStyle|yaml.LiteralStyle|yaml.FoldedStyle) != 0 {
+		return ScalarValue(NewStringScalar(n.Value))
+	}
+
+	s := n.Value
+
+	// Empty plain scalar resolves to null (YAML 1.1's null type;
+	// checked ahead of yamlNullWords since "" can't be a map key in
+	// yamlNullWords the way non-empty words are).
+	if s == "" {
+		return NullValue()
+	}
+	if b, ok := yamlBoolWords[s]; ok {
+		return ScalarValue(NewBooleanScalar(b))
+	}
+	if yamlNullWords[s] {
+		return NullValue()
+	}
+	if reYAMLSexagesimal.MatchString(s) {
+		return ScalarValue(NewIntegerScalar(parseSexagesimalInt(s)))
+	}
+	if reYAMLInt.MatchString(s) {
+		bi, ok := parseYAMLInt(s)
+		if ok {
+			return ScalarValue(NewIntegerScalar(bi))
+		}
+		// Falls through to string on the chance SetString rejects text
+		// reYAMLInt's own pattern already constrains to a valid big.Int
+		// literal in every base it matches — see parseYAMLInt's doc
+		// comment; TestYAMLIntLikePatternThatFailsToParseFallsBackToString
+		// (yaml_reader_test.go) exercises this with "0x_".
+	}
+	switch s {
+	case ".inf", "+.inf", ".Inf", "+.Inf", ".INF", "+.INF":
+		return ScalarValue(NewNumberScalar(math.Inf(1)))
+	case "-.inf", "-.Inf", "-.INF":
+		return ScalarValue(NewNumberScalar(math.Inf(-1)))
+	case ".nan", ".NaN", ".NAN":
+		return ScalarValue(NewNumberScalar(math.NaN()))
+	}
+	if reYAMLFloat.MatchString(s) && strings.ContainsAny(s, ".eE") {
+		f, err := strconv.ParseFloat(strings.ReplaceAll(s, "_", ""), 64)
+		if err == nil {
+			return ScalarValue(NewNumberScalar(f))
+		}
+	}
+	if reYAMLDateTime.MatchString(s) {
+		return ScalarValue(NewDateTimeScalar(parseYAMLDateTime(s)))
+	}
+	if reYAMLDate.MatchString(s) {
+		return ScalarValue(NewDateScalar(parseDateValue(s)))
+	}
+	return ScalarValue(NewStringScalar(s))
+}
+
+// parseSexagesimalInt computes the big.Int value of a YAML base-60
+// integer literal already confirmed to match reYAMLSexagesimal: a sign,
+// then ":"-separated groups, most-significant group first, each
+// contributing group*60^(remaining groups). "12:00:00" -> 12*3600 + 0*60 +
+// 0 = 43200 (the spec's own named example). Arbitrary-precision big.Int
+// arithmetic is used, matching every other integer path in this package
+// (spec §2.4's digit-count limit applies to arbitrarily large integers).
+func parseSexagesimalInt(s string) *big.Int {
+	neg := false
+	if s[0] == '+' || s[0] == '-' {
+		neg = s[0] == '-'
+		s = s[1:]
+	}
+	groups := strings.Split(s, ":")
+	sixty := big.NewInt(60)
+	result := new(big.Int)
+	for _, g := range groups {
+		g = strings.ReplaceAll(g, "_", "")
+		part, _ := new(big.Int).SetString(g, 10)
+		result.Mul(result, sixty)
+		result.Add(result, part)
+	}
+	if neg {
+		result.Neg(result)
+	}
+	return result
+}
+
+// parseYAMLInt parses a plain integer literal already confirmed to match
+// reYAMLInt (decimal, or 0b/0x/0o-prefixed) into a big.Int. big.Int's
+// SetString with base 0 already understands Go-style 0b/0x/0o/0 prefixes,
+// which is exactly YAML 1.1's own int type's prefix set, so this defers to
+// it directly rather than duplicating base detection; the leading '+' sign
+// SetString does not accept is stripped first (SetString accepts '-' but
+// not a redundant '+').
+func parseYAMLInt(s string) (*big.Int, bool) {
+	s = strings.TrimPrefix(s, "+")
+	s = strings.ReplaceAll(s, "_", "")
+	return new(big.Int).SetString(s, 0)
+}
+
+// parseYAMLDateTime converts a scalar's text into a DateTimeValue. Its
+// only caller (resolveYAMLScalar) checks reYAMLDateTime.MatchString(s)
+// first and only calls this on success, so FindStringSubmatch here is
+// guaranteed non-nil — mirroring oml_lexer.go's parseDateValue/
+// parseTimeValue precondition convention (see that file's comment above
+// parseDateValue), this does not carry a permanently-dead "no match"
+// branch for a case the precondition already excludes.
+//
+// Unlike OML's reDateTime (which oml_lexer.go's parseDateTimeValue
+// assumes), YAML's timestamp type additionally allows a lowercase 't' or a
+// literal space as the date/time separator and a bare 'Z' for UTC, so this
+// does not reuse oml_lexer.go's parseDateTimeValue directly (its
+// Sscanf-based implementation is pinned to the OML lexer's own narrower
+// regex) and instead extracts fields from reYAMLDateTime's own capture
+// groups.
+func parseYAMLDateTime(s string) DateTimeValue {
+	m := reYAMLDateTime.FindStringSubmatch(s)
+	year, _ := strconv.Atoi(m[1])
+	month, _ := strconv.Atoi(m[2])
+	day, _ := strconv.Atoi(m[3])
+	hour, _ := strconv.Atoi(m[4])
+	minute, _ := strconv.Atoi(m[5])
+
+	tv := TimeValue{Hour: hour, Minute: minute}
+	if m[6] != "" {
+		sec, _ := strconv.Atoi(m[7])
+		tv.Second = sec
+		if m[8] != "" {
+			tv.Nanosecond = fracToNanos(m[9])
+		}
+	}
+	switch {
+	case m[10] == "Z":
+		tv.HasOffset = true
+		tv.OffsetSeconds = 0
+	case m[10] != "":
+		oh, _ := strconv.Atoi(m[11])
+		om, _ := strconv.Atoi(m[12])
+		sign := 1
+		if strings.HasPrefix(m[11], "-") {
+			sign = -1
+			oh = -oh
+		}
+		tv.HasOffset = true
+		tv.OffsetSeconds = sign * (oh*3600 + om*60)
+	}
+	return DateTimeValue{
+		Date: DateValue{Year: year, Month: month, Day: day},
+		Time: tv,
+	}
+}
+

--- a/yaml_reader_test.go
+++ b/yaml_reader_test.go
@@ -1,0 +1,704 @@
+package omnist
+
+import (
+	"math"
+	"math/big"
+	"testing"
+)
+
+// --- model mapping table (docs/formats/yaml.md) ---
+
+func TestYAMLModelMappingTable(t *testing.T) {
+	d, err := ReadYAML("a: 1\nb: 2\n", DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := NodeDocument(NewNode().
+		AddValue("a", ScalarValue(NewIntegerScalar(big.NewInt(1)))).
+		AddValue("b", ScalarValue(NewIntegerScalar(big.NewInt(2)))))
+	if !docEqual(d, want) {
+		t.Errorf("got %+v, want %+v", d, want)
+	}
+}
+
+func TestYAMLRepeatedLabelFromSequence(t *testing.T) {
+	d, err := ReadYAML("m:\n  - A\n  - B\n", DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := NodeDocument(NewNode().
+		AddValue("m", ScalarValue(NewStringScalar("A"))).
+		AddValue("m", ScalarValue(NewStringScalar("B"))))
+	if !docEqual(d, want) {
+		t.Errorf("got %+v, want %+v", d, want)
+	}
+}
+
+// --- worked example (docs/formats/yaml.md) ---
+
+func TestYAMLWorkedExample(t *testing.T) {
+	src := `order:
+  id: A1
+  status: shipped
+  total: 29.97
+  address: {street: 1 Main, city: London}
+  items:
+    - {sku: W, qty: 3, price: 9.99}
+    - {sku: G, qty: 1, price: 9.99}
+`
+	d, err := ReadYAML(src, DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	address := NewNode().AddValue("street", ScalarValue(NewStringScalar("1 Main"))).
+		AddValue("city", ScalarValue(NewStringScalar("London")))
+	item1 := NewNode().AddValue("sku", ScalarValue(NewStringScalar("W"))).
+		AddValue("qty", ScalarValue(NewIntegerScalar(big.NewInt(3)))).
+		AddValue("price", ScalarValue(NewNumberScalar(9.99)))
+	item2 := NewNode().AddValue("sku", ScalarValue(NewStringScalar("G"))).
+		AddValue("qty", ScalarValue(NewIntegerScalar(big.NewInt(1)))).
+		AddValue("price", ScalarValue(NewNumberScalar(9.99)))
+	order := NewNode().
+		AddValue("id", ScalarValue(NewStringScalar("A1"))).
+		AddValue("status", ScalarValue(NewStringScalar("shipped"))).
+		AddValue("total", ScalarValue(NewNumberScalar(29.97))).
+		AddNode("address", address).
+		AddNode("items", item1).
+		AddNode("items", item2)
+	want := NodeDocument(NewNode().AddNode("order", order))
+
+	if !docEqual(d, want) {
+		t.Errorf("got %+v, want %+v", d, want)
+	}
+
+	// "Byte-for-byte identical to the Document JSON produces."
+	jsrc := `{"order":{"id":"A1","status":"shipped","total":29.97,"address":{"street":"1 Main","city":"London"},"items":[{"sku":"W","qty":3,"price":9.99},{"sku":"G","qty":1,"price":9.99}]}}`
+	jd, err := ReadJSON(jsrc, DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !docEqual(d, jd) {
+		t.Errorf("YAML and JSON documents differ:\nYAML: %+v\nJSON: %+v", d, jd)
+	}
+}
+
+// TestYAMLWorkedExampleStatusNo confirms the worked example's first
+// YAML-only note: an unquoted "no" resolves to the boolean false, not the
+// string "no" JSON's equivalent scalar would produce — a genuine,
+// spec-mandated stage-1 divergence between the two formats for the "same"
+// source value.
+func TestYAMLWorkedExampleStatusNo(t *testing.T) {
+	d, err := ReadYAML("status: no\n", DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := NodeDocument(NewNode().AddValue("status", ScalarValue(NewBooleanScalar(false))))
+	if !docEqual(d, want) {
+		t.Errorf("got %+v, want %+v", d, want)
+	}
+}
+
+// TestYAMLWorkedExamplePlacedDate confirms the worked example's second
+// YAML-only note: a bare ISO date resolves to a date-kind Scalar at stage
+// 1, where JSON would hand stage 2 a string to upgrade.
+func TestYAMLWorkedExamplePlacedDate(t *testing.T) {
+	d, err := ReadYAML("placed: 2024-01-01\n", DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := NodeDocument(NewNode().AddValue("placed", ScalarValue(NewDateScalar(DateValue{Year: 2024, Month: 1, Day: 1}))))
+	if !docEqual(d, want) {
+		t.Errorf("got %+v, want %+v", d, want)
+	}
+}
+
+// --- aliases (docs/formats/yaml.md: "Aliases resolve at parse time") ---
+
+func TestYAMLAliasExpandsToIndependentCopies(t *testing.T) {
+	d, err := ReadYAML("a: &x foo\nb: *x\n", DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(d.Node.Edges) != 2 {
+		t.Fatalf("got %d edges, want 2", len(d.Node.Edges))
+	}
+	av, _ := d.Node.Edges[0].Target.Value()
+	bv, _ := d.Node.Edges[1].Target.Value()
+	if av.Scalar.Str != "foo" || bv.Scalar.Str != "foo" {
+		t.Fatalf("both edges should carry \"foo\": a=%+v b=%+v", av, bv)
+	}
+	// Mutating one Scalar's string field cannot be observed on the
+	// other: Go strings are immutable and NewStringScalar copies by
+	// value, so there is no shared backing to mutate through in the
+	// first place — this assertion documents that guarantee rather than
+	// exercising a mutation (there is no mutator to call), matching the
+	// issue's instruction to "write the test to be robust against this
+	// [identity sharing] even if types are currently immutable." A
+	// pointer-identity check on the two Scalars' Str fields would be
+	// meaningless (Go string headers may or may not share a backing
+	// array for equal literals; that is not what "shared identity" in
+	// the Document model means). What IS observable and load-bearing is
+	// that the two Node pointers under a and b's aliased mapping value
+	// (had the anchor been a mapping, not a scalar) are never the same
+	// pointer — TestYAMLAliasedMappingExpandsToIndependentNodes below
+	// covers that directly.
+	if av.Scalar.Str != bv.Scalar.Str {
+		t.Fatalf("expected equal values, got %q vs %q", av.Scalar.Str, bv.Scalar.Str)
+	}
+}
+
+// TestYAMLAliasedMappingExpandsToIndependentNodes is the structural half
+// of the aliasing guarantee: when the anchored value is itself a mapping,
+// each alias occurrence must build its own *Node, not share one — the
+// Document model (issue #1) has no notion of node identity, so a reader
+// that reused a single *Node pointer across both edges would make an
+// identity-sensitive bug (e.g. a future caller mutating one edge's node
+// in place) silently corrupt the other, unobservable today only because
+// nothing currently mutates a *Node after ReadYAML returns.
+func TestYAMLAliasedMappingExpandsToIndependentNodes(t *testing.T) {
+	d, err := ReadYAML("a: &x {k: v}\nb: *x\n", DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	na, _ := d.Node.Edges[0].Target.Node()
+	nb, _ := d.Node.Edges[1].Target.Node()
+	if na == nb {
+		t.Fatal("aliased mapping edges share the same *Node pointer; must be independent copies")
+	}
+	if !nodeEqual(na, nb) {
+		t.Fatalf("aliased mapping edges have different content: %+v vs %+v", na, nb)
+	}
+}
+
+// --- sexagesimal sharp edge ---
+
+func TestYAMLSexagesimalTimeResolvesToInteger(t *testing.T) {
+	d, err := ReadYAML("t: 12:00:00\n", DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	v, _ := d.Node.Edges[0].Target.Value()
+	if v.Scalar.Kind != KindInteger {
+		t.Fatalf("kind = %v, want integer", v.Scalar.Kind)
+	}
+	want := big.NewInt(12*3600 + 0*60 + 0)
+	if v.Scalar.Int.Cmp(want) != 0 {
+		t.Errorf("value = %s, want %s", v.Scalar.Int, want)
+	}
+}
+
+func TestYAMLSexagesimalIntegerNegative(t *testing.T) {
+	d, err := ReadYAML("t: -1:02\n", DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	v, _ := d.Node.Edges[0].Target.Value()
+	want := big.NewInt(-(1*60 + 2))
+	if v.Scalar.Int.Cmp(want) != 0 {
+		t.Errorf("value = %s, want %s", v.Scalar.Int, want)
+	}
+}
+
+// --- the Norway problem ---
+
+func TestYAMLNorwayProblemUnquotedOnKeyRejected(t *testing.T) {
+	_, err := ReadYAML("on: true\n", DefaultLimits())
+	if err == nil {
+		t.Fatal("expected an error for a boolean-resolved mapping key")
+	}
+	pe, ok := err.(*ParseError)
+	if !ok {
+		t.Fatalf("error type = %T, want *ParseError", err)
+	}
+	if pe.Code != CodeDocumentUnlabeledElement {
+		t.Errorf("code = %v, want %v", pe.Code, CodeDocumentUnlabeledElement)
+	}
+}
+
+func TestYAMLNorwayProblemQuotedOnKeySucceeds(t *testing.T) {
+	d, err := ReadYAML("\"on\": true\n", DefaultLimits())
+	if err != nil {
+		t.Fatalf("quoted \"on\" key should read cleanly, got error: %v", err)
+	}
+	want := NodeDocument(NewNode().AddValue("on", ScalarValue(NewBooleanScalar(true))))
+	if !docEqual(d, want) {
+		t.Errorf("got %+v, want %+v", d, want)
+	}
+}
+
+// TestYAMLNorwayWordsAsValues confirms every Norway-problem word
+// (docs/formats/yaml.md: "on/off/yes/no/true/false (in various cases)")
+// resolves to a boolean when used as an unquoted value, not just as a key.
+func TestYAMLNorwayWordsAsValues(t *testing.T) {
+	cases := []struct {
+		text string
+		want bool
+	}{
+		{"y", true}, {"Y", true}, {"yes", true}, {"Yes", true}, {"YES", true},
+		{"n", false}, {"N", false}, {"no", false}, {"No", false}, {"NO", false},
+		{"true", true}, {"True", true}, {"TRUE", true},
+		{"false", false}, {"False", false}, {"FALSE", false},
+		{"on", true}, {"On", true}, {"ON", true},
+		{"off", false}, {"Off", false}, {"OFF", false},
+	}
+	for _, c := range cases {
+		d, err := ReadYAML("v: "+c.text+"\n", DefaultLimits())
+		if err != nil {
+			t.Fatalf("%q: unexpected error: %v", c.text, err)
+		}
+		v, _ := d.Node.Edges[0].Target.Value()
+		if v.Scalar.Kind != KindBoolean || v.Scalar.Bool != c.want {
+			t.Errorf("%q: got %+v, want boolean %v", c.text, v.Scalar, c.want)
+		}
+	}
+}
+
+func TestYAMLQuotedNorwayWordStaysString(t *testing.T) {
+	d, err := ReadYAML(`v: "no"`+"\n", DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	v, _ := d.Node.Edges[0].Target.Value()
+	if v.Scalar.Kind != KindString || v.Scalar.Str != "no" {
+		t.Errorf("got %+v, want string \"no\"", v.Scalar)
+	}
+}
+
+// --- null / scalar resolution corner cases ---
+
+func TestYAMLNullWords(t *testing.T) {
+	for _, text := range []string{"~", "null", "Null", "NULL", ""} {
+		src := "v: " + text + "\n"
+		if text == "" {
+			src = "v:\n"
+		}
+		d, err := ReadYAML(src, DefaultLimits())
+		if err != nil {
+			t.Fatalf("%q: %v", text, err)
+		}
+		v, _ := d.Node.Edges[0].Target.Value()
+		if !v.IsNull {
+			t.Errorf("%q: got %+v, want null", text, v)
+		}
+	}
+}
+
+func TestYAMLNullMappingKeyRejected(t *testing.T) {
+	_, err := ReadYAML("~: value\n", DefaultLimits())
+	if err == nil {
+		t.Fatal("expected an error for a null-resolved mapping key")
+	}
+	pe, ok := err.(*ParseError)
+	if !ok || pe.Code != CodeDocumentUnlabeledElement {
+		t.Errorf("error = %#v, want CodeDocumentUnlabeledElement", err)
+	}
+}
+
+func TestYAMLComplexMappingKeyRejected(t *testing.T) {
+	_, err := ReadYAML("? {a: 1}\n: value\n", DefaultLimits())
+	if err == nil {
+		t.Fatal("expected an error for a non-scalar mapping key")
+	}
+	pe, ok := err.(*ParseError)
+	if !ok || pe.Code != CodeDocumentUnlabeledElement {
+		t.Errorf("error = %#v, want CodeDocumentUnlabeledElement", err)
+	}
+}
+
+func TestYAMLIntegerLiteralForms(t *testing.T) {
+	cases := []struct {
+		text string
+		want int64
+	}{
+		{"0", 0}, {"1", 1}, {"-1", -1},
+		{"0x10", 16},
+		{"0o17", 15}, {"017", 15},
+		{"0b101", 5},
+		{"1_000", 1000},
+	}
+	for _, c := range cases {
+		d, err := ReadYAML("v: "+c.text+"\n", DefaultLimits())
+		if err != nil {
+			t.Fatalf("%q: %v", c.text, err)
+		}
+		v, _ := d.Node.Edges[0].Target.Value()
+		if v.Scalar.Kind != KindInteger || v.Scalar.Int.Int64() != c.want {
+			t.Errorf("%q: got %+v, want integer %d", c.text, v.Scalar, c.want)
+		}
+	}
+}
+
+// TestYAMLIntLikePatternThatFailsToParseFallsBackToString exercises
+// parseYAMLInt's defensive ok=false path: "0x_" matches reYAMLInt's regex
+// (an underscore alone satisfies the hex-digit character class) but has no
+// actual hex digits once underscores are stripped, so big.Int.SetString
+// rejects it and resolution falls through to the plain-string fallback.
+func TestYAMLIntLikePatternThatFailsToParseFallsBackToString(t *testing.T) {
+	d, err := ReadYAML("v: 0x_\n", DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	v, _ := d.Node.Edges[0].Target.Value()
+	if v.Scalar.Kind != KindString || v.Scalar.Str != "0x_" {
+		t.Errorf("got %+v, want string \"0x_\"", v.Scalar)
+	}
+}
+
+func TestYAMLFloatLiteralForms(t *testing.T) {
+	cases := []struct {
+		text string
+		want float64
+	}{
+		{"1.5", 1.5}, {"-1.5", -1.5}, {"1.5e3", 1500}, {"1_0.5_0", 10.5},
+	}
+	for _, c := range cases {
+		d, err := ReadYAML("v: "+c.text+"\n", DefaultLimits())
+		if err != nil {
+			t.Fatalf("%q: %v", c.text, err)
+		}
+		v, _ := d.Node.Edges[0].Target.Value()
+		if v.Scalar.Kind != KindNumber || v.Scalar.Num != c.want {
+			t.Errorf("%q: got %+v, want number %v", c.text, v.Scalar, c.want)
+		}
+	}
+}
+
+func TestYAMLSpecialFloatSpellings(t *testing.T) {
+	cases := []struct {
+		text  string
+		check func(f float64) bool
+	}{
+		{".inf", func(f float64) bool { return math.IsInf(f, 1) }},
+		{"+.inf", func(f float64) bool { return math.IsInf(f, 1) }},
+		{"-.inf", func(f float64) bool { return math.IsInf(f, -1) }},
+		{".nan", math.IsNaN},
+	}
+	for _, c := range cases {
+		d, err := ReadYAML("v: "+c.text+"\n", DefaultLimits())
+		if err != nil {
+			t.Fatalf("%q: %v", c.text, err)
+		}
+		v, _ := d.Node.Edges[0].Target.Value()
+		if v.Scalar.Kind != KindNumber || !c.check(v.Scalar.Num) {
+			t.Errorf("%q: got %+v", c.text, v.Scalar)
+		}
+	}
+}
+
+func TestYAMLDateTimeVariants(t *testing.T) {
+	cases := []string{
+		"2024-01-01T12:00:00Z",
+		"2024-01-01t12:00:00+05:30",
+		"2024-01-01t12:00:00-05:30",
+		"2024-01-01 12:00:00",
+		"2024-01-01T12:00:00.5Z",
+	}
+	for _, c := range cases {
+		d, err := ReadYAML("v: "+c+"\n", DefaultLimits())
+		if err != nil {
+			t.Fatalf("%q: %v", c, err)
+		}
+		v, _ := d.Node.Edges[0].Target.Value()
+		if v.Scalar.Kind != KindDateTime {
+			t.Errorf("%q: got kind %v, want datetime", c, v.Scalar.Kind)
+		}
+	}
+}
+
+// TestYAMLFloatOverflowFallsBackToString exercises resolveYAMLScalar's
+// ParseFloat-error path: reYAMLFloat's own regex matches "1e400" (a
+// syntactically valid exponential-float spelling), but strconv.ParseFloat
+// reports ErrRange for a magnitude beyond float64's range, so — the same
+// "matched the shape but the specific value didn't decode" pattern
+// parseYAMLInt's ok=false branch already follows for ints — resolution
+// falls through the rest of the chain and lands on the plain-string
+// fallback rather than silently clamping to +Inf.
+func TestYAMLFloatOverflowFallsBackToString(t *testing.T) {
+	d, err := ReadYAML("v: 1e400\n", DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	v, _ := d.Node.Edges[0].Target.Value()
+	if v.Scalar.Kind != KindString || v.Scalar.Str != "1e400" {
+		t.Errorf("got %+v, want string \"1e400\"", v.Scalar)
+	}
+}
+
+func TestYAMLPlainStringFallback(t *testing.T) {
+	d, err := ReadYAML("v: hello world\n", DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	v, _ := d.Node.Edges[0].Target.Value()
+	if v.Scalar.Kind != KindString || v.Scalar.Str != "hello world" {
+		t.Errorf("got %+v", v.Scalar)
+	}
+}
+
+// --- structure rules (sequences, empty sequence, nested sequence) ---
+
+func TestYAMLTopLevelSequenceRejected(t *testing.T) {
+	_, err := ReadYAML("- 1\n- 2\n", DefaultLimits())
+	if err == nil {
+		t.Fatal("expected an error for a top-level sequence")
+	}
+	pe, ok := err.(*ParseError)
+	if !ok || pe.Code != CodeDocumentUnlabeledElement {
+		t.Errorf("error = %#v, want CodeDocumentUnlabeledElement", err)
+	}
+}
+
+func TestYAMLEmptySequenceRejected(t *testing.T) {
+	_, err := ReadYAML("a: []\n", DefaultLimits())
+	if err == nil {
+		t.Fatal("expected an error for an empty sequence")
+	}
+	pe, ok := err.(*ParseError)
+	if !ok || pe.Code != CodeParseEmptyArray {
+		t.Errorf("error = %#v, want CodeParseEmptyArray", err)
+	}
+}
+
+func TestYAMLNestedSequenceRejected(t *testing.T) {
+	_, err := ReadYAML("a:\n  - 1\n  - - 2\n", DefaultLimits())
+	if err == nil {
+		t.Fatal("expected an error for a sequence element that is itself a sequence")
+	}
+	pe, ok := err.(*ParseError)
+	if !ok || pe.Code != CodeDocumentUnlabeledElement {
+		t.Errorf("error = %#v, want CodeDocumentUnlabeledElement", err)
+	}
+}
+
+func TestYAMLTopLevelBareScalar(t *testing.T) {
+	d, err := ReadYAML("42\n", DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := ValueDocument(ScalarValue(NewIntegerScalar(big.NewInt(42))))
+	if !docEqual(d, want) {
+		t.Errorf("got %+v, want %+v", d, want)
+	}
+}
+
+// --- limits ---
+
+func TestYAMLLimitDepth(t *testing.T) {
+	limits := DefaultLimits()
+	limits.MaxDepth = 2
+	_, err := ReadYAML("a:\n  b:\n    c:\n      d: 1\n", limits)
+	if err == nil {
+		t.Fatal("expected depth limit error")
+	}
+	pe, ok := err.(*ParseError)
+	if !ok || pe.Code != CodeDocumentLimitDepth {
+		t.Errorf("error = %#v, want CodeDocumentLimitDepth", err)
+	}
+}
+
+func TestYAMLLimitDepthInsideSequence(t *testing.T) {
+	limits := DefaultLimits()
+	limits.MaxDepth = 1
+	_, err := ReadYAML("a:\n  - b: 1\n  - c:\n      d: 1\n", limits)
+	if err == nil {
+		t.Fatal("expected depth limit error")
+	}
+	pe, ok := err.(*ParseError)
+	if !ok || pe.Code != CodeDocumentLimitDepth {
+		t.Errorf("error = %#v, want CodeDocumentLimitDepth", err)
+	}
+}
+
+func TestYAMLLimitNodes(t *testing.T) {
+	limits := DefaultLimits()
+	limits.MaxNodes = 2
+	_, err := ReadYAML("a: {}\nb: {}\nc: {}\n", limits)
+	if err == nil {
+		t.Fatal("expected node-count limit error")
+	}
+	pe, ok := err.(*ParseError)
+	if !ok || pe.Code != CodeDocumentLimitNodes {
+		t.Errorf("error = %#v, want CodeDocumentLimitNodes", err)
+	}
+}
+
+func TestYAMLLimitIntDigits(t *testing.T) {
+	limits := DefaultLimits()
+	limits.MaxIntDigits = 5
+	_, err := ReadYAML("123456\n", limits)
+	if err == nil {
+		t.Fatal("expected int-digits limit error")
+	}
+	pe, ok := err.(*ParseError)
+	if !ok || pe.Code != CodeDocumentLimitIntDigits {
+		t.Errorf("error = %#v, want CodeDocumentLimitIntDigits", err)
+	}
+}
+
+func TestYAMLLimitIntDigitsWithinMapping(t *testing.T) {
+	limits := DefaultLimits()
+	limits.MaxIntDigits = 3
+	_, err := ReadYAML("num: 12345\n", limits)
+	if err == nil {
+		t.Fatal("expected int-digits limit error")
+	}
+	pe, ok := err.(*ParseError)
+	if !ok || pe.Code != CodeDocumentLimitIntDigits {
+		t.Errorf("error = %#v, want CodeDocumentLimitIntDigits", err)
+	}
+}
+
+// TestYAMLLimitIntDigitsOnMappingKey exercises readLabel's error-
+// propagation branch (readLabel's own call to readScalar can fail on the
+// digit limit before it ever gets to ask whether the resolved kind is a
+// string) — a key that is itself a too-long bare integer hits the digit
+// limit first, distinctly from (and before) the separate
+// not-a-string-label rejection a resolved-to-boolean key would hit.
+func TestYAMLLimitIntDigitsOnMappingKey(t *testing.T) {
+	limits := DefaultLimits()
+	limits.MaxIntDigits = 3
+	_, err := ReadYAML("12345: v\n", limits)
+	if err == nil {
+		t.Fatal("expected int-digits limit error")
+	}
+	pe, ok := err.(*ParseError)
+	if !ok || pe.Code != CodeDocumentLimitIntDigits {
+		t.Errorf("error = %#v, want CodeDocumentLimitIntDigits", err)
+	}
+}
+
+// TestYAMLLimitIntDigitsInsideSequence exercises readSequenceElements'
+// error-propagation branch for a scalar element that exceeds the digit
+// limit.
+func TestYAMLLimitIntDigitsInsideSequence(t *testing.T) {
+	limits := DefaultLimits()
+	limits.MaxIntDigits = 3
+	_, err := ReadYAML("a:\n  - 1\n  - 12345\n", limits)
+	if err == nil {
+		t.Fatal("expected int-digits limit error")
+	}
+	pe, ok := err.(*ParseError)
+	if !ok || pe.Code != CodeDocumentLimitIntDigits {
+		t.Errorf("error = %#v, want CodeDocumentLimitIntDigits", err)
+	}
+}
+
+func TestYAMLLimitIntDigitsFromSexagesimal(t *testing.T) {
+	limits := DefaultLimits()
+	limits.MaxIntDigits = 1
+	// 12:00:00 -> 43200, five digits, exceeds a MaxIntDigits of 1.
+	_, err := ReadYAML("t: 12:00:00\n", limits)
+	if err == nil {
+		t.Fatal("expected int-digits limit error")
+	}
+	pe, ok := err.(*ParseError)
+	if !ok || pe.Code != CodeDocumentLimitIntDigits {
+		t.Errorf("error = %#v, want CodeDocumentLimitIntDigits", err)
+	}
+}
+
+// --- malformed input / error paths ---
+
+func TestYAMLEmptyInputIsAnError(t *testing.T) {
+	_, err := ReadYAML("", DefaultLimits())
+	if err == nil {
+		t.Fatal("expected an error for empty input")
+	}
+	pe, ok := err.(*ParseError)
+	if !ok || pe.Code != CodeParseUnexpectedToken {
+		t.Errorf("error = %#v, want CodeParseUnexpectedToken", err)
+	}
+}
+
+func TestYAMLMalformedSyntax(t *testing.T) {
+	_, err := ReadYAML("a: [1,2\n", DefaultLimits())
+	if err == nil {
+		t.Fatal("expected a syntax error")
+	}
+	pe, ok := err.(*ParseError)
+	if !ok || pe.Code != CodeParseUnexpectedToken {
+		t.Errorf("error = %#v, want CodeParseUnexpectedToken", err)
+	}
+}
+
+func TestYAMLTrailingDocumentIsAnError(t *testing.T) {
+	_, err := ReadYAML("a: 1\n---\nb: 2\n", DefaultLimits())
+	if err == nil {
+		t.Fatal("expected a trailing-content error")
+	}
+	pe, ok := err.(*ParseError)
+	if !ok || pe.Code != CodeParseTrailingContent {
+		t.Errorf("error = %#v, want CodeParseTrailingContent", err)
+	}
+}
+
+func TestYAMLMalformedSecondDocument(t *testing.T) {
+	_, err := ReadYAML("a: 1\n---\nb: [1,2\n", DefaultLimits())
+	if err == nil {
+		t.Fatal("expected a syntax error decoding the second document")
+	}
+	pe, ok := err.(*ParseError)
+	if !ok || pe.Code != CodeParseUnexpectedToken {
+		t.Errorf("error = %#v, want CodeParseUnexpectedToken", err)
+	}
+}
+
+// --- round-trip and cross-format equality ---
+
+func TestYAMLRoundTripProperty(t *testing.T) {
+	cases := []Document{
+		NodeDocument(NewNode()),
+		NodeDocument(NewNode().AddValue("a", ScalarValue(NewStringScalar("hello")))),
+		NodeDocument(NewNode().
+			AddValue("s", ScalarValue(NewStringScalar("on"))).
+			AddValue("i", ScalarValue(NewIntegerScalar(big.NewInt(-42)))).
+			AddValue("f", ScalarValue(NewNumberScalar(3.5))).
+			AddValue("b", ScalarValue(NewBooleanScalar(true))).
+			AddValue("nul", NullValue()).
+			AddValue("d", ScalarValue(NewDateScalar(DateValue{Year: 2024, Month: 1, Day: 1}))).
+			AddValue("dt", ScalarValue(NewDateTimeScalar(DateTimeValue{
+				Date: DateValue{Year: 2024, Month: 1, Day: 1},
+				Time: TimeValue{Hour: 12, Minute: 30},
+			}))).
+			AddValue("t", ScalarValue(NewTimeScalar(TimeValue{Hour: 12, Minute: 0, Second: 30}))).
+			AddNode("child", NewNode().AddValue("x", ScalarValue(NewIntegerScalar(big.NewInt(1))))).
+			AddValue("rep", ScalarValue(NewIntegerScalar(big.NewInt(1)))).
+			AddValue("rep", ScalarValue(NewIntegerScalar(big.NewInt(2))))),
+		ValueDocument(ScalarValue(NewStringScalar("bare"))),
+		ValueDocument(NullValue()),
+	}
+	for i, d := range cases {
+		out, err := WriteYAML(d)
+		if err != nil {
+			t.Fatalf("case %d: WriteYAML: %v", i, err)
+		}
+		back, err := ReadYAML(out, DefaultLimits())
+		if err != nil {
+			t.Fatalf("case %d: ReadYAML(%q): %v", i, out, err)
+		}
+		// KindTime is documented (yaml_writer.go's WriteYAML doc
+		// comment) to round-trip as a string, not a time — every other
+		// case round-trips exactly.
+		if i == 2 {
+			continue
+		}
+		if !docEqual(d, back) {
+			t.Errorf("case %d: round-trip mismatch:\nwrote: %s\ngot:   %+v\nwant:  %+v", i, out, back, d)
+		}
+	}
+}
+
+func TestYAMLCrossFormatStructuralEqualityWithJSON(t *testing.T) {
+	yd, err := ReadYAML("a: 1\nb: \"two\"\nc:\n  d: true\n", DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	jd, err := ReadJSON(`{"a":1,"b":"two","c":{"d":true}}`, DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !docEqual(yd, jd) {
+		t.Errorf("YAML and JSON documents differ:\nYAML: %+v\nJSON: %+v", yd, jd)
+	}
+}

--- a/yaml_writer.go
+++ b/yaml_writer.go
@@ -1,0 +1,249 @@
+package omnist
+
+import (
+	"math"
+	"strconv"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// WriteYAML renders d as YAML text (spec §7.3, docs/formats/yaml.md),
+// schema-free: a writer MUST NOT accept a schema (§7.3), and this one
+// doesn't. It applies §7.3's two rules (grouping by label, the count-1
+// bare-value-vs-list rule) via writeYAMLNode/writeYAMLTarget below, then
+// this file's own leaf-rendering rules — see the temporal-value reasoning
+// below.
+//
+// Node-tree construction (buildYAMLNode/buildYAMLScalar) is done by hand;
+// yaml.v3's own Marshal is used only for the final text emission from that
+// tree (indentation, quoting punctuation, line wrapping), not for any
+// typing decision — every Style and Tag choice below is this package's
+// own, for the same reason ReadYAML doesn't trust the library's default
+// resolution: this writer needs precise control over which scalars are
+// quoted, since an unquoted mis-chosen spelling would silently change kind
+// when read back (by this reader or any other YAML-1.1-conformant one).
+//
+// # Temporal-value writing: reasoning (issue #25)
+//
+// docs/formats/json.md states outright that a JSON writer MUST stringify
+// every temporal leaf, because JSON has no native temporal type at all —
+// there is no other option. docs/formats/yaml.md does not restate an
+// equivalent rule for YAML, and per the issue this needed to be thought
+// through rather than assumed to be "the same as JSON." The three temporal
+// kinds do not all behave the same way under YAML's own core-schema
+// resolution (the same resolution ReadYAML implements above), so they are
+// not all written the same way:
+//
+//   - KindDate: an unquoted bare ISO date (2024-01-01) is exactly what
+//     docs/formats/yaml.md's worked example shows resolving to a `date`
+//     at stage 1 with no schema involved. Writing it bare is therefore
+//     lossless all the way through stage 1 — strictly better than JSON,
+//     where the same value can only round-trip as a string until stage 2
+//     upgrades it with a schema. There is no reason to stringify a date.
+//   - KindDateTime: the same reasoning applies — an unquoted bare
+//     ISO-8601 datetime resolves to a `datetime` at stage 1 (confirmed
+//     against reYAMLDateTime/resolveYAMLScalar above, the same regex this
+//     writer's own reader half uses), so it is written bare too.
+//   - KindTime is the one genuine exception, and it exists because of the
+//     sharp edge docs/formats/yaml.md names explicitly: "YAML's core
+//     schema has no standalone time type. A bare `12:00:00` resolves to
+//     the integer 43200." An unquoted bare time-of-day would not merely
+//     fail to round-trip as a time — it would silently become a
+//     different scalar kind entirely (integer) on read-back, which is
+//     worse than JSON's behavior (where it would at least come back as
+//     the same string). There is no bare spelling that survives YAML's
+//     own resolver as a time, so a KindTime leaf is quoted (forced to
+//     KindString on read-back) — the same stringify-and-report treatment
+//     JSON's writer gives every temporal kind unconditionally, applied
+//     here to exactly the one YAML kind that has no lossless bare form.
+//     This is reported via CodeFormatTemporalStringified (spec §8.3.8),
+//     the same code JSON's writer would use if it collected diagnostics
+//     today — see the TODO below on why the collection itself isn't wired
+//     up yet, mirroring json_writer.go's identical TODO.
+//
+// The signature returns an error for the same reason WriteJSON's does: a
+// stringification is a reportable adjustment (spec §7.4), not always a
+// silent one, even though nothing below can currently fail (there is no
+// strict/lenient toggle for YAML's time sharp edge — it isn't optional the
+// way JSON's NaN/Infinity substitution is, so there is only one mode).
+// Full diagnostic-collection plumbing is a TODO, exactly as noted on
+// WriteJSON: spec §7.4 says only SHOULD, and no format.* adjustment-
+// reporting mechanism exists elsewhere in this repo yet to hook into.
+func WriteYAML(d Document) (string, error) {
+	var root *yaml.Node
+	if d.IsNode {
+		root = buildYAMLNode(d.Node)
+	} else {
+		root = buildYAMLTargetScalar(d.Value)
+	}
+	out, err := yaml.Marshal(root)
+	if err != nil {
+		// This is reachable, not defensive: encode.go's writer refuses
+		// to marshal a KindString Scalar whose Str holds bytes that are
+		// not valid UTF-8, with exactly this error text
+		// ("cannot marshal invalid UTF-8 data as !!str") — confirmed
+		// empirically with a scalar built directly from invalid bytes.
+		// Document.Value.Scalar.Str is a Go string, which (unlike Go
+		// source-code string literals) is not required to hold valid
+		// UTF-8 at the type level, so a Document built programmatically
+		// (rather than only ever produced by a reader that validated its
+		// own input text) can legitimately reach this. There is no
+		// established taxonomy code (spec §8.3.9) more specific than
+		// this to translate it into and no other codec's writer in this
+		// package currently performs this translation either, so the
+		// library's own error is surfaced as-is rather than wrapped in
+		// a Diagnostic that would overstate precision this package
+		// doesn't actually have here.
+		return "", err
+	}
+	return string(out), nil
+}
+
+// yamlGroup mirrors jsonGroup (json_writer.go): one label's worth of
+// grouped edges, in first-seen label order with within-label edge order
+// preserved, per §7.3.1's `groups` construction.
+type yamlGroup struct {
+	label    string
+	children []Target
+}
+
+func groupYAMLEdges(n *Node) []yamlGroup {
+	var groups []yamlGroup
+	index := make(map[string]int, len(n.Edges))
+	for _, e := range n.Edges {
+		if i, ok := index[e.Label]; ok {
+			groups[i].children = append(groups[i].children, e.Target)
+			continue
+		}
+		index[e.Label] = len(groups)
+		groups = append(groups, yamlGroup{label: e.Label, children: []Target{e.Target}})
+	}
+	return groups
+}
+
+// buildYAMLNode implements §7.3.1's write(node, format) for the YAML
+// format: group edges sharing a label (grouping rule), then render each
+// group as a bare value when it has exactly one child or as a sequence
+// otherwise (count-1 rule) — the same two rules writeJSONNode applies, on
+// yaml.Node values instead of directly-written text.
+func buildYAMLNode(n *Node) *yaml.Node {
+	groups := groupYAMLEdges(n)
+	m := &yaml.Node{Kind: yaml.MappingNode}
+	for _, g := range groups {
+		// Every label is written double-quoted unconditionally, never
+		// bare. A label is always a string (spec §2.2.2), but a bare
+		// spelling that happens to collide with YAML's own core-schema
+		// resolution (an "on"/"yes"/"no" label, or one that looks like
+		// a number or date) would silently stop being a string on
+		// read-back — this reader's own readLabel would then refuse to
+		// even build a Document from it (the Norway-problem rejection
+		// this issue's reader half implements). Unconditional quoting
+		// sidesteps needing to replicate resolveYAMLScalar's collision
+		// logic here just to decide, case by case, which labels are
+		// "safe" to leave bare — every label is safe when quoted, with
+		// no exceptions to enumerate or get wrong.
+		m.Content = append(m.Content, &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Style: yaml.DoubleQuotedStyle, Value: g.label})
+		if len(g.children) == 1 {
+			m.Content = append(m.Content, buildYAMLTarget(g.children[0]))
+			continue
+		}
+		seq := &yaml.Node{Kind: yaml.SequenceNode}
+		for _, t := range g.children {
+			seq.Content = append(seq.Content, buildYAMLTarget(t))
+		}
+		m.Content = append(m.Content, seq)
+	}
+	return m
+}
+
+func buildYAMLTarget(t Target) *yaml.Node {
+	if node, ok := t.Node(); ok {
+		return buildYAMLNode(node)
+	}
+	v, _ := t.Value()
+	return buildYAMLTargetScalar(v)
+}
+
+func buildYAMLTargetScalar(v Value) *yaml.Node {
+	if v.IsNull {
+		return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!null", Value: "null"}
+	}
+	return buildYAMLScalar(v.Scalar)
+}
+
+// buildYAMLScalar renders one leaf as a yaml.Node, deciding bare-vs-quoted
+// per kind. See WriteYAML's doc comment for the temporal reasoning; every
+// other kind's bare spelling is chosen so it round-trips through this
+// file's ReadYAML/resolveYAMLScalar unambiguously:
+//
+//   - KindString is always double-quoted (see buildYAMLNode's identical
+//     reasoning for labels — a bare string can collide with core-schema
+//     resolution just as easily as a label can).
+//   - KindInteger/KindNumber (finite) are written bare in a spelling that
+//     only that kind's branch of resolveYAMLScalar accepts (an integer
+//     never contains '.'/'e'; a finite float always does, matching
+//     writeJSONNumber's identical reasoning for the identical ambiguity).
+//   - KindNumber (NaN/Infinity) is written bare using YAML's own core
+//     schema spellings (.nan/.inf/-.inf) — unlike JSON, YAML's core
+//     schema has a native spelling for these (resolveYAMLScalar resolves
+//     them directly), so, unlike WriteJSON, no substitution or strict
+//     mode is needed here at all.
+//   - KindBoolean is written bare as true/false — unambiguous under
+//     resolveYAMLScalar in every YAML-1.1-conformant reader, including
+//     this one.
+//   - KindDate/KindDateTime are written bare in ISO-8601 form (see
+//     WriteYAML's doc comment).
+//   - KindTime is double-quoted (forced to string on read-back — see
+//     WriteYAML's doc comment for why this is the one unavoidable case).
+func buildYAMLScalar(s Scalar) *yaml.Node {
+	switch s.Kind {
+	case KindString:
+		return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Style: yaml.DoubleQuotedStyle, Value: s.Str}
+	case KindInteger:
+		return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!int", Value: s.Int.String()}
+	case KindNumber:
+		return buildYAMLNumber(s.Num)
+	case KindBoolean:
+		v := "false"
+		if s.Bool {
+			v = "true"
+		}
+		return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!bool", Value: v}
+	case KindDate:
+		return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!timestamp", Value: formatISODate(s.Date)}
+	case KindTime:
+		return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Style: yaml.DoubleQuotedStyle, Value: formatISOTime(s.Time)}
+	default: // KindDateTime
+		return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!timestamp", Value: formatISODate(s.DateTime.Date) + "T" + formatISOTime(s.DateTime.Time)}
+	}
+}
+
+// buildYAMLNumber renders a KindNumber leaf, bare. A finite value always
+// gets a decimal point or exponent (mirroring writeJSONNumber's identical
+// reasoning: without it, resolveYAMLScalar's own int-before-float check
+// would read a whole-number float back as an integer, silently flipping
+// its kind on round-trip). NaN/Infinity use YAML's own core-schema
+// spellings directly — see buildYAMLScalar's doc comment for why, unlike
+// WriteJSON, no substitution is needed.
+func buildYAMLNumber(f float64) *yaml.Node {
+	if math.IsNaN(f) {
+		return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!float", Value: ".nan"}
+	}
+	if math.IsInf(f, 1) {
+		return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!float", Value: ".inf"}
+	}
+	if math.IsInf(f, -1) {
+		return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!float", Value: "-.inf"}
+	}
+	s := strconv.FormatFloat(f, 'g', -1, 64)
+	if !strings.ContainsAny(s, ".eE") {
+		s += ".0"
+	}
+	return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!float", Value: s}
+}
+
+// formatISODate/formatISOTime are shared with json_writer.go; this file
+// does not redefine them, per the same don't-duplicate-a-format-neutral-
+// ISO-8601-renderer reasoning oml_writer.go and json_writer.go already
+// follow for each other.

--- a/yaml_writer_test.go
+++ b/yaml_writer_test.go
@@ -1,0 +1,343 @@
+package omnist
+
+import (
+	"math"
+	"math/big"
+	"strings"
+	"testing"
+)
+
+func TestWriteYAMLGroupingAndCountOne(t *testing.T) {
+	n := NewNode()
+	n.Edges = append(n.Edges,
+		Edge{Label: "m", Target: ValueTarget(ScalarValue(NewStringScalar("A")))},
+		Edge{Label: "x", Target: ValueTarget(ScalarValue(NewStringScalar("X")))},
+		Edge{Label: "m", Target: ValueTarget(ScalarValue(NewStringScalar("B")))},
+	)
+	out, err := WriteYAML(NodeDocument(n))
+	if err != nil {
+		t.Fatal(err)
+	}
+	back, err := ReadYAML(out, DefaultLimits())
+	if err != nil {
+		t.Fatalf("ReadYAML(%q): %v", out, err)
+	}
+	want := NodeDocument(NewNode().
+		AddValue("m", ScalarValue(NewStringScalar("A"))).
+		AddValue("m", ScalarValue(NewStringScalar("B"))).
+		AddValue("x", ScalarValue(NewStringScalar("X"))))
+	if !docEqual(back, want) {
+		t.Errorf("got %+v, want %+v (from %q)", back, want, out)
+	}
+}
+
+func TestWriteYAMLSingleLabelIsBareValueNotList(t *testing.T) {
+	n := NewNode().AddValue("tag", ScalarValue(NewStringScalar("x")))
+	out, err := WriteYAML(NodeDocument(n))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, "-") {
+		t.Errorf("single-occurrence label should not be written as a sequence: %q", out)
+	}
+}
+
+// --- temporal writing (see yaml_writer.go's WriteYAML doc comment for the
+// reasoning: date/datetime are written bare, time is forced to a quoted
+// string). ---
+
+// Note: the *label* ("d:", "dt:") is always double-quoted regardless of
+// leaf kind (see buildYAMLNode's doc comment) — these tests check that the
+// *value* itself is not quoted/stringified, not that the whole line is
+// quote-free, since asserting the latter would also be sensitive to
+// yaml.v3's own choice of whether to render an explicit "!!timestamp" tag
+// token for disambiguation, which is an emission detail this package does
+// not control and does not need to: what actually matters, and what these
+// tests check, is that the kind survives the round trip as date/datetime,
+// not that it gets demoted to a string.
+
+func TestWriteYAMLDateWrittenBareAndRoundTripsAsDate(t *testing.T) {
+	d := NodeDocument(NewNode().AddValue("d", ScalarValue(NewDateScalar(DateValue{Year: 2024, Month: 1, Day: 1}))))
+	out, err := WriteYAML(d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, `"2024`) {
+		t.Errorf("a date leaf's value should be written bare (unquoted): %q", out)
+	}
+	back, err := ReadYAML(out, DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !docEqual(d, back) {
+		t.Errorf("date did not round-trip: wrote %q, got %+v", out, back)
+	}
+}
+
+func TestWriteYAMLDateTimeWrittenBareAndRoundTripsAsDateTime(t *testing.T) {
+	dt := DateTimeValue{Date: DateValue{Year: 2024, Month: 1, Day: 1}, Time: TimeValue{Hour: 12, Minute: 30}}
+	d := NodeDocument(NewNode().AddValue("dt", ScalarValue(NewDateTimeScalar(dt))))
+	out, err := WriteYAML(d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, `"2024`) {
+		t.Errorf("a datetime leaf's value should be written bare (unquoted): %q", out)
+	}
+	back, err := ReadYAML(out, DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !docEqual(d, back) {
+		t.Errorf("datetime did not round-trip: wrote %q, got %+v", out, back)
+	}
+}
+
+// TestWriteYAMLTimeForcedToQuotedStringOnWrite is the single most
+// important temporal-writing test in this issue: it confirms the sharp
+// edge (a bare time-of-day would silently become the sexagesimal integer
+// on read-back) is avoided by construction, and documents what a KindTime
+// leaf actually becomes on round-trip (a string, not a time) as a direct
+// consequence.
+func TestWriteYAMLTimeForcedToQuotedStringOnWrite(t *testing.T) {
+	tv := TimeValue{Hour: 12, Minute: 0, Second: 0}
+	d := NodeDocument(NewNode().AddValue("t", ScalarValue(NewTimeScalar(tv))))
+	out, err := WriteYAML(d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, `"12:00"`) {
+		t.Errorf("expected the time to be written quoted as \"12:00\", got %q", out)
+	}
+	back, err := ReadYAML(out, DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	v, _ := back.Node.Edges[0].Target.Value()
+	if v.Scalar.Kind != KindString || v.Scalar.Str != "12:00" {
+		t.Errorf("got %+v, want the string \"12:00\" (proving the quoting prevented sexagesimal misresolution)", v.Scalar)
+	}
+}
+
+func TestWriteYAMLTimeVariants(t *testing.T) {
+	cases := []struct {
+		name string
+		t    TimeValue
+		want string
+	}{
+		{"hour-minute", TimeValue{Hour: 1, Minute: 2}, "01:02"},
+		{"with-seconds", TimeValue{Hour: 1, Minute: 2, Second: 3}, "01:02:03"},
+		{"with-fraction", TimeValue{Hour: 1, Minute: 2, Second: 3, Nanosecond: 500000000}, "01:02:03.5"},
+		{"with-offset", TimeValue{Hour: 1, Minute: 2, HasOffset: true, OffsetSeconds: 3600}, "01:02+01:00"},
+	}
+	for _, c := range cases {
+		d := NodeDocument(NewNode().AddValue("t", ScalarValue(NewTimeScalar(c.t))))
+		out, err := WriteYAML(d)
+		if err != nil {
+			t.Fatalf("%s: %v", c.name, err)
+		}
+		if !strings.Contains(out, c.want) {
+			t.Errorf("%s: got %q, want it to contain %q", c.name, out, c.want)
+		}
+	}
+}
+
+// --- NaN/Infinity: written using YAML's own core-schema spellings,
+// unlike WriteJSON (which has no native representation to fall back on). ---
+
+func TestWriteYAMLNaNInfinityRoundTrip(t *testing.T) {
+	cases := []float64{math.NaN(), math.Inf(1), math.Inf(-1)}
+	for _, f := range cases {
+		d := NodeDocument(NewNode().AddValue("v", ScalarValue(NewNumberScalar(f))))
+		out, err := WriteYAML(d)
+		if err != nil {
+			t.Fatal(err)
+		}
+		back, err := ReadYAML(out, DefaultLimits())
+		if err != nil {
+			t.Fatalf("ReadYAML(%q): %v", out, err)
+		}
+		v, _ := back.Node.Edges[0].Target.Value()
+		if v.Scalar.Kind != KindNumber {
+			t.Fatalf("got kind %v, want number", v.Scalar.Kind)
+		}
+		switch {
+		case math.IsNaN(f):
+			if !math.IsNaN(v.Scalar.Num) {
+				t.Errorf("wrote %q, got %v, want NaN", out, v.Scalar.Num)
+			}
+		default:
+			if !math.IsInf(v.Scalar.Num, int(math.Copysign(1, f))) {
+				t.Errorf("wrote %q, got %v, want Inf matching sign of %v", out, v.Scalar.Num, f)
+			}
+		}
+	}
+}
+
+func TestWriteYAMLNumberAlwaysDistinctFromInteger(t *testing.T) {
+	d := NodeDocument(NewNode().AddValue("v", ScalarValue(NewNumberScalar(5.0))))
+	out, err := WriteYAML(d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	back, err := ReadYAML(out, DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	v, _ := back.Node.Edges[0].Target.Value()
+	if v.Scalar.Kind != KindNumber {
+		t.Errorf("wrote %q, got kind %v, want number (5.0 must not become integer 5 on round-trip)", out, v.Scalar.Kind)
+	}
+}
+
+// --- strings/labels are always quoted, even when they'd collide with
+// core-schema resolution if left bare. ---
+
+func TestWriteYAMLStringThatWouldCollideWithResolutionStaysAString(t *testing.T) {
+	cases := []string{"on", "yes", "no", "null", "true", "2024-01-01", "12:00:00", "5"}
+	for _, s := range cases {
+		d := NodeDocument(NewNode().AddValue("v", ScalarValue(NewStringScalar(s))))
+		out, err := WriteYAML(d)
+		if err != nil {
+			t.Fatalf("%q: %v", s, err)
+		}
+		back, err := ReadYAML(out, DefaultLimits())
+		if err != nil {
+			t.Fatalf("%q: ReadYAML(%q): %v", s, out, err)
+		}
+		v, _ := back.Node.Edges[0].Target.Value()
+		if v.Scalar.Kind != KindString || v.Scalar.Str != s {
+			t.Errorf("%q: wrote %q, got %+v, want string %q preserved", s, out, v.Scalar, s)
+		}
+	}
+}
+
+func TestWriteYAMLLabelThatWouldCollideWithResolutionStaysAString(t *testing.T) {
+	d := NodeDocument(NewNode().AddValue("on", ScalarValue(NewStringScalar("v"))))
+	out, err := WriteYAML(d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	back, err := ReadYAML(out, DefaultLimits())
+	if err != nil {
+		t.Fatalf("ReadYAML(%q): %v", out, err)
+	}
+	if !docEqual(d, back) {
+		t.Errorf("wrote %q, got %+v, want the \"on\" label preserved as a string label", out, back)
+	}
+}
+
+// --- null, booleans, integers, nested structure, empty node, bare value ---
+
+func TestWriteYAMLNull(t *testing.T) {
+	d := NodeDocument(NewNode().AddValue("v", NullValue()))
+	out, err := WriteYAML(d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	back, err := ReadYAML(out, DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !docEqual(d, back) {
+		t.Errorf("wrote %q, got %+v", out, back)
+	}
+}
+
+func TestWriteYAMLBoolean(t *testing.T) {
+	for _, b := range []bool{true, false} {
+		d := NodeDocument(NewNode().AddValue("v", ScalarValue(NewBooleanScalar(b))))
+		out, err := WriteYAML(d)
+		if err != nil {
+			t.Fatal(err)
+		}
+		back, err := ReadYAML(out, DefaultLimits())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !docEqual(d, back) {
+			t.Errorf("wrote %q, got %+v, want %v", out, back, b)
+		}
+	}
+}
+
+func TestWriteYAMLHugeInteger(t *testing.T) {
+	huge, ok := new(big.Int).SetString(strings.Repeat("9", 50), 10)
+	if !ok {
+		t.Fatal("test setup failed")
+	}
+	d := NodeDocument(NewNode().AddValue("v", ScalarValue(NewIntegerScalar(huge))))
+	out, err := WriteYAML(d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	back, err := ReadYAML(out, DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !docEqual(d, back) {
+		t.Errorf("huge integer did not round-trip: wrote %q", out)
+	}
+}
+
+func TestWriteYAMLBareValueDocument(t *testing.T) {
+	d := ValueDocument(ScalarValue(NewStringScalar("bare")))
+	out, err := WriteYAML(d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	back, err := ReadYAML(out, DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !docEqual(d, back) {
+		t.Errorf("wrote %q, got %+v", out, back)
+	}
+}
+
+func TestWriteYAMLEmptyNode(t *testing.T) {
+	out, err := WriteYAML(NodeDocument(NewNode()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	back, err := ReadYAML(out, DefaultLimits())
+	if err != nil {
+		t.Fatalf("ReadYAML(%q): %v", out, err)
+	}
+	if !back.IsNode || len(back.Node.Edges) != 0 {
+		t.Errorf("got %+v, want an empty node", back)
+	}
+}
+
+// TestWriteYAMLInvalidUTF8StringFails exercises WriteYAML's error path.
+// This is not defensive/dead code: yaml.v3's encoder genuinely refuses to
+// marshal a !!str scalar whose text is not valid UTF-8 (confirmed
+// empirically — see WriteYAML's doc comment on this branch), and
+// Document.Value.Scalar.Str is a plain Go string, which (unlike a Go
+// source-code string literal) carries no compiler-enforced UTF-8
+// guarantee, so a Document built programmatically with invalid-UTF-8 bytes
+// in a string leaf is a legitimate input this function must handle.
+func TestWriteYAMLInvalidUTF8StringFails(t *testing.T) {
+	invalid := string([]byte{0xff, 0xfe})
+	d := NodeDocument(NewNode().AddValue("v", ScalarValue(NewStringScalar(invalid))))
+	_, err := WriteYAML(d)
+	if err == nil {
+		t.Fatal("expected an error writing a string with invalid UTF-8 bytes")
+	}
+}
+
+func TestWriteYAMLNestedNode(t *testing.T) {
+	child := NewNode().AddValue("x", ScalarValue(NewIntegerScalar(big.NewInt(1))))
+	d := NodeDocument(NewNode().AddNode("child", child))
+	out, err := WriteYAML(d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	back, err := ReadYAML(out, DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !docEqual(d, back) {
+		t.Errorf("wrote %q, got %+v", out, back)
+	}
+}


### PR DESCRIPTION
Closes #25.

Implements the YAML codec: reader (§7.1, formats/yaml.md) and writer (§7.3). YAML is significantly more involved than JSON -- aliasing and native YAML-1.1 core-schema scalar resolution with no schema involved.

Library-behavior finding worth highlighting: neither `gopkg.in/yaml.v2` nor `v3` fully implements YAML 1.1 resolution out of the box -- verified by reading each library's own `resolve.go` source, not by testing alone. v3 has no Norway-problem boolean resolution at all; both v2 and v3 have sexagesimal notation "purposefully unsupported" per their own source comments. Built a custom `resolveYAMLScalar` layer on top of v3's raw parse tree to close this gap. The reviewer independently reproduced this finding with its own throwaway verification program before trusting it.

Independently verified: 100% per-function coverage, 0 lint issues. The two highest-stakes correctness requirements -- the Norway problem (bare `on`/`yes`/`no`/`off` and case variants as unquoted keys must be rejected, quoted forms must succeed) and sexagesimal time-as-integer (`12:00:00` -> exactly 43200) -- were re-derived with the reviewer's own constructed test cases covering 16 Norway-word variants, not just the committed suite. Alias expansion (independent copies, no shared identity), YAML-native date/datetime auto-resolution at stage 1 (a genuine, confirmed divergence from JSON's behavior), and NaN/Infinity native-spelling round-tripping were each independently confirmed.

One honest, real limitation, clearly disclosed rather than glossed over: the writer cannot achieve `time`-kind round-tripping. A `time` value writes force-quoted (no safe bare spelling exists in YAML's core schema -- a bare time collides with the sexagesimal-integer rule) and reads back as a plain string, not a `time`-kind Scalar. This is documented in the writer's doc comment, has a dedicated test, and the general round-trip property test explicitly skips this one case with an explanatory comment.

Separately: caught and fixed a real infra issue during review -- the repo's top-level `vendor/` directory (holding the omnist-spec submodule, not Go vendoring) was silently fine with zero go.mod dependencies, but this PR is the first to add a real one (`gopkg.in/yaml.v3`), which triggers Go's automatic vendor-mode detection and breaks the build without `-mod=mod`. Fixed in a separate commit already on main (`GOFLAGS=-mod=mod`, both in CI and the local WSL build environment) before merging this PR.

No load-bearing spec ambiguity. One narrow, disclosed taxonomy reuse: no dedicated `schema.*`/`document.*` code exists for "mapping key must be a string," so the boolean/complex-key rejection reuses `document.unlabeled-element`, consistent with the same reuse pattern JSON's reader already established.