### PR TITLE
TOML codec (reader + writer)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,5 @@ module github.com/omnist-dev/omnist-go
 go 1.24
 
 require gopkg.in/yaml.v3 v3.0.1
+
+require github.com/pelletier/go-toml/v2 v2.4.3

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/pelletier/go-toml/v2 v2.4.3 h1:GTRvJQutkOSftxIFD5xw9aepkYNuPWmVJpffdDPYVpY=
+github.com/pelletier/go-toml/v2 v2.4.3/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/toml_reader.go
+++ b/toml_reader.go
@@ -1,0 +1,568 @@
+package omnist
+
+import (
+	"math"
+	"math/big"
+	"strconv"
+	"strings"
+
+	"github.com/pelletier/go-toml/v2/unstable"
+)
+
+// ReadTOML parses TOML source text into a Document (spec §7.1,
+// docs/formats/toml.md, "stage 1 only, no schema"). limits configures the
+// safety limits enforced while reading, per the same Limits struct every
+// other codec uses (limits.go); see the "Limit enforcement" section below
+// for how this reader applies them — TOML's own document shape does not
+// fit LimitChecker's Enter/LeaveNode calling convention directly, so this
+// reader adapts rather than forces it.
+//
+// # Library choice and empirical verification (issue #27)
+//
+// github.com/pelletier/go-toml/v2 is used, specifically its unstable
+// package (an explicitly-unstable but public raw-AST API: unstable.Parser
+// hands back a stream of Node values with Kind/Raw/Data/Children, one per
+// top-level expression, rather than only a fully-decoded Go value) — the
+// same "raw parse tree to build on top of" shape issue #25 used yaml.v3's
+// Node API for, and for the identical reason: this reader needs source
+// key order and full-precision numeric literals, neither of which the
+// library's own high-level decode path (toml.Unmarshal) preserves.
+//
+// This was confirmed empirically (not assumed from documentation) with a
+// standalone throwaway program (not part of this package) that fed the
+// library varied TOML documents and inspected both decode paths:
+//
+//   - Key order: decoding into map[string]interface{} loses order (Go
+//     maps have none) for every table's fields, and would violate D-1.
+//     The unstable.Parser's NextExpression()/Expression() stream instead
+//     yields exactly one Node per top-level statement (KeyValue, Table,
+//     ArrayTable) in source order, with each container Node's Children()
+//     iterator likewise walking child nodes (inline-table members, array
+//     elements, dotted-key segments) in source order. This reader builds
+//     the Document tree directly from that stream, never through the
+//     map-shaped decode path, so source order is preserved throughout.
+//   - Integer precision: decoding into either map[string]interface{} or a
+//     typed field routes through the library's internal parseInteger,
+//     which parses into int64 and hard-fails ("...too large to fit in a
+//     64-bit signed integer") on any literal outside that range —
+//     confirmed with a 53-digit literal, which the high-level decode path
+//     rejects outright. Spec §2.4 requires supporting integers up to
+//     4,300 decimal digits. The unstable.Parser's own tokenizer, however,
+//     does not apply this width limit at all: an Integer-kind Node's Data
+//     field holds the literal's raw, unparsed text regardless of
+//     magnitude (confirmed with the same 53-digit literal, which the
+//     unstable parser accepts and reports as Kind=Integer, Data="999...").
+//     This reader therefore never calls the library's own numeric decode
+//     functions (they are unexported besides), parsing every Integer/
+//     Float leaf's raw text itself in parseTOMLInt/parseTOMLFloat below,
+//     into a *big.Int the same way every other codec in this package
+//     does (oml_lexer.go, ReadJSON, ReadYAML).
+//   - Number/integer distinction: confirmed directly against the AST —
+//     `a = 1` produces Kind=Integer, `c = 2.0` produces Kind=Float, never
+//     collapsed together regardless of magnitude (`2.0`'s Data is
+//     literally "2.0", distinct from `2`'s "2") — TOML's own grammar
+//     already carries this distinction lexically, exactly as the issue
+//     anticipated, so there is nothing to reconcile the way ReadJSON's
+//     shape-not-magnitude reasoning has to.
+//   - Native date/time/datetime: the AST's Kind enum has four distinct
+//     temporal kinds — LocalDate, LocalTime, LocalDateTime, and DateTime
+//     (offset) — confirmed by parsing all four TOML forms and observing
+//     each produces its own Kind. See "Offset vs. local datetime" below
+//     for how DateTime (the offset-carrying one) maps onto the Document
+//     model, which has no separate offset-datetime kind of its own.
+//   - Float special values: confirmed `nan`/`inf`/`+inf`/`-inf` all parse
+//     to Kind=Float with their literal spelling in Data (not resolved to
+//     a Go float64 by the AST layer). Go's strconv.ParseFloat happens to
+//     already accept "inf"/"+inf"/"-inf"/"nan" directly, matching TOML's
+//     spelling — but NOT "-nan"/"+nan" (strconv.ParseFloat errors on a
+//     signed nan, confirmed empirically), even though TOML's grammar
+//     allows a sign on nan (its sign is defined to be insignificant).
+//     parseTOMLFloat below special-cases a signed nan/inf's first
+//     character before falling back to strconv.ParseFloat, mirroring the
+//     small hand-rolled check the library's own (unexported) parseFloat
+//     in decode.go uses internally for exactly the same reason — this
+//     reader cannot call that function, but the shape of the fix is the
+//     same once the gap is known.
+//   - Bare TOML syntax errors (e.g. a sign on a hex/octal/binary literal,
+//     which TOML's grammar forbids): confirmed the unstable.Parser itself
+//     rejects these at the grammar level (NextExpression() returns false,
+//     Error() reports "sign is not allowed on numbers with a radix
+//     prefix") — so parseTOMLInt below can assume any Integer-kind node
+//     it receives already satisfies TOML's own grammar (no unsigned-radix
+//     combination to re-validate).
+//
+// # Offset vs. local datetime
+//
+// TOML's grammar has both local-date-time (no offset) and offset-date-time
+// (RFC 3339, with a 'Z' or +HH:MM/-HH:MM suffix); the Document model's
+// `datetime` kind (spec §2.2.1) makes no such distinction — issue #1's
+// design does not carve out a separate "offset datetime" kind, and
+// docs/formats/toml.md does not address TOML's offset variant explicitly
+// (noted in the issue as something this reader would need to decide).
+//
+// The decision made here: an offset date-time reads to the same
+// Document-model `datetime` kind as a local one, with the offset itself
+// preserved losslessly in TimeValue.HasOffset/OffsetSeconds (document.go)
+// — fields that already exist on every datetime's embedded TimeValue and
+// are already populated by ReadYAML's identical offset-carrying timestamp
+// case (yaml_reader.go's parseYAMLDateTime) and already round-tripped by
+// WriteJSON/WriteYAML's shared formatISOTime (json_writer.go). This is not
+// a lossy adjustment or a new mechanism: it is the existing, already-
+// exercised path for "a datetime that happens to carry an offset",
+// applied to TOML's own offset-datetime literal the same way it already
+// applies to YAML's. A local (no-offset) date-time simply leaves
+// HasOffset false, the same as any other offset-less datetime in this
+// package.
+//
+// # Limit enforcement
+//
+// LimitChecker (limits.go) is built around a single recursive descent
+// (EnterNode before descending into a nested value, LeaveNode after)
+// which fits ReadJSON/ReadYAML/OML's parsers exactly, because each of
+// those readers builds one nested container in one recursive call.
+// TOML's grammar is different in a way that breaks that fit: a document
+// is a *flat* stream of top-level expressions (KeyValue/Table/
+// ArrayTable), and a `[table.header]` expression can re-enter and extend
+// a table that a much earlier, unrelated expression already created
+// (`[[fruits]]` ... later ... `[fruits.physical]`), or a sibling header at
+// the same depth follows immediately after a deeply-nested one with no
+// "closing" expression in between. LimitChecker's currentDepth is a
+// single monotonic counter that only ever goes up between EnterNode calls
+// and down on LeaveNode — there is no natural point in a flat expression
+// stream to call LeaveNode "the right number of times" between two
+// unrelated headers without either double-counting reused nodes as new
+// ones (inflating MaxNodes) or leaving currentDepth permanently
+// overstated (falsely tripping MaxDepth on unrelated sibling tables).
+//
+// Rather than force TOML's flat shape through an API built for recursive
+// descent, this reader enforces the identical §2.4 limits directly:
+// every *Node this reader allocates is assigned its true depth (parent's
+// depth + 1, exactly what EnterNode would have computed had the document
+// been built by recursive descent) at creation time, checked against
+// limits.MaxDepth right there — this needs no running counter at all,
+// since a node's distance from the root never changes after it is
+// created. A single monotonic nodeCount field (never decremented, exactly
+// matching LimitChecker's own nodeCount field, which also never
+// decreases) is checked against limits.MaxNodes on the same allocations.
+// Both checks report the identical Diagnostic codes/messages/severity
+// LimitChecker.EnterNode itself would (CodeDocumentLimitDepth,
+// CodeDocumentLimitNodes) — this is the same §2.4 enforcement against the
+// same Limits configuration, adapted to fit, not a different policy.
+// CheckIntDigits (limits.go), the one LimitChecker method that is
+// stateless, is used directly and unmodified, exactly as every other
+// codec uses it.
+func ReadTOML(text string, limits Limits) (Document, error) {
+	r := &tomlReader{
+		limits:  limits,
+		checker: NewLimitChecker(limits),
+		root:    NewNode(),
+	}
+	p := &unstable.Parser{}
+	p.Reset([]byte(text))
+	r.p = p
+
+	for p.NextExpression() {
+		expr := p.Expression()
+		if err := r.readTopLevel(expr); err != nil {
+			return Document{}, err
+		}
+	}
+	if err := p.Error(); err != nil {
+		return Document{}, r.wrapParserError(err)
+	}
+	return NodeDocument(r.root), nil
+}
+
+// tomlReader holds the state for one ReadTOML call.
+type tomlReader struct {
+	limits    Limits
+	checker   *LimitChecker
+	p         *unstable.Parser
+	root      *Node
+	current   *Node // insertion point for a bare (non-dotted) KeyValue
+	nodeCount int
+}
+
+// newChildNode allocates a new *Node at depth childDepth (the parent's own
+// depth + 1), enforcing MaxDepth/MaxNodes per ReadTOML's doc comment. path
+// is used only for the resulting Diagnostic's Path field.
+func (r *tomlReader) newChildNode(childDepth int, path string) (*Node, error) {
+	if childDepth > r.limits.MaxDepth {
+		return nil, &ParseError{Path: path, Code: CodeDocumentLimitDepth, Message: "nesting exceeds the configured depth limit"}
+	}
+	r.nodeCount++
+	if r.nodeCount > r.limits.MaxNodes {
+		return nil, &ParseError{Path: path, Code: CodeDocumentLimitNodes, Message: "node count exceeds the configured node limit"}
+	}
+	return NewNode(), nil
+}
+
+// readTopLevel dispatches one top-level expression (Table, ArrayTable, or
+// KeyValue) per the model-mapping table (docs/formats/toml.md): a Table
+// header switches the "current table" pointer that subsequent bare
+// KeyValue expressions attach to; an ArrayTable header does the same but
+// always creates a brand-new node (never reuses one), matching
+// `[[x]]` written twice becoming the label `x` twice with no adjustment.
+func (r *tomlReader) readTopLevel(expr *unstable.Node) error {
+	switch expr.Kind {
+	case unstable.Table:
+		node, _, err := r.resolvePath(r.root, 0, expr.Key())
+		if err != nil {
+			return err
+		}
+		r.current = node
+		return nil
+	case unstable.ArrayTable:
+		parent, depth, label, err := r.resolveParentPath(expr.Key())
+		if err != nil {
+			return err
+		}
+		child, err := r.newChildNode(depth+1, r.posPath(expr.Raw))
+		if err != nil {
+			return err
+		}
+		parent.AddNode(label, child)
+		r.current = child
+		return nil
+	default: // unstable.KeyValue
+		if r.current == nil {
+			r.current = r.root
+		}
+		return r.readKeyValue(r.current, 0, expr)
+	}
+}
+
+// resolveParentPath walks all but the last segment of an ArrayTable
+// header's dotted key, root-anchored (an ArrayTable header's path is
+// always relative to the document root, per TOML's own grammar — see
+// resolveParentPathFrom's doc comment for the contrasting KeyValue case),
+// and returns the resolved parent node, its depth, and the final
+// (unresolved) segment's label. ReadTOML's ArrayTable branch always
+// allocates a fresh node for that final segment itself (never reusing an
+// existing one — see resolvePath's doc comment for why), which is why
+// this stops one segment short of resolveParentPathFrom, its
+// arbitrary-starting-point counterpart used for a KeyValue's dotted key.
+func (r *tomlReader) resolveParentPath(keys unstable.Iterator) (*Node, int, string, error) {
+	return r.resolveParentPathFrom(r.root, 0, keys)
+}
+
+// resolvePath walks every segment of a Table header's dotted key,
+// reusing an existing matching child table at each step when one exists
+// and creating one otherwise — every segment, including the last, uses
+// the same reuse-or-create rule (navigateOrCreate), which is exactly
+// right for a plain `[section]` header: re-opening an already-existing
+// table (e.g. `[fruits.physical]` extending a `fruits` table an earlier
+// `[[fruits]]` implicitly created) is legal TOML and must land on the
+// same node, not a new sibling. ArrayTable headers do NOT use this
+// function — see ReadTOML's readTopLevel, which always allocates a fresh
+// node for an ArrayTable's final segment (two `[[x]]` headers are two
+// distinct nodes sharing the label `x`, never merged) — that is the one
+// point docs/formats/toml.md itself contrasts Table and ArrayTable on.
+func (r *tomlReader) resolvePath(start *Node, startDepth int, keys unstable.Iterator) (*Node, int, error) {
+	var segs []string
+	for keys.Next() {
+		segs = append(segs, string(keys.Node().Data))
+	}
+	node, depth := start, startDepth
+	for _, seg := range segs {
+		var err error
+		node, depth, err = r.navigateOrCreate(node, depth, seg)
+		if err != nil {
+			return nil, 0, err
+		}
+	}
+	return node, depth, nil
+}
+
+// navigateOrCreate resolves one dotted-key segment under node: the LAST
+// matching edge whose label equals seg and whose target is itself a node
+// is reused (matching real TOML semantics for both a table header
+// re-opening an earlier implicit table, e.g. `[fruits.physical]` after an
+// earlier `[[fruits]]`, and a dotted KeyValue key extending an
+// already-started implicit table across multiple statements, e.g.
+// `host.name = "x"` then `host.port = 1`) — "last" matters specifically
+// for array-of-tables: dotted references after a repeated `[[x]]` header
+// always mean the most-recently-opened `x` instance, never an earlier
+// one. When no matching edge exists, a new node is created and appended.
+//
+// This reader does not separately enforce TOML's own "cannot redefine an
+// already-fully-defined table" validity rule (e.g. two plain `[a]`
+// headers for the same path) — that is a semantic well-formedness check
+// beyond stage-1 shape construction, and neither ReadJSON nor ReadYAML
+// independently re-validates grammar-adjacent rules their own underlying
+// library doesn't already enforce. This is the plainly-correct reading of
+// a narrow, cosmetic gap (malformed input of exactly this shape produces
+// a Document that merges the redefinitions rather than an error), noted
+// here rather than treated as load-bearing.
+func (r *tomlReader) navigateOrCreate(node *Node, depth int, seg string) (*Node, int, error) {
+	for i := len(node.Edges) - 1; i >= 0; i-- {
+		e := node.Edges[i]
+		if e.Label == seg {
+			if child, ok := e.Target.Node(); ok {
+				return child, depth + 1, nil
+			}
+			break
+		}
+	}
+	child, err := r.newChildNode(depth+1, seg)
+	if err != nil {
+		return nil, 0, err
+	}
+	node.AddNode(seg, child)
+	return child, depth + 1, nil
+}
+
+// readKeyValue processes one KeyValue expression (top-level, or nested
+// inside an inline table), attaching its value under target at the depth
+// target itself sits at (targetDepth), per the dotted-key resolution
+// navigateOrCreate implements.
+func (r *tomlReader) readKeyValue(target *Node, targetDepth int, kv *unstable.Node) error {
+	parent, depth, label, err := r.resolveParentPathFrom(target, targetDepth, kv.Key())
+	if err != nil {
+		return err
+	}
+	return r.attachValue(parent, depth, label, kv.Value())
+}
+
+// resolveParentPathFrom is resolveParentPath's counterpart for a KeyValue
+// nested under an arbitrary starting node (target/targetDepth) rather
+// than always the document root — the root-anchored resolveParentPath is
+// used for Table/ArrayTable headers (whose dotted path is always
+// root-relative per TOML's own grammar), while a KeyValue's dotted key
+// (whether top-level or inside an inline table) is relative to whatever
+// table it appears in.
+func (r *tomlReader) resolveParentPathFrom(target *Node, targetDepth int, keys unstable.Iterator) (*Node, int, string, error) {
+	var segs []string
+	for keys.Next() {
+		segs = append(segs, string(keys.Node().Data))
+	}
+	node, depth := target, targetDepth
+	for i := 0; i < len(segs)-1; i++ {
+		var err error
+		node, depth, err = r.navigateOrCreate(node, depth, segs[i])
+		if err != nil {
+			return nil, 0, "", err
+		}
+	}
+	return node, depth, segs[len(segs)-1], nil
+}
+
+// attachValue builds and attaches the Target(s) for one resolved
+// (parent, label) pair from a KeyValue's value node. An Array value
+// expands into one edge per element sharing label, exactly as ReadJSON's
+// readMember/ReadYAML's readSequenceElements treat a JSON array/YAML
+// sequence — TOML has no model-mapping-table entry contrasting inline
+// arrays with JSON's (docs/formats/toml.md is silent on them, discussing
+// only tables/array-of-tables), so this is the plainly-correct default
+// reading shared by every other format in the JSON family, applied here
+// too, per the same repeated-label rule.
+func (r *tomlReader) attachValue(parent *Node, parentDepth int, label string, v *unstable.Node) error {
+	switch v.Kind {
+	case unstable.Array:
+		return r.attachArray(parent, parentDepth, label, v)
+	case unstable.InlineTable:
+		child, err := r.buildInlineTable(parentDepth, v)
+		if err != nil {
+			return err
+		}
+		parent.AddNode(label, child)
+		return nil
+	default:
+		val, err := r.readScalar(v)
+		if err != nil {
+			return err
+		}
+		parent.AddValue(label, val)
+		return nil
+	}
+}
+
+// attachArray appends one edge per array element to parent, all sharing
+// label — the repeated-label expansion attachValue's doc comment
+// describes. An empty array is rejected with CodeParseEmptyArray, and a
+// nested bare array (an array element that is itself an Array) is
+// rejected with CodeDocumentUnlabeledElement, mirroring ReadYAML's
+// readSequenceElements exactly (see that function's doc comment for why:
+// the same array-as-repeated-label-sugar mechanism, a third format).
+func (r *tomlReader) attachArray(parent *Node, parentDepth int, label string, arr *unstable.Node) error {
+	it := arr.Children()
+	empty := true
+	for it.Next() {
+		empty = false
+		elem := it.Node()
+		switch elem.Kind {
+		case unstable.Array:
+			return &ParseError{Path: label, Code: CodeDocumentUnlabeledElement, Message: "an array element must not itself be an array"}
+		case unstable.InlineTable:
+			child, err := r.buildInlineTable(parentDepth, elem)
+			if err != nil {
+				return err
+			}
+			parent.AddNode(label, child)
+		default:
+			val, err := r.readScalar(elem)
+			if err != nil {
+				return err
+			}
+			parent.AddValue(label, val)
+		}
+	}
+	if empty {
+		return &ParseError{Path: label, Code: CodeParseEmptyArray, Message: "an empty array is not a valid value"}
+	}
+	return nil
+}
+
+// buildInlineTable reads an InlineTable value node's children (each one a
+// KeyValue node — confirmed empirically against the AST; the unstable
+// package's own doc comment on Node states an InlineTable's children are
+// "each of kind InlineTable", which a throwaway probe program showed to
+// be inaccurate: `{a = 1, b = "x"}` produces two KeyValue children, not
+// InlineTable ones. This reader trusts what the AST actually returns
+// (checked directly) rather than that comment, per this issue's own
+// instruction to verify empirically rather than trust documentation) into
+// a freshly allocated node one level deeper than parentDepth.
+func (r *tomlReader) buildInlineTable(parentDepth int, tbl *unstable.Node) (*Node, error) {
+	child, err := r.newChildNode(parentDepth+1, "")
+	if err != nil {
+		return nil, err
+	}
+	it := tbl.Children()
+	for it.Next() {
+		if err := r.readKeyValue(child, parentDepth+1, it.Node()); err != nil {
+			return nil, err
+		}
+	}
+	return child, nil
+}
+
+// posPath renders a Raw range as a "line:col" Path via the parser's own
+// Shape (unstable.Parser.Shape), matching every other reader's ParseError
+// Path convention (spec §8.4).
+func (r *tomlReader) posPath(raw unstable.Range) string {
+	shape := r.p.Shape(raw)
+	return itoa(shape.Start.Line) + ":" + itoa(shape.Start.Column)
+}
+
+func itoa(n int) string { return strconv.Itoa(n) }
+
+// wrapParserError converts the error unstable.Parser.Error() reports into
+// a *ParseError. Every one of the library's own error sites (confirmed by
+// reading every unstable.NewParserError call in the library's parser.go)
+// constructs a *unstable.ParserError with a genuine, non-nil Highlight —
+// a real subslice of the input — so the type assertion below is
+// unchecked and Highlight is trusted to be non-nil, the same precondition
+// -trusting convention oml_lexer.go's parseDateValue/parseTimeValue
+// already use in this package (see that file's comment above
+// parseDateValue) rather than carrying a defensive fallback branch no
+// input can reach.
+func (r *tomlReader) wrapParserError(err error) error {
+	pe := err.(*unstable.ParserError) //nolint:errorlint // see doc comment: the library's own error is always this concrete type
+	shape := r.p.Shape(r.p.Range(pe.Highlight))
+	path := itoa(shape.Start.Line) + ":" + itoa(shape.Start.Column)
+	return &ParseError{Line: shape.Start.Line, Col: shape.Start.Column, Path: path, Code: CodeParseUnexpectedToken, Message: pe.Message}
+}
+
+// readScalar resolves a scalar-kind value node (String/Bool/Integer/
+// Float/LocalDate/LocalTime/LocalDateTime/DateTime) to a Document Value,
+// applying the digit-count limit to any resulting integer via
+// LimitChecker.CheckIntDigits, exactly as ReadYAML's own readScalar does.
+func (r *tomlReader) readScalar(v *unstable.Node) (Value, error) {
+	switch v.Kind {
+	case unstable.String:
+		return ScalarValue(NewStringScalar(string(v.Data))), nil
+	case unstable.Bool:
+		return ScalarValue(NewBooleanScalar(string(v.Data) == "true")), nil
+	case unstable.Integer:
+		bi := parseTOMLInt(string(v.Data))
+		digits := len(strings.TrimPrefix(bi.String(), "-"))
+		if diag := r.checker.CheckIntDigits(r.posPath(v.Raw), digits); diag != nil {
+			return Value{}, &ParseError{Path: diag.Path, Code: diag.Code, Message: diag.Message}
+		}
+		return ScalarValue(NewIntegerScalar(bi)), nil
+	case unstable.Float:
+		return ScalarValue(NewNumberScalar(parseTOMLFloat(string(v.Data)))), nil
+	case unstable.LocalDate:
+		return ScalarValue(NewDateScalar(parseDateValue(string(v.Data)))), nil
+	case unstable.LocalTime:
+		return ScalarValue(NewTimeScalar(parseTimeValue(string(v.Data)))), nil
+	default: // unstable.LocalDateTime, unstable.DateTime
+		return ScalarValue(NewDateTimeScalar(parseTOMLDateTime(string(v.Data)))), nil
+	}
+}
+
+// parseTOMLInt parses an Integer-kind node's raw literal text into a
+// *big.Int, arbitrary precision (spec §2.4), after stripping TOML's
+// digit-group underscores. big.Int.SetString's base-0 mode already
+// understands the exact prefix set TOML's own integer grammar uses
+// (0x/0o/0b, or a bare decimal with an optional +/- sign) — the same
+// reasoning ReadYAML's parseYAMLInt already applies to YAML 1.1's
+// (different but overlapping) prefix set — so this defers to it directly
+// rather than hand-rolling per-base parsing. Every Integer-kind node this
+// is called on already satisfies TOML's grammar (confirmed empirically —
+// see ReadTOML's doc comment on the sign/radix-prefix combination the
+// parser itself rejects before this function ever sees the text), so
+// SetString cannot fail on well-formed input, so — mirroring
+// oml_lexer.go's parseDateValue/parseTimeValue convention of trusting a
+// checked precondition rather than carrying a permanently-dead error
+// branch (see that file's comment for the same reasoning applied to a
+// different precondition) — this has no error return at all.
+func parseTOMLInt(raw string) *big.Int {
+	s := strings.ReplaceAll(raw, "_", "")
+	bi, _ := new(big.Int).SetString(s, 0)
+	return bi
+}
+
+// parseTOMLFloat parses a Float-kind node's raw literal text into a
+// float64, stripping underscores first. TOML's grammar allows a sign on
+// "nan" (`+nan`/`-nan`), whose sign is defined to carry no meaning, but
+// Go's strconv.ParseFloat rejects a signed nan outright — confirmed
+// empirically (see ReadTOML's doc comment) — so a signed inf/nan is
+// special-cased here first, mirroring the small hand-rolled check the
+// library's own unexported decode.go parseFloat performs for the
+// identical reason, before falling back to strconv.ParseFloat for every
+// ordinary decimal/exponent literal.
+func parseTOMLFloat(raw string) float64 {
+	s := strings.ReplaceAll(raw, "_", "")
+	i := 0
+	if len(s) > 0 && (s[0] == '+' || s[0] == '-') {
+		i = 1
+	}
+	if len(s) == i+3 {
+		switch s[i] {
+		case 'i':
+			if len(s) > 0 && s[0] == '-' {
+				return math.Inf(-1)
+			}
+			return math.Inf(1)
+		case 'n':
+			return math.NaN()
+		}
+	}
+	f, _ := strconv.ParseFloat(s, 64)
+	return f
+}
+
+// parseTOMLDateTime parses a LocalDateTime or DateTime node's raw literal
+// text into a DateTimeValue. TOML's grammar allows 'T', 't', or a literal
+// space as the date/time separator (all three confirmed empirically to
+// reach Kind=LocalDateTime/DateTime, not rejected), and either 'Z'/'z' or
+// a +HH:MM/-HH:MM suffix for an offset — wider than oml_lexer.go's own
+// parseDateTimeValue (OML's grammar only allows 'T', matching reDateTime),
+// so this does not reuse it directly, though it does reuse
+// parseDateValue/parseTimeValue (document-model-neutral, format-agnostic
+// field parsers oml_lexer.go already defines) for the date and
+// (offset-less) time portions.
+func parseTOMLDateTime(s string) DateTimeValue {
+	datePart := s[:10]
+	timePart := s[11:]
+	var tv TimeValue
+	if n := len(timePart); n > 0 && (timePart[n-1] == 'Z' || timePart[n-1] == 'z') {
+		tv = parseTimeValue(timePart[:n-1])
+		tv.HasOffset = true
+		tv.OffsetSeconds = 0
+	} else {
+		tv = parseTimeValue(timePart)
+	}
+	return DateTimeValue{Date: parseDateValue(datePart), Time: tv}
+}

--- a/toml_reader_test.go
+++ b/toml_reader_test.go
@@ -1,0 +1,694 @@
+package omnist
+
+import (
+	"math"
+	"math/big"
+	"strings"
+	"testing"
+)
+
+// --- model mapping table (docs/formats/toml.md) ---
+
+func TestTOMLModelMappingTableSimpleKeys(t *testing.T) {
+	d, err := ReadTOML("a = 1\nb = 2\n", DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := NodeDocument(NewNode().
+		AddValue("a", ScalarValue(NewIntegerScalar(big.NewInt(1)))).
+		AddValue("b", ScalarValue(NewIntegerScalar(big.NewInt(2)))))
+	if !docEqual(d, want) {
+		t.Errorf("got %+v, want %+v", d, want)
+	}
+}
+
+func TestTOMLArrayOfTablesRepeatedLabel(t *testing.T) {
+	src := "[[x]]\nname = \"a\"\n[[x]]\nname = \"b\"\n"
+	d, err := ReadTOML(src, DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	x1 := NewNode().AddValue("name", ScalarValue(NewStringScalar("a")))
+	x2 := NewNode().AddValue("name", ScalarValue(NewStringScalar("b")))
+	want := NodeDocument(NewNode().AddNode("x", x1).AddNode("x", x2))
+	if !docEqual(d, want) {
+		t.Errorf("got %+v, want %+v", d, want)
+	}
+	// Confirm this is genuinely 2 distinct edges sharing a label, not a
+	// list collapsed onto one edge.
+	if len(d.Node.Edges) != 2 || d.Node.Edges[0].Label != "x" || d.Node.Edges[1].Label != "x" {
+		t.Fatalf("expected 2 edges labeled x, got %+v", d.Node.Edges)
+	}
+}
+
+func TestTOMLSingleTableIsOneEdge(t *testing.T) {
+	src := "[x]\nname = \"c\"\n"
+	d, err := ReadTOML(src, DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(d.Node.Edges) != 1 || d.Node.Edges[0].Label != "x" {
+		t.Fatalf("expected exactly one edge labeled x, got %+v", d.Node.Edges)
+	}
+	want := NodeDocument(NewNode().AddNode("x", NewNode().AddValue("name", ScalarValue(NewStringScalar("c")))))
+	if !docEqual(d, want) {
+		t.Errorf("got %+v, want %+v", d, want)
+	}
+}
+
+// --- worked example (docs/formats/toml.md) ---
+
+func TestTOMLWorkedExample(t *testing.T) {
+	src := `[order]
+id = "A1"
+status = "shipped"
+total = 29.97
+
+[order.address]
+street = "1 Main"
+city = "London"
+
+[[order.items]]
+sku = "W"
+qty = 3
+price = 9.99
+
+[[order.items]]
+sku = "G"
+qty = 1
+price = 9.99
+`
+	d, err := ReadTOML(src, DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	address := NewNode().AddValue("street", ScalarValue(NewStringScalar("1 Main"))).
+		AddValue("city", ScalarValue(NewStringScalar("London")))
+	item1 := NewNode().AddValue("sku", ScalarValue(NewStringScalar("W"))).
+		AddValue("qty", ScalarValue(NewIntegerScalar(big.NewInt(3)))).
+		AddValue("price", ScalarValue(NewNumberScalar(9.99)))
+	item2 := NewNode().AddValue("sku", ScalarValue(NewStringScalar("G"))).
+		AddValue("qty", ScalarValue(NewIntegerScalar(big.NewInt(1)))).
+		AddValue("price", ScalarValue(NewNumberScalar(9.99)))
+	order := NewNode().
+		AddValue("id", ScalarValue(NewStringScalar("A1"))).
+		AddValue("status", ScalarValue(NewStringScalar("shipped"))).
+		AddValue("total", ScalarValue(NewNumberScalar(29.97))).
+		AddNode("address", address).
+		AddNode("items", item1).
+		AddNode("items", item2)
+	want := NodeDocument(NewNode().AddNode("order", order))
+
+	if !docEqual(d, want) {
+		t.Errorf("got %+v, want %+v", d, want)
+	}
+}
+
+func TestTOMLCrossFormatStructuralEqualityWithJSON(t *testing.T) {
+	src := `[order]
+id = "A1"
+status = "shipped"
+total = 29.97
+
+[order.address]
+street = "1 Main"
+city = "London"
+
+[[order.items]]
+sku = "W"
+qty = 3
+price = 9.99
+
+[[order.items]]
+sku = "G"
+qty = 1
+price = 9.99
+`
+	td, err := ReadTOML(src, DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	jsonSrc := `{"order":{"id":"A1","status":"shipped","total":29.97,"address":{"street":"1 Main","city":"London"},"items":[{"sku":"W","qty":3,"price":9.99},{"sku":"G","qty":1,"price":9.99}]}}`
+	jd, err := ReadJSON(jsonSrc, DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !docEqual(td, jd) {
+		t.Errorf("TOML and JSON documents differ:\nTOML: %+v\nJSON: %+v", td, jd)
+	}
+}
+
+// --- native temporal literals ---
+
+func TestTOMLNativeDate(t *testing.T) {
+	d, err := ReadTOML("d = 2024-01-01\n", DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := NodeDocument(NewNode().AddValue("d", ScalarValue(NewDateScalar(DateValue{Year: 2024, Month: 1, Day: 1}))))
+	if !docEqual(d, want) {
+		t.Errorf("got %+v, want %+v", d, want)
+	}
+}
+
+func TestTOMLNativeTime(t *testing.T) {
+	d, err := ReadTOML("t = 12:30:45\n", DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := NodeDocument(NewNode().AddValue("t", ScalarValue(NewTimeScalar(TimeValue{Hour: 12, Minute: 30, Second: 45}))))
+	if !docEqual(d, want) {
+		t.Errorf("got %+v, want %+v", d, want)
+	}
+}
+
+func TestTOMLNativeTimeWithFraction(t *testing.T) {
+	d, err := ReadTOML("t = 12:30:45.5\n", DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := d.Node.Edges[0].Target
+	v, _ := got.Value()
+	if v.Scalar.Kind != KindTime || v.Scalar.Time.Nanosecond != 500000000 {
+		t.Errorf("got %+v, want a time with 500000000ns", v)
+	}
+}
+
+func TestTOMLNativeLocalDateTime(t *testing.T) {
+	d, err := ReadTOML("dt = 2024-01-01T12:00:00\n", DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := NodeDocument(NewNode().AddValue("dt", ScalarValue(NewDateTimeScalar(DateTimeValue{
+		Date: DateValue{Year: 2024, Month: 1, Day: 1},
+		Time: TimeValue{Hour: 12},
+	}))))
+	if !docEqual(d, want) {
+		t.Errorf("got %+v, want %+v", d, want)
+	}
+}
+
+func TestTOMLNativeOffsetDateTimeZ(t *testing.T) {
+	d, err := ReadTOML("dt = 2024-01-01T12:00:00Z\n", DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	v, _ := d.Node.Edges[0].Target.Value()
+	if v.Scalar.Kind != KindDateTime {
+		t.Fatalf("kind = %v, want KindDateTime", v.Scalar.Kind)
+	}
+	if !v.Scalar.DateTime.Time.HasOffset || v.Scalar.DateTime.Time.OffsetSeconds != 0 {
+		t.Errorf("got %+v, want HasOffset=true OffsetSeconds=0", v.Scalar.DateTime.Time)
+	}
+}
+
+func TestTOMLNativeOffsetDateTimeLowercaseZ(t *testing.T) {
+	d, err := ReadTOML("dt = 2024-01-01 12:00:00z\n", DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	v, _ := d.Node.Edges[0].Target.Value()
+	if !v.Scalar.DateTime.Time.HasOffset {
+		t.Errorf("got %+v, want HasOffset=true", v.Scalar.DateTime.Time)
+	}
+}
+
+func TestTOMLNativeOffsetDateTimeWithOffset(t *testing.T) {
+	d, err := ReadTOML("dt = 2024-01-01T12:00:00.123+05:30\n", DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	v, _ := d.Node.Edges[0].Target.Value()
+	tv := v.Scalar.DateTime.Time
+	if !tv.HasOffset || tv.OffsetSeconds != 5*3600+30*60 {
+		t.Errorf("got %+v, want offset +05:30", tv)
+	}
+	if tv.Nanosecond != 123000000 {
+		t.Errorf("got nanosecond %d, want 123000000", tv.Nanosecond)
+	}
+}
+
+func TestTOMLNativeDateTimeSpaceSeparator(t *testing.T) {
+	d, err := ReadTOML("dt = 2024-01-01 12:00:00\n", DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	v, _ := d.Node.Edges[0].Target.Value()
+	if v.Scalar.Kind != KindDateTime || v.Scalar.DateTime.Time.HasOffset {
+		t.Errorf("got %+v, want a local datetime with no offset", v)
+	}
+}
+
+// --- integer/float distinction ---
+
+func TestTOMLIntegerFloatDistinctionByShape(t *testing.T) {
+	d, err := ReadTOML("i = 2\nf = 2.0\n", DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := NodeDocument(NewNode().
+		AddValue("i", ScalarValue(NewIntegerScalar(big.NewInt(2)))).
+		AddValue("f", ScalarValue(NewNumberScalar(2.0))))
+	if !docEqual(d, want) {
+		t.Errorf("got %+v, want %+v", d, want)
+	}
+}
+
+func TestTOMLIntegerRadixForms(t *testing.T) {
+	d, err := ReadTOML("hex = 0xFF\noct = 0o17\nbin = 0b101\n", DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := NodeDocument(NewNode().
+		AddValue("hex", ScalarValue(NewIntegerScalar(big.NewInt(255)))).
+		AddValue("oct", ScalarValue(NewIntegerScalar(big.NewInt(15)))).
+		AddValue("bin", ScalarValue(NewIntegerScalar(big.NewInt(5)))))
+	if !docEqual(d, want) {
+		t.Errorf("got %+v, want %+v", d, want)
+	}
+}
+
+func TestTOMLIntegerArbitraryPrecision(t *testing.T) {
+	big53 := "99999999999999999999999999999999999999999999999999"
+	d, err := ReadTOML("n = "+big53+"\n", DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	v, _ := d.Node.Edges[0].Target.Value()
+	if v.Scalar.Kind != KindInteger || v.Scalar.Int.String() != big53 {
+		t.Errorf("got %+v, want integer %s", v, big53)
+	}
+}
+
+func TestTOMLIntegerUnderscoreSeparators(t *testing.T) {
+	d, err := ReadTOML("n = 1_000_000\n", DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := NodeDocument(NewNode().AddValue("n", ScalarValue(NewIntegerScalar(big.NewInt(1000000)))))
+	if !docEqual(d, want) {
+		t.Errorf("got %+v, want %+v", d, want)
+	}
+}
+
+func TestTOMLIntegerNegative(t *testing.T) {
+	d, err := ReadTOML("n = -42\n", DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := NodeDocument(NewNode().AddValue("n", ScalarValue(NewIntegerScalar(big.NewInt(-42)))))
+	if !docEqual(d, want) {
+		t.Errorf("got %+v, want %+v", d, want)
+	}
+}
+
+// --- floats, including special values ---
+
+func TestTOMLFloatSpecialValues(t *testing.T) {
+	d, err := ReadTOML("a = inf\nb = +inf\nc = -inf\nd = nan\ne = -nan\nf = +nan\n", DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	get := func(label string) float64 {
+		for _, e := range d.Node.Edges {
+			if e.Label == label {
+				v, _ := e.Target.Value()
+				return v.Scalar.Num
+			}
+		}
+		t.Fatalf("no edge %s", label)
+		return 0
+	}
+	if !math.IsInf(get("a"), 1) || !math.IsInf(get("b"), 1) || !math.IsInf(get("c"), -1) {
+		t.Errorf("inf spellings did not resolve to Inf/-Inf")
+	}
+	if !math.IsNaN(get("d")) || !math.IsNaN(get("e")) || !math.IsNaN(get("f")) {
+		t.Errorf("nan spellings (including signed) did not resolve to NaN")
+	}
+}
+
+func TestTOMLFloatUnderscoreAndExponent(t *testing.T) {
+	d, err := ReadTOML("n = 1_234.5e1_0\n", DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	v, _ := d.Node.Edges[0].Target.Value()
+	want := 1234.5e10
+	if v.Scalar.Kind != KindNumber || v.Scalar.Num != want {
+		t.Errorf("got %+v, want %v", v, want)
+	}
+}
+
+// --- inline tables and arrays ---
+
+func TestTOMLInlineTable(t *testing.T) {
+	d, err := ReadTOML(`p = {x = 1, y = 2}`+"\n", DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := NodeDocument(NewNode().AddNode("p", NewNode().
+		AddValue("x", ScalarValue(NewIntegerScalar(big.NewInt(1)))).
+		AddValue("y", ScalarValue(NewIntegerScalar(big.NewInt(2))))))
+	if !docEqual(d, want) {
+		t.Errorf("got %+v, want %+v", d, want)
+	}
+}
+
+func TestTOMLInlineArrayRepeatedLabel(t *testing.T) {
+	d, err := ReadTOML("nums = [1, 2, 3]\n", DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := NodeDocument(NewNode().
+		AddValue("nums", ScalarValue(NewIntegerScalar(big.NewInt(1)))).
+		AddValue("nums", ScalarValue(NewIntegerScalar(big.NewInt(2)))).
+		AddValue("nums", ScalarValue(NewIntegerScalar(big.NewInt(3)))))
+	if !docEqual(d, want) {
+		t.Errorf("got %+v, want %+v", d, want)
+	}
+}
+
+func TestTOMLInlineArrayOfInlineTables(t *testing.T) {
+	d, err := ReadTOML(`items = [{n = "a"}, {n = "b"}]`+"\n", DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := NodeDocument(NewNode().
+		AddNode("items", NewNode().AddValue("n", ScalarValue(NewStringScalar("a")))).
+		AddNode("items", NewNode().AddValue("n", ScalarValue(NewStringScalar("b")))))
+	if !docEqual(d, want) {
+		t.Errorf("got %+v, want %+v", d, want)
+	}
+}
+
+func TestTOMLEmptyInlineArrayIsRejected(t *testing.T) {
+	_, err := ReadTOML("a = []\n", DefaultLimits())
+	if err == nil {
+		t.Fatal("expected an error for an empty array")
+	}
+	pe, ok := err.(*ParseError)
+	if !ok || pe.Code != CodeParseEmptyArray {
+		t.Errorf("error = %#v, want CodeParseEmptyArray", err)
+	}
+}
+
+func TestTOMLNestedArrayIsRejected(t *testing.T) {
+	_, err := ReadTOML("a = [[1, 2], [3, 4]]\n", DefaultLimits())
+	if err == nil {
+		t.Fatal("expected an error for a nested bare array")
+	}
+	pe, ok := err.(*ParseError)
+	if !ok || pe.Code != CodeDocumentUnlabeledElement {
+		t.Errorf("error = %#v, want CodeDocumentUnlabeledElement", err)
+	}
+}
+
+// --- dotted keys ---
+
+func TestTOMLDottedKeyCreatesImplicitTable(t *testing.T) {
+	d, err := ReadTOML("host.name = \"x\"\nhost.port = 1\n", DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(d.Node.Edges) != 1 || d.Node.Edges[0].Label != "host" {
+		t.Fatalf("expected a single host edge, got %+v", d.Node.Edges)
+	}
+	want := NodeDocument(NewNode().AddNode("host", NewNode().
+		AddValue("name", ScalarValue(NewStringScalar("x"))).
+		AddValue("port", ScalarValue(NewIntegerScalar(big.NewInt(1))))))
+	if !docEqual(d, want) {
+		t.Errorf("got %+v, want %+v", d, want)
+	}
+}
+
+func TestTOMLDottedKeyDeepNesting(t *testing.T) {
+	d, err := ReadTOML("a.b.c = 5\n", DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := NodeDocument(NewNode().AddNode("a", NewNode().AddNode("b", NewNode().
+		AddValue("c", ScalarValue(NewIntegerScalar(big.NewInt(5)))))))
+	if !docEqual(d, want) {
+		t.Errorf("got %+v, want %+v", d, want)
+	}
+}
+
+func TestTOMLQuotedKey(t *testing.T) {
+	d, err := ReadTOML(`"q key" = 9` + "\n", DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := NodeDocument(NewNode().AddValue("q key", ScalarValue(NewIntegerScalar(big.NewInt(9)))))
+	if !docEqual(d, want) {
+		t.Errorf("got %+v, want %+v", d, want)
+	}
+}
+
+// TestTOMLDottedKeyOverALabelAlreadyUsedForAScalar exercises
+// navigateOrCreate's "existing edge with a matching label but a scalar
+// (non-node) target" path: this reader does not independently enforce
+// TOML's own "cannot redefine an already-defined key" validity rule (see
+// navigateOrCreate's doc comment) — a dotted key that collides with an
+// earlier plain key of the same label falls through to allocating a
+// fresh node rather than reusing the scalar edge (which it structurally
+// cannot reuse: a scalar has no edges to extend). This is exactly the
+// narrow, documented gap, not a crash or silent data loss.
+func TestTOMLDottedKeyOverALabelAlreadyUsedForAScalar(t *testing.T) {
+	d, err := ReadTOML("a = 1\na.b = 2\n", DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(d.Node.Edges) != 2 {
+		t.Fatalf("expected 2 edges labeled a, got %+v", d.Node.Edges)
+	}
+	v, ok := d.Node.Edges[0].Target.Value()
+	if !ok || v.Scalar.Kind != KindInteger {
+		t.Errorf("first a edge = %+v, want the original scalar", d.Node.Edges[0])
+	}
+	child, ok := d.Node.Edges[1].Target.Node()
+	if !ok || len(child.Edges) != 1 || child.Edges[0].Label != "b" {
+		t.Errorf("second a edge = %+v, want a fresh node holding b", d.Node.Edges[1])
+	}
+}
+
+func TestTOMLNestedErrorInsideInlineTableInsideArray(t *testing.T) {
+	_, err := ReadTOML("items = [{a = []}]\n", DefaultLimits())
+	if err == nil {
+		t.Fatal("expected an error for the empty array nested inside the inline table")
+	}
+	pe, ok := err.(*ParseError)
+	if !ok || pe.Code != CodeParseEmptyArray {
+		t.Errorf("error = %#v, want CodeParseEmptyArray", err)
+	}
+}
+
+// --- ArrayTable path re-entry (official TOML fruits example) ---
+
+func TestTOMLArrayTableDottedPathReentry(t *testing.T) {
+	src := `[[fruits]]
+name = "apple"
+
+[fruits.physical]
+color = "red"
+
+[[fruits.varieties]]
+name = "red delicious"
+
+[[fruits]]
+name = "banana"
+
+[[fruits.varieties]]
+name = "plantain"
+`
+	d, err := ReadTOML(src, DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(d.Node.Edges) != 2 {
+		t.Fatalf("expected 2 top-level fruits edges, got %d", len(d.Node.Edges))
+	}
+	apple, _ := d.Node.Edges[0].Target.Node()
+	banana, _ := d.Node.Edges[1].Target.Node()
+
+	// apple: name, physical, varieties(1)
+	if len(apple.Edges) != 3 {
+		t.Fatalf("apple edges = %+v, want 3", apple.Edges)
+	}
+	if apple.Edges[1].Label != "physical" {
+		t.Errorf("apple.Edges[1] = %+v, want physical", apple.Edges[1])
+	}
+	if apple.Edges[2].Label != "varieties" {
+		t.Errorf("apple.Edges[2] = %+v, want varieties", apple.Edges[2])
+	}
+
+	// banana: name, varieties(1) — the [fruits.physical] and first
+	// [[fruits.varieties]] from the apple instance must not leak in.
+	if len(banana.Edges) != 2 {
+		t.Fatalf("banana edges = %+v, want 2", banana.Edges)
+	}
+	if banana.Edges[1].Label != "varieties" {
+		t.Errorf("banana.Edges[1] = %+v, want varieties", banana.Edges[1])
+	}
+}
+
+// --- empty document ---
+
+func TestTOMLEmptyDocument(t *testing.T) {
+	d, err := ReadTOML("", DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !d.IsNode || len(d.Node.Edges) != 0 {
+		t.Errorf("got %+v, want an empty node document", d)
+	}
+}
+
+// --- syntax errors ---
+
+func TestTOMLSyntaxErrorReported(t *testing.T) {
+	_, err := ReadTOML("a = -0xFF\n", DefaultLimits())
+	if err == nil {
+		t.Fatal("expected a parse error for a signed radix literal")
+	}
+	pe, ok := err.(*ParseError)
+	if !ok || pe.Code != CodeParseUnexpectedToken {
+		t.Errorf("error = %#v, want CodeParseUnexpectedToken", err)
+	}
+	if !strings.Contains(pe.Message, "radix") {
+		t.Errorf("message = %q, want it to mention the radix-prefix rule", pe.Message)
+	}
+}
+
+// --- limits ---
+
+func TestTOMLLimitDepth(t *testing.T) {
+	limits := DefaultLimits()
+	limits.MaxDepth = 2
+	_, err := ReadTOML("a.b.c.d = 1\n", limits)
+	if err == nil {
+		t.Fatal("expected depth limit error")
+	}
+	pe, ok := err.(*ParseError)
+	if !ok || pe.Code != CodeDocumentLimitDepth {
+		t.Errorf("error = %#v, want CodeDocumentLimitDepth", err)
+	}
+}
+
+func TestTOMLLimitDepthViaTableHeader(t *testing.T) {
+	limits := DefaultLimits()
+	limits.MaxDepth = 1
+	_, err := ReadTOML("[a.b]\nc = 1\n", limits)
+	if err == nil {
+		t.Fatal("expected depth limit error")
+	}
+	pe, ok := err.(*ParseError)
+	if !ok || pe.Code != CodeDocumentLimitDepth {
+		t.Errorf("error = %#v, want CodeDocumentLimitDepth", err)
+	}
+}
+
+func TestTOMLLimitNodes(t *testing.T) {
+	limits := DefaultLimits()
+	limits.MaxNodes = 2
+	_, err := ReadTOML("a = {}\nb = {}\nc = {}\n", limits)
+	if err == nil {
+		t.Fatal("expected node-count limit error")
+	}
+	pe, ok := err.(*ParseError)
+	if !ok || pe.Code != CodeDocumentLimitNodes {
+		t.Errorf("error = %#v, want CodeDocumentLimitNodes", err)
+	}
+}
+
+func TestTOMLLimitDepthViaArrayTableParentPath(t *testing.T) {
+	limits := DefaultLimits()
+	limits.MaxDepth = 1
+	_, err := ReadTOML("[[a.b.c]]\nx = 1\n", limits)
+	if err == nil {
+		t.Fatal("expected depth limit error")
+	}
+	pe, ok := err.(*ParseError)
+	if !ok || pe.Code != CodeDocumentLimitDepth {
+		t.Errorf("error = %#v, want CodeDocumentLimitDepth", err)
+	}
+}
+
+func TestTOMLLimitNodesViaArrayTable(t *testing.T) {
+	limits := DefaultLimits()
+	limits.MaxNodes = 1
+	_, err := ReadTOML("[[a]]\nx = 1\n[[a]]\ny = 2\n", limits)
+	if err == nil {
+		t.Fatal("expected node-count limit error")
+	}
+	pe, ok := err.(*ParseError)
+	if !ok || pe.Code != CodeDocumentLimitNodes {
+		t.Errorf("error = %#v, want CodeDocumentLimitNodes", err)
+	}
+}
+
+func TestTOMLLimitIntDigitsInsideArray(t *testing.T) {
+	limits := DefaultLimits()
+	limits.MaxIntDigits = 3
+	_, err := ReadTOML("n = [12345]\n", limits)
+	if err == nil {
+		t.Fatal("expected int-digits limit error")
+	}
+	pe, ok := err.(*ParseError)
+	if !ok || pe.Code != CodeDocumentLimitIntDigits {
+		t.Errorf("error = %#v, want CodeDocumentLimitIntDigits", err)
+	}
+}
+
+func TestTOMLLimitIntDigits(t *testing.T) {
+	limits := DefaultLimits()
+	limits.MaxIntDigits = 3
+	_, err := ReadTOML("n = 12345\n", limits)
+	if err == nil {
+		t.Fatal("expected int-digits limit error")
+	}
+	pe, ok := err.(*ParseError)
+	if !ok || pe.Code != CodeDocumentLimitIntDigits {
+		t.Errorf("error = %#v, want CodeDocumentLimitIntDigits", err)
+	}
+}
+
+// --- string escaping ---
+
+func TestTOMLBasicStringEscapes(t *testing.T) {
+	d, err := ReadTOML(`s = "a\nb\tc\"d"` + "\n", DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	v, _ := d.Node.Edges[0].Target.Value()
+	want := "a\nb\tc\"d"
+	if v.Scalar.Str != want {
+		t.Errorf("got %q, want %q", v.Scalar.Str, want)
+	}
+}
+
+func TestTOMLMultilineString(t *testing.T) {
+	d, err := ReadTOML("s = \"\"\"hi\nthere\"\"\"\n", DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	v, _ := d.Node.Edges[0].Target.Value()
+	if v.Scalar.Str != "hi\nthere" {
+		t.Errorf("got %q, want %q", v.Scalar.Str, "hi\nthere")
+	}
+}
+
+// --- booleans ---
+
+func TestTOMLBooleans(t *testing.T) {
+	d, err := ReadTOML("t = true\nf = false\n", DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := NodeDocument(NewNode().
+		AddValue("t", ScalarValue(NewBooleanScalar(true))).
+		AddValue("f", ScalarValue(NewBooleanScalar(false))))
+	if !docEqual(d, want) {
+		t.Errorf("got %+v, want %+v", d, want)
+	}
+}

--- a/toml_writer.go
+++ b/toml_writer.go
@@ -1,0 +1,302 @@
+package omnist
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+)
+
+// WriteTOML renders d as TOML text (spec §7.3, docs/formats/toml.md),
+// schema-free: a writer MUST NOT accept a schema (§7.3), and this one
+// doesn't. It applies §7.3's two rules (grouping by label, the count-1
+// bare-value-vs-list rule) via writeTOMLTopLevel/writeTOMLInlineTable
+// below, then this file's own leaf-rendering rules.
+//
+// # Inline-only rendering: a deliberate simplification, not a spec gap
+//
+// docs/formats/toml.md's model-mapping table documents what `[section]`
+// and `[[section]]` header syntax MEANS when READ (a single edge vs. a
+// repeated label) — it does not require a writer to prefer header syntax
+// over TOML's other, equally valid way of expressing the identical
+// shape: inline tables (`{k = v, ...}`) and inline arrays (`[v, v, ...]`).
+// This writer always uses the inline forms for every nested table and
+// every repeated-label group, at every depth, and never emits a
+// `[section]`/`[[section]]` header.
+//
+// This is a real simplification with a real, deliberate reason: header
+// syntax carries TOML-specific positional rules with no equivalent in the
+// Document model itself — a `[section]` header must appear after all of
+// its parent table's bare key-values, `[[section]]` instances must be
+// contiguous, and re-opening a dotted path later in the document is only
+// legal under specific conditions (see navigateOrCreate's doc comment in
+// toml_reader.go for the read side of this same asymmetry). None of that
+// is a concern §7.3's schema-free write(node, format) algorithm has any
+// input for — it just groups edges by label and asks for a value or a
+// list. Inline tables/arrays have no positional constraints at all: they
+// are ordinary values that can appear anywhere a value can, so this
+// writer can implement §7.3.1 exactly as written, with no extra
+// bookkeeping to keep a table's context "open" across non-adjacent
+// writes, and no risk of ever emitting a header-ordering violation.
+// docs/formats/toml.md's own worked example (rendered with `[section]`
+// headers) and this writer's inline-only output are two different, both
+// entirely valid, TOML spellings of the identical Document — ReadTOML
+// reads either one back to the exact same edge structure (confirmed by
+// TestWriteTOMLRoundTripsWorkedExample), which is what §7.3's writer
+// contract actually requires (a correct rendering of the Document's
+// shape), not any particular surface syntax.
+//
+// # Null: no TOML spelling exists at all
+//
+// docs/formats/toml.md is explicit: "A null-valued leaf cannot be
+// written... Implementations MUST report this as a write-time
+// adjustment rather than inventing a representation." Unlike WriteJSON's
+// NaN/Infinity substitution (which has a lenient default and a strict
+// opt-in that fails instead), TOML has no lenient option to fall back to
+// here — there is no spelling of any kind, not even a lossy one, so this
+// writer's only choice is to fail. It does so by returning a Diagnostic
+// (CodeFormatNullUnrepresentable, spec §8.3.8, the code's own defined
+// warning severity, carrying the Document path to the offending leaf) the
+// first time it encounters a null anywhere in the tree — this is the
+// same "return the Diagnostic itself as the error" mechanism
+// WriteJSONStrict already uses for its own hard-failure case
+// (write.unsupported-value), applied here to the one case TOML's writer
+// has no lenient mode for at all.
+//
+// # Bare-scalar-root: a real error, not malformed output
+//
+// docs/formats/toml.md: "A bare scalar Document cannot be written as
+// TOML." TOML has no syntax for a document whose entire content is one
+// value with no key — every top-level statement is a `key = value` or a
+// table header. WriteTOML checks d.IsNode before writing anything and
+// fails immediately (CodeWriteUnsupportedValue) if the root is a scalar
+// Value rather than a Node, rather than producing any output at all.
+func WriteTOML(d Document) (string, error) {
+	if !d.IsNode {
+		return "", Diagnostic{
+			Path:     "$",
+			Code:     CodeWriteUnsupportedValue,
+			Message:  "a TOML document's top level must be a table; a bare scalar Document has no TOML spelling",
+			Severity: SeverityError,
+		}
+	}
+	var b strings.Builder
+	if err := writeTOMLTopLevel(&b, d.Node); err != nil {
+		return "", err
+	}
+	return b.String(), nil
+}
+
+// tomlGroup mirrors jsonGroup/yamlGroup (json_writer.go/yaml_writer.go):
+// one label's worth of grouped edges, in first-seen label order with
+// within-label edge order preserved, per §7.3.1's `groups` construction.
+type tomlGroup struct {
+	label    string
+	children []Target
+}
+
+func groupTOMLEdges(n *Node) []tomlGroup {
+	var groups []tomlGroup
+	index := make(map[string]int, len(n.Edges))
+	for _, e := range n.Edges {
+		if i, ok := index[e.Label]; ok {
+			groups[i].children = append(groups[i].children, e.Target)
+			continue
+		}
+		index[e.Label] = len(groups)
+		groups = append(groups, tomlGroup{label: e.Label, children: []Target{e.Target}})
+	}
+	return groups
+}
+
+// writeTOMLTopLevel implements §7.3.1's write(node, format) at the
+// document root: one `key = value` (or `key = [values]`) line per group,
+// per the grouping and count-1 rules — see WriteTOML's doc comment for
+// why nested tables are written as inline-table values here rather than
+// `[section]` headers.
+func writeTOMLTopLevel(b *strings.Builder, n *Node) error {
+	groups := groupTOMLEdges(n)
+	for _, g := range groups {
+		writeTOMLKey(b, g.label)
+		b.WriteString(" = ")
+		if err := writeTOMLGroupValue(b, g, "$."+g.label); err != nil {
+			return err
+		}
+		b.WriteByte('\n')
+	}
+	return nil
+}
+
+// writeTOMLGroupValue renders one group's value per §7.3.1's count-1
+// rule: a bare rendering of the single target when the group has exactly
+// one child, an inline array of renderings otherwise.
+func writeTOMLGroupValue(b *strings.Builder, g tomlGroup, path string) error {
+	if len(g.children) == 1 {
+		return writeTOMLTarget(b, g.children[0], path)
+	}
+	b.WriteByte('[')
+	for i, t := range g.children {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		if err := writeTOMLTarget(b, t, fmt.Sprintf("%s[%d]", path, i)); err != nil {
+			return err
+		}
+	}
+	b.WriteByte(']')
+	return nil
+}
+
+// writeTOMLTarget renders one Target: an inline table for a Node, a
+// scalar literal (or the null failure) for a Value.
+func writeTOMLTarget(b *strings.Builder, t Target, path string) error {
+	if node, ok := t.Node(); ok {
+		return writeTOMLInlineTable(b, node, path)
+	}
+	v, _ := t.Value()
+	if v.IsNull {
+		return Diagnostic{
+			Path:     path,
+			Code:     CodeFormatNullUnrepresentable,
+			Message:  "a null leaf cannot be written in TOML, so it is dropped",
+			Severity: SeverityWarning,
+		}
+	}
+	writeTOMLScalar(b, v.Scalar)
+	return nil
+}
+
+// writeTOMLInlineTable renders n as a TOML inline table (`{k = v, ...}`),
+// applying the same grouping/count-1 rules writeTOMLTopLevel applies at
+// the root — an inline table is exactly a nested write(node, format).
+func writeTOMLInlineTable(b *strings.Builder, n *Node, path string) error {
+	groups := groupTOMLEdges(n)
+	b.WriteByte('{')
+	for i, g := range groups {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		writeTOMLKey(b, g.label)
+		b.WriteString(" = ")
+		if err := writeTOMLGroupValue(b, g, path+"."+g.label); err != nil {
+			return err
+		}
+	}
+	b.WriteByte('}')
+	return nil
+}
+
+// writeTOMLKey renders a label as a TOML quoted (basic string) key,
+// unconditionally — never bare. A bare TOML key is restricted to
+// `[A-Za-z0-9_-]+`; rather than replicate that bareness test here (and
+// risk missing a character class TOML's grammar excludes), every label is
+// quoted, mirroring buildYAMLNode's identical unconditional-quoting
+// reasoning (yaml_writer.go) for the identical reason: a quoted key is
+// always valid, with no bareness rule to get right or wrong.
+func writeTOMLKey(b *strings.Builder, label string) {
+	writeTOMLString(b, label)
+}
+
+// writeTOMLScalar renders one leaf. Every kind but KindTime has a native
+// TOML spelling with no stringification needed at all — see WriteTOML's
+// doc comment and ReadTOML's "Offset vs. local datetime" section for the
+// datetime reasoning. KindTime is the one kind that needs a small
+// adjustment on write: see the case below.
+func writeTOMLScalar(b *strings.Builder, s Scalar) {
+	switch s.Kind {
+	case KindString:
+		writeTOMLString(b, s.Str)
+	case KindInteger:
+		b.WriteString(s.Int.String())
+	case KindNumber:
+		writeTOMLNumber(b, s.Num)
+	case KindBoolean:
+		if s.Bool {
+			b.WriteString("true")
+		} else {
+			b.WriteString("false")
+		}
+	case KindDate:
+		b.WriteString(formatISODate(s.Date))
+	case KindTime:
+		// TOML's local-time literal (partial-time in its grammar) has no
+		// offset field at all — only a full datetime can carry one. No
+		// reader in this package currently ever produces a KindTime
+		// scalar with HasOffset set (only a KindDateTime's embedded
+		// TimeValue carries an offset in practice), but the Document
+		// model does not forbid the combination at the type level, so
+		// this guards it explicitly rather than emitting a spelling
+		// TOML's own time-literal grammar would reject: the offset is
+		// dropped from a bare KindTime write (narrow/cosmetic — there is
+		// no TOML spelling of "a bare time of day with a UTC offset" to
+		// preserve it in).
+		t := s.Time
+		t.HasOffset = false
+		b.WriteString(formatISOTime(t))
+	default: // KindDateTime
+		b.WriteString(formatISODate(s.DateTime.Date) + "T" + formatISOTime(s.DateTime.Time))
+	}
+}
+
+// writeTOMLNumber renders a KindNumber leaf. A finite value always gets a
+// decimal point or exponent (mirroring writeJSONNumber's/buildYAMLNumber's
+// identical reasoning: without it, this reader's own int-vs-float split —
+// decided purely by the literal's shape, per ReadTOML's doc comment —
+// would read a whole-number float back as an integer, silently flipping
+// its kind on round-trip). NaN/Infinity use TOML's own native spellings
+// (confirmed against the grammar and against ReadTOML's own
+// parseTOMLFloat, which accepts them back) — unlike WriteJSON, no
+// substitution or strict mode is needed, matching WriteYAML's identical
+// reasoning for YAML's own native nan/inf spellings.
+func writeTOMLNumber(b *strings.Builder, f float64) {
+	switch {
+	case math.IsNaN(f):
+		b.WriteString("nan")
+	case math.IsInf(f, 1):
+		b.WriteString("inf")
+	case math.IsInf(f, -1):
+		b.WriteString("-inf")
+	default:
+		s := strconv.FormatFloat(f, 'g', -1, 64)
+		if !strings.ContainsAny(s, ".eE") {
+			s += ".0"
+		}
+		b.WriteString(s)
+	}
+}
+
+// writeTOMLString renders s as a TOML basic string literal (double
+// quoted), escaping exactly what TOML's basic-string grammar requires:
+// '"', '\\', the named short escapes for backspace/formfeed/newline/
+// CR/tab, and \u00XX for every other control character — the same escape
+// set writeJSONString (json_writer.go) uses, which TOML's basic-string
+// grammar shares control-character-for-control-character with JSON's.
+// Non-ASCII characters pass through as literal UTF-8: TOML basic strings
+// are valid UTF-8 text and have no requirement to \u-escape non-ASCII
+// content, mirroring writeJSONString's identical reasoning.
+func writeTOMLString(b *strings.Builder, s string) {
+	b.WriteByte('"')
+	for _, r := range s {
+		switch {
+		case r == '"':
+			b.WriteString(`\"`)
+		case r == '\\':
+			b.WriteString(`\\`)
+		case r == '\b':
+			b.WriteString(`\b`)
+		case r == '\f':
+			b.WriteString(`\f`)
+		case r == '\n':
+			b.WriteString(`\n`)
+		case r == '\r':
+			b.WriteString(`\r`)
+		case r == '\t':
+			b.WriteString(`\t`)
+		case r < 0x20:
+			fmt.Fprintf(b, `\u%04x`, r)
+		default:
+			b.WriteRune(r)
+		}
+	}
+	b.WriteByte('"')
+}

--- a/toml_writer_test.go
+++ b/toml_writer_test.go
@@ -1,0 +1,341 @@
+package omnist
+
+import (
+	"math"
+	"math/big"
+	"strings"
+	"testing"
+)
+
+func TestWriteTOMLGroupingAndCountOne(t *testing.T) {
+	d := NodeDocument(NewNode().
+		AddValue("a", ScalarValue(NewIntegerScalar(big.NewInt(1)))).
+		AddValue("m", ScalarValue(NewStringScalar("A"))).
+		AddValue("m", ScalarValue(NewStringScalar("B"))))
+	out, err := WriteTOML(d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	back, err := ReadTOML(out, DefaultLimits())
+	if err != nil {
+		t.Fatalf("round-trip parse failed on %q: %v", out, err)
+	}
+	if !docEqual(d, back) {
+		t.Errorf("round-trip mismatch: wrote %q, read back %+v, want %+v", out, back, d)
+	}
+	if !strings.Contains(out, "[") {
+		t.Errorf("expected an inline array for the repeated label m, got %q", out)
+	}
+}
+
+func TestWriteTOMLSingleLabelIsBareValueNotList(t *testing.T) {
+	d := NodeDocument(NewNode().AddValue("a", ScalarValue(NewIntegerScalar(big.NewInt(1)))))
+	out, err := WriteTOML(d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, "[") {
+		t.Errorf("a single-child group must not be rendered as a list: got %q", out)
+	}
+}
+
+// --- worked example round-trip ---
+
+func TestWriteTOMLRoundTripsWorkedExample(t *testing.T) {
+	address := NewNode().AddValue("street", ScalarValue(NewStringScalar("1 Main"))).
+		AddValue("city", ScalarValue(NewStringScalar("London")))
+	item1 := NewNode().AddValue("sku", ScalarValue(NewStringScalar("W"))).
+		AddValue("qty", ScalarValue(NewIntegerScalar(big.NewInt(3)))).
+		AddValue("price", ScalarValue(NewNumberScalar(9.99)))
+	item2 := NewNode().AddValue("sku", ScalarValue(NewStringScalar("G"))).
+		AddValue("qty", ScalarValue(NewIntegerScalar(big.NewInt(1)))).
+		AddValue("price", ScalarValue(NewNumberScalar(9.99)))
+	order := NewNode().
+		AddValue("id", ScalarValue(NewStringScalar("A1"))).
+		AddValue("status", ScalarValue(NewStringScalar("shipped"))).
+		AddValue("total", ScalarValue(NewNumberScalar(29.97))).
+		AddNode("address", address).
+		AddNode("items", item1).
+		AddNode("items", item2)
+	d := NodeDocument(NewNode().AddNode("order", order))
+
+	out, err := WriteTOML(d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	back, err := ReadTOML(out, DefaultLimits())
+	if err != nil {
+		t.Fatalf("round-trip parse failed on %q: %v", out, err)
+	}
+	if !docEqual(d, back) {
+		t.Errorf("round-trip mismatch: wrote %q,\ngot  %+v,\nwant %+v", out, back, d)
+	}
+}
+
+// --- native temporal round-trip: date/time/datetime all survive bare ---
+
+func TestWriteTOMLTemporalRoundTripAllThreeKinds(t *testing.T) {
+	d := NodeDocument(NewNode().
+		AddValue("d", ScalarValue(NewDateScalar(DateValue{Year: 2024, Month: 1, Day: 1}))).
+		AddValue("t", ScalarValue(NewTimeScalar(TimeValue{Hour: 12, Minute: 30, Second: 45}))).
+		AddValue("dt", ScalarValue(NewDateTimeScalar(DateTimeValue{
+			Date: DateValue{Year: 2024, Month: 1, Day: 1},
+			Time: TimeValue{Hour: 12},
+		}))))
+	out, err := WriteTOML(d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	back, err := ReadTOML(out, DefaultLimits())
+	if err != nil {
+		t.Fatalf("round-trip parse failed on %q: %v", out, err)
+	}
+	if !docEqual(d, back) {
+		t.Errorf("round-trip mismatch: wrote %q,\ngot  %+v,\nwant %+v", out, back, d)
+	}
+	// Confirm none of the three kinds degraded to a string — unlike
+	// YAML's writer, which has to stringify (quote) KindTime because
+	// YAML's own core schema has no bare spelling for it. TOML does.
+	for _, e := range back.Node.Edges {
+		v, _ := e.Target.Value()
+		if v.Scalar.Kind == KindString {
+			t.Errorf("label %s degraded to a string on round-trip: %q", e.Label, out)
+		}
+	}
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		parts := strings.SplitN(line, " = ", 2)
+		if len(parts) != 2 {
+			t.Fatalf("unexpected line %q in %q", line, out)
+		}
+		if strings.Contains(parts[1], `"`) {
+			t.Errorf("expected the value in %q to be written bare (unquoted)", line)
+		}
+	}
+}
+
+func TestWriteTOMLOffsetDateTimeRoundTrips(t *testing.T) {
+	d := NodeDocument(NewNode().AddValue("dt", ScalarValue(NewDateTimeScalar(DateTimeValue{
+		Date: DateValue{Year: 2024, Month: 1, Day: 1},
+		Time: TimeValue{Hour: 12, Minute: 0, Second: 0, HasOffset: true, OffsetSeconds: 5*3600 + 30*60},
+	}))))
+	out, err := WriteTOML(d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	back, err := ReadTOML(out, DefaultLimits())
+	if err != nil {
+		t.Fatalf("round-trip parse failed on %q: %v", out, err)
+	}
+	if !docEqual(d, back) {
+		t.Errorf("round-trip mismatch: wrote %q,\ngot  %+v,\nwant %+v", out, back, d)
+	}
+}
+
+// --- null: write-time adjustment, reported not invented ---
+
+func TestWriteTOMLNullReportsAdjustment(t *testing.T) {
+	d := NodeDocument(NewNode().AddValue("coupon", NullValue()))
+	_, err := WriteTOML(d)
+	if err == nil {
+		t.Fatal("expected an error: TOML has no null spelling")
+	}
+	diag, ok := err.(Diagnostic)
+	if !ok {
+		t.Fatalf("error is %T, want Diagnostic", err)
+	}
+	if diag.Code != CodeFormatNullUnrepresentable {
+		t.Errorf("Diagnostic.Code = %s, want %s", diag.Code, CodeFormatNullUnrepresentable)
+	}
+	if diag.Path != "$.coupon" {
+		t.Errorf("Diagnostic.Path = %s, want $.coupon", diag.Path)
+	}
+	if diag.Error() == "" {
+		t.Error("Diagnostic.Error() returned empty string")
+	}
+}
+
+func TestWriteTOMLNullInsideNestedNodeReportsAdjustment(t *testing.T) {
+	d := NodeDocument(NewNode().AddNode("order", NewNode().AddValue("coupon", NullValue())))
+	_, err := WriteTOML(d)
+	diag, ok := err.(Diagnostic)
+	if !ok {
+		t.Fatalf("error is %T, want Diagnostic", err)
+	}
+	if diag.Path != "$.order.coupon" {
+		t.Errorf("Diagnostic.Path = %s, want $.order.coupon", diag.Path)
+	}
+}
+
+func TestWriteTOMLNullInsideListReportsAdjustment(t *testing.T) {
+	d := NodeDocument(NewNode().
+		AddValue("m", ScalarValue(NewStringScalar("A"))).
+		AddValue("m", NullValue()))
+	_, err := WriteTOML(d)
+	diag, ok := err.(Diagnostic)
+	if !ok {
+		t.Fatalf("error is %T, want Diagnostic", err)
+	}
+	if diag.Code != CodeFormatNullUnrepresentable {
+		t.Errorf("Diagnostic.Code = %s, want %s", diag.Code, CodeFormatNullUnrepresentable)
+	}
+	if diag.Path != "$.m[1]" {
+		t.Errorf("Diagnostic.Path = %s, want $.m[1]", diag.Path)
+	}
+}
+
+// --- bare-scalar-root rejection ---
+
+func TestWriteTOMLBareScalarRootFails(t *testing.T) {
+	d := ValueDocument(ScalarValue(NewStringScalar("x")))
+	_, err := WriteTOML(d)
+	if err == nil {
+		t.Fatal("expected an error: TOML has no bare-scalar-root spelling")
+	}
+	diag, ok := err.(Diagnostic)
+	if !ok {
+		t.Fatalf("error is %T, want Diagnostic", err)
+	}
+	if diag.Code != CodeWriteUnsupportedValue {
+		t.Errorf("Diagnostic.Code = %s, want %s", diag.Code, CodeWriteUnsupportedValue)
+	}
+}
+
+// --- integer/float distinction preserved ---
+
+func TestWriteTOMLNumberAlwaysDistinctFromInteger(t *testing.T) {
+	d := NodeDocument(NewNode().
+		AddValue("i", ScalarValue(NewIntegerScalar(big.NewInt(2)))).
+		AddValue("f", ScalarValue(NewNumberScalar(2.0))))
+	out, err := WriteTOML(d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	back, err := ReadTOML(out, DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !docEqual(d, back) {
+		t.Errorf("round-trip mismatch: wrote %q,\ngot  %+v,\nwant %+v", out, back, d)
+	}
+}
+
+func TestWriteTOMLNaNInfinityNativeSpellings(t *testing.T) {
+	d := NodeDocument(NewNode().
+		AddValue("a", ScalarValue(NewNumberScalar(math.NaN()))).
+		AddValue("b", ScalarValue(NewNumberScalar(math.Inf(1)))).
+		AddValue("c", ScalarValue(NewNumberScalar(math.Inf(-1)))))
+	out, err := WriteTOML(d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	back, err := ReadTOML(out, DefaultLimits())
+	if err != nil {
+		t.Fatalf("round-trip parse failed on %q: %v", out, err)
+	}
+	if !docEqual(d, back) {
+		t.Errorf("round-trip mismatch (NaN-aware): wrote %q,\ngot  %+v,\nwant %+v", out, back, d)
+	}
+}
+
+// --- KindTime with an (unusual) offset set: dropped, not malformed ---
+
+func TestWriteTOMLBareTimeWithOffsetDropsOffset(t *testing.T) {
+	d := NodeDocument(NewNode().AddValue("t", ScalarValue(NewTimeScalar(TimeValue{
+		Hour: 12, Minute: 0, Second: 0, HasOffset: true, OffsetSeconds: 3600,
+	}))))
+	out, err := WriteTOML(d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	back, err := ReadTOML(out, DefaultLimits())
+	if err != nil {
+		t.Fatalf("round-trip parse failed on %q: %v", out, err)
+	}
+	v, _ := back.Node.Edges[0].Target.Value()
+	if v.Scalar.Kind != KindTime || v.Scalar.Time.HasOffset {
+		t.Errorf("got %+v, want a bare local time with no offset", v)
+	}
+}
+
+// --- string escaping ---
+
+func TestWriteTOMLStringEscaping(t *testing.T) {
+	d := NodeDocument(NewNode().AddValue("s", ScalarValue(NewStringScalar("a\nb\tc\"d\\e\bf\rg\fh\x01i"))))
+	out, err := WriteTOML(d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	back, err := ReadTOML(out, DefaultLimits())
+	if err != nil {
+		t.Fatalf("round-trip parse failed on %q: %v", out, err)
+	}
+	if !docEqual(d, back) {
+		t.Errorf("round-trip mismatch: wrote %q,\ngot  %+v,\nwant %+v", out, back, d)
+	}
+}
+
+// --- keys always quoted, including ones that would need it ---
+
+func TestWriteTOMLQuotesEveryKey(t *testing.T) {
+	d := NodeDocument(NewNode().AddValue("has space", ScalarValue(NewIntegerScalar(big.NewInt(1)))))
+	out, err := WriteTOML(d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	back, err := ReadTOML(out, DefaultLimits())
+	if err != nil {
+		t.Fatalf("round-trip parse failed on %q: %v", out, err)
+	}
+	if !docEqual(d, back) {
+		t.Errorf("round-trip mismatch: wrote %q,\ngot  %+v,\nwant %+v", out, back, d)
+	}
+}
+
+// --- booleans ---
+
+func TestWriteTOMLBooleans(t *testing.T) {
+	d := NodeDocument(NewNode().
+		AddValue("t", ScalarValue(NewBooleanScalar(true))).
+		AddValue("f", ScalarValue(NewBooleanScalar(false))))
+	out, err := WriteTOML(d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	back, err := ReadTOML(out, DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !docEqual(d, back) {
+		t.Errorf("round-trip mismatch: wrote %q,\ngot  %+v,\nwant %+v", out, back, d)
+	}
+}
+
+// --- empty node ---
+
+func TestWriteTOMLEmptyNode(t *testing.T) {
+	d := NodeDocument(NewNode())
+	out, err := WriteTOML(d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "" {
+		t.Errorf("got %q, want empty output for an empty node", out)
+	}
+}
+
+// --- nested node (inline table) ---
+
+func TestWriteTOMLNestedNode(t *testing.T) {
+	d := NodeDocument(NewNode().AddNode("a", NewNode().AddValue("b", ScalarValue(NewIntegerScalar(big.NewInt(1))))))
+	out, err := WriteTOML(d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	back, err := ReadTOML(out, DefaultLimits())
+	if err != nil {
+		t.Fatalf("round-trip parse failed on %q: %v", out, err)
+	}
+	if !docEqual(d, back) {
+		t.Errorf("round-trip mismatch: wrote %q,\ngot  %+v,\nwant %+v", out, back, d)
+	}
+}


### PR DESCRIPTION
Closes #27.

Implements the TOML codec: reader (§7.1, formats/toml.md) and writer (§7.3), using `github.com/pelletier/go-toml/v2`'s low-level `unstable` (raw AST) package rather than its high-level `Unmarshal`.

Four real library-behavior gaps found and worked around, each verified by reading the library's own source/behavior directly rather than trusting its docs (same discipline as issue #25's YAML work):
- High-level `Unmarshal` loses key order via Go maps; the raw AST token stream preserves exact source order, so the reader is built on that instead.
- The library's own integer decode path hard-fails past int64 -- a real gap against spec's 4,300-digit `integer` requirement. The reader bypasses it entirely, parsing the AST's raw integer token text into `*big.Int` directly.
- Go's `strconv.ParseFloat` rejects `-nan`/`+nan` even though TOML's grammar permits a signed nan -- found and special-cased.
- The library's own doc comment for inline-table children is wrong (claims `InlineTable` kind, empirically `KeyValue`).

Independently verified: 100% per-function coverage, 0 lint issues. All four library-behavior claims above were independently reproduced by the reviewer with its own throwaway verification program, not just re-read from the report. The writer's raw text output was fed through the *external* library's own `Unmarshal` (not this repo's own reader) as an independent validity check -- confirms the writer's inline-only-syntax design choice (never emits `[section]`/`[[section]]`, sidesteps TOML's header-positional rules) produces genuinely valid TOML, not just output that's self-consistent with this repo's own parser.

Offset-vs-local datetime reuses the `TimeValue.HasOffset`/`OffsetSeconds` mechanism already built for YAML (issue #25) -- no new mechanism, no lossy conversion, round-trip confirmed. Native temporal round-trip for all three of date/time/datetime confirmed working end to end -- the one case where TOML's writer does strictly better than YAML's (YAML couldn't round-trip `time`). Null and bare-scalar-root write rejection confirmed producing the correct diagnostic codes (`format.null-unrepresentable`, `write.unsupported-value`), not silent drops or crashes.

No load-bearing spec ambiguity. One narrow, documented, non-blocking gap: TOML's "cannot redefine an already-defined key" rule isn't independently re-validated by this reader, consistent with how the JSON/YAML readers also don't re-enforce grammar-adjacent rules their own libraries already handle at a different layer.