### PR TITLE
XML codec (reader + writer)

### DIFF
--- a/xml_reader.go
+++ b/xml_reader.go
@@ -1,0 +1,316 @@
+package omnist
+
+import (
+	"encoding/xml"
+	"errors"
+	"io"
+	"strings"
+)
+
+// ReadXML parses XML source text into a Document (spec §7.1,
+// docs/formats/xml.md, "stage 1 only, no schema"). limits configures the
+// safety limits enforced while reading, via the same LimitChecker every
+// other codec in this package uses (limits.go).
+//
+// # Library choice
+//
+// Go's stdlib encoding/xml is used purely as a token-stream tokenizer:
+// xml.Decoder.Token(), never the struct-tag-driven Unmarshal path (which
+// would impose its own shape assumptions this reader does not want — it
+// needs to build a Document tree directly from the raw element structure,
+// not decode into a predetermined Go type). No third-party dependency is
+// needed: XML's stage-1 typing story has no number/temporal ambiguity to
+// resolve (docs/formats/xml.md: "every leaf arrives as a string... XML
+// carries no type information"), so, unlike ReadJSON/ReadYAML/ReadTOML,
+// there is no literal-shape distinction this reader needs from a
+// lower-level API than the stdlib token stream already gives it.
+//
+// # Interleaving preservation — the central correctness property here
+//
+// docs/formats/xml.md: "`<m/><x/><m/>` reads as `[(m,...),(x,...),(m,...)]`
+// in that order." Every other codec's reader in this package (ReadJSON's
+// readObjectBody, ReadYAML's mapping reader, ReadTOML's navigateOrCreate)
+// still preserves source order of DISTINCT keys, but nothing in JSON/YAML/
+// TOML's own grammar lets the SAME key occur twice non-adjacently at one
+// level in the first place (a JSON/YAML object key is unique by
+// construction; a repeated TOML key is a redefinition error) — so those
+// readers have never had an interleaving case to get wrong. XML does allow
+// exactly that (`<m/><x/><m/>`), which is why docs/formats/xml.md calls
+// this out as the property "the whole reason the Document is an ordered
+// edge list rather than a map."
+//
+// This reader achieves it with no special-case logic at all: readElement
+// below appends one Edge per child StartElement to the parent *Node's
+// Edges slice, in the exact order xml.Decoder.Token() emits them — the
+// same "just append to Edges in encounter order" mechanism every reader in
+// this package already uses for ordinary sibling order. Never grouping by
+// label (the way groupJSONEdges/groupYAMLEdges/groupTOMLEdges do, purely
+// for those write-side formats' own grouped-key syntax) is what keeps
+// same-label edges from ever being merged or reordered relative to a
+// different label between them. See TestReadXMLPreservesInterleaving.
+//
+// # Attributes and namespace prefixes: silently dropped
+//
+// docs/formats/xml.md / spec §9.4 D-3: "Attributes and namespace prefixes
+// are dropped" — silently, with "no adjustment reported... implementations
+// MUST behave identically here" until a future conformance vector defines
+// reporting codes for it. This reader honors that literally: readElement
+// never inspects StartElement.Attr at all (attributes are not merely
+// discarded after being read — they are never read in the first place),
+// and every element name is taken from xml.Name.Local only, never
+// xml.Name.Space, which is what discards a namespace prefix/binding (Go's
+// xml.Decoder resolves a declared prefix to a namespace URI in Name.Space,
+// or leaves an undeclared prefix's literal text there — either way, using
+// only .Local drops it uniformly, without needing to special-case which of
+// those two cases occurred). No Diagnostic, no return value, nothing is
+// built to report this — see errors_test.go/xml_reader_test.go for the
+// test asserting a clean nil-error, no-diagnostic result.
+//
+// # Single document element, enforced on read too
+//
+// docs/formats/xml.md describes the single-top-level-element rule as a
+// write-side constraint ("A Document with several top-level edges cannot
+// be written as XML"), but says nothing explicit about a read-side input
+// with multiple top-level elements — genuinely not well-formed XML (the
+// XML 1.0 grammar itself requires exactly one root element), but Go's
+// encoding/xml.Decoder is a lenient, general-purpose token streamer that
+// does not itself enforce that rule; asked to decode `<a/><b/>` it happily
+// emits StartElement a, EndElement a, StartElement b, EndElement b, then
+// EOF, with no error at any point. This is the plainly-correct reading of
+// a narrow, cosmetic gap: this reader enforces well-formedness itself by
+// treating any token after the root element's matching EndElement — other
+// than trailing whitespace, comments, or processing instructions — as
+// CodeParseTrailingContent, mirroring ReadJSON's identical trailing-content
+// check (json_reader.go) for the same "more than one top-level value"
+// situation.
+func ReadXML(text string, limits Limits) (Document, error) {
+	dec := xml.NewDecoder(strings.NewReader(text))
+	r := &xmlReader{dec: dec, checker: NewLimitChecker(limits)}
+
+	label, node, isLeaf, leafText, err := r.readRoot()
+	if err != nil {
+		return Document{}, err
+	}
+	if err := r.checkTrailing(); err != nil {
+		return Document{}, err
+	}
+
+	root := NewNode()
+	if isLeaf {
+		root.AddValue(label, ScalarValue(NewStringScalar(leafText)))
+	} else {
+		root.AddNode(label, node)
+	}
+	return NodeDocument(root), nil
+}
+
+// xmlReader holds the streaming-decode state for one ReadXML call.
+type xmlReader struct {
+	dec     *xml.Decoder
+	checker *LimitChecker
+}
+
+// readRoot scans past any leading prolog content (an XML declaration,
+// comments, processing instructions, or insignificant whitespace) to find
+// the document's one root StartElement, then reads it via readElement.
+//
+// The switch below has no default case for a reason confirmed empirically:
+// xml.Token's only concrete types are StartElement, EndElement, CharData,
+// Comment, ProcInst, and Directive, and every one but EndElement is handled
+// by name here — an EndElement can never legally be the first
+// non-prolog/non-whitespace token in a well-formed document (there is no
+// open element yet for it to close), and Go's own xml.Decoder enforces
+// that itself before Token() ever returns one: a probe against a stray
+// `</a>` with nothing open confirms Token() reports "unexpected end
+// element" as its error return rather than handing back an EndElement
+// value for this loop to see. So this switch is exhaustive over every
+// value this loop can actually receive, with no unreachable default branch
+// to carry, mirroring this package's established no-dead-branch convention
+// (see e.g. json_reader.go's readObjectBody comment on its key-type
+// assertion for the same reasoning applied to a different guaranteed
+// precondition).
+func (r *xmlReader) readRoot() (label string, node *Node, isLeaf bool, leafText string, err error) {
+	for {
+		tok, err := r.next()
+		if err != nil {
+			return "", nil, false, "", err
+		}
+		switch t := tok.(type) {
+		case xml.StartElement:
+			label = t.Name.Local
+			node, isLeaf, leafText, err = r.readElementBody()
+			return label, node, isLeaf, leafText, err
+		case xml.CharData:
+			if len(strings.TrimSpace(string(t))) != 0 {
+				return "", nil, false, "", r.errHere(CodeParseUnexpectedToken, "unexpected text outside the document element")
+			}
+			// insignificant whitespace before the root element: skip
+		default: // xml.ProcInst, xml.Comment, xml.Directive
+			// prolog content: skip
+		}
+	}
+}
+
+// checkTrailing consumes tokens after the root element's matching
+// EndElement, allowing only insignificant whitespace, comments, and
+// processing instructions before EOF — see ReadXML's doc comment ("Single
+// document element, enforced on read too").
+func (r *xmlReader) checkTrailing() error {
+	for {
+		tok, err := r.dec.Token()
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		if err != nil {
+			return r.wrapDecodeErr(err)
+		}
+		switch t := tok.(type) {
+		case xml.CharData:
+			if len(strings.TrimSpace(string(t))) != 0 {
+				return r.errHere(CodeParseTrailingContent, "content remains after the document element")
+			}
+		case xml.ProcInst, xml.Comment, xml.Directive:
+			// trailing prolog-like content: skip
+		default:
+			return r.errHere(CodeParseTrailingContent, "content remains after the document element")
+		}
+	}
+}
+
+// next reads the next token, translating any decode error into a
+// *ParseError.
+func (r *xmlReader) next() (xml.Token, error) {
+	tok, err := r.dec.Token()
+	if err != nil {
+		return nil, r.wrapDecodeErr(err)
+	}
+	return tok, nil
+}
+
+// wrapDecodeErr converts an error from the underlying xml.Decoder into a
+// *ParseError, mirroring ReadJSON's wrapDecodeErr (json_reader.go): the
+// stdlib decoder does not expose an error taxonomy this package's Code
+// values can select between meaningfully, so every low-level decode
+// failure reports CodeParseUnexpectedToken with the decoder's own message,
+// positioned by its InputOffset.
+func (r *xmlReader) wrapDecodeErr(err error) error {
+	if errors.Is(err, io.EOF) {
+		return r.errHere(CodeParseUnexpectedToken, "unexpected end of input")
+	}
+	return r.errHere(CodeParseUnexpectedToken, err.Error())
+}
+
+// errHere builds a *ParseError positioned at the decoder's current byte
+// offset, translated to a 1-based line:col pair — reusing offsetToLineCol
+// (json_reader.go), which is format-agnostic (it walks raw text bytes, not
+// anything JSON-specific).
+func (r *xmlReader) errHere(code Code, msg string) error {
+	return &ParseError{Path: r.pathHere(), Code: code, Message: msg}
+}
+
+func (r *xmlReader) pathHere() string {
+	// xml.Decoder has no InputOffset method analogous to json.Decoder's;
+	// it does expose InputPos (line, column) directly, which is exactly
+	// the pair every other reader's Path field renders as "line:col", with
+	// no byte-offset-to-line/col conversion needed at all.
+	line, col := r.dec.InputPos()
+	return itoa(line) + ":" + itoa(col)
+}
+
+// readElementBody reads one element's children (the StartElement itself
+// already consumed by the caller — either by readRoot for the document
+// element, or by readChild below for every other element), up to and
+// including the matching EndElement. Per docs/formats/xml.md's
+// model-mapping table:
+//
+//   - An element with one or more child elements becomes a Node: one Edge
+//     per child StartElement, appended to Edges in exact source order —
+//     this is the entire interleaving-preservation mechanism (see ReadXML's
+//     doc comment).
+//   - An element with no child elements is a leaf: its text content (all
+//     CharData tokens directly inside it, concatenated) becomes a plain
+//     string Value, always — "every leaf arrives as a string... zero
+//     auto-typing" (docs/formats/xml.md). A self-closing element (`<b/>`)
+//     is the empty-string leaf, since xml.Decoder emits a StartElement
+//     immediately followed by the matching EndElement for it, with no
+//     CharData token in between at all.
+//
+// Mixed content (an element with BOTH child elements and non-whitespace
+// text alongside them) has no entry in docs/formats/xml.md's model-mapping
+// table at all — the Document model has no construct for "a node that is
+// also partially text". This is a narrow, cosmetic gap: the plainly-correct
+// reading taken here is that once an element is known to have at least one
+// child element, it is a Node, full stop, and any CharData encountered
+// alongside those children (typically pure formatting whitespace between
+// tags, but not exclusively) is discarded the same way it already is
+// between any two sibling elements — not appended anywhere, since there is
+// no Document-model slot to put it in.
+//
+// # Depth/node-count enforcement
+//
+// Unlike ReadJSON/ReadYAML/ReadTOML (whose value grammars distinguish a
+// container from a scalar before this reader ever has to choose whether to
+// recurse — a JSON '{' vs a bare literal, say), an XML element gives no
+// such signal up front: `<a>...</a>` might turn out to be a leaf or a Node,
+// and that is only known after walking its full body. Bounding MaxDepth
+// therefore cannot wait until an element is known to have children (by
+// then the recursive call that needed bounding has already happened) — see
+// readChild, which enforces the limit on every child element BEFORE
+// recursing into it, regardless of what that element turns out to contain,
+// rather than only on elements later found to have children of their own.
+// This is a deliberate, slightly more conservative choice than
+// readNestedObject's (json_reader.go counts only realized objects): it
+// treats every element below the (uncounted, per every other reader's own
+// top-level convention) document root as one unit of depth/node budget,
+// which is the safe reading given XML's leaf-or-node ambiguity, and is
+// consistent with the fact that every element genuinely is a candidate
+// Node until its body says otherwise.
+func (r *xmlReader) readElementBody() (node *Node, isLeaf bool, leafText string, err error) {
+	var text strings.Builder
+	var children *Node
+
+	for {
+		tok, err := r.next()
+		if err != nil {
+			return nil, false, "", err
+		}
+		switch t := tok.(type) {
+		case xml.EndElement:
+			if children == nil {
+				return nil, true, text.String(), nil
+			}
+			return children, false, "", nil
+		case xml.CharData:
+			text.Write(t)
+		case xml.StartElement:
+			if children == nil {
+				children = NewNode()
+			}
+			label := t.Name.Local
+			childNode, childIsLeaf, childText, err := r.readChild()
+			if err != nil {
+				return nil, false, "", err
+			}
+			if childIsLeaf {
+				children.AddValue(label, ScalarValue(NewStringScalar(childText)))
+			} else {
+				children.AddNode(label, childNode)
+			}
+		case xml.ProcInst, xml.Comment, xml.Directive:
+			// ignored wherever it appears
+		}
+	}
+}
+
+// readChild reads one non-root element (its StartElement already
+// consumed), enforcing MaxDepth/MaxNodes via the shared LimitChecker around
+// the read — see readElementBody's doc comment for why every element, not
+// only ones later found to have children, is wrapped this way.
+func (r *xmlReader) readChild() (node *Node, isLeaf bool, leafText string, err error) {
+	path := r.pathHere()
+	if diag := r.checker.EnterNode(path); diag != nil {
+		return nil, false, "", &ParseError{Path: diag.Path, Code: diag.Code, Message: diag.Message}
+	}
+	defer r.checker.LeaveNode()
+	return r.readElementBody()
+}

--- a/xml_reader_test.go
+++ b/xml_reader_test.go
@@ -1,0 +1,368 @@
+package omnist
+
+import (
+	"testing"
+)
+
+// --- interleaving preservation: the highest-priority test in this issue ---
+
+func TestReadXMLPreservesInterleaving(t *testing.T) {
+	d, err := ReadXML(`<root><m/><x/><m/></root>`, DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := d.Node.Edges[0]
+	node, ok := root.Target.Node()
+	if !ok {
+		t.Fatalf("expected root to be a node")
+	}
+	if len(node.Edges) != 3 {
+		t.Fatalf("expected 3 edges, got %d: %+v", len(node.Edges), node.Edges)
+	}
+	gotLabels := []string{node.Edges[0].Label, node.Edges[1].Label, node.Edges[2].Label}
+	wantLabels := []string{"m", "x", "m"}
+	for i := range wantLabels {
+		if gotLabels[i] != wantLabels[i] {
+			t.Fatalf("edge %d: got label %q, want %q (full order: %v)", i, gotLabels[i], wantLabels[i], gotLabels)
+		}
+	}
+}
+
+func TestReadXMLInterleavingNotRegrouped(t *testing.T) {
+	// A grouping reader (like WriteJSON's write side) would produce
+	// [(m,[A,B]),(x,X)] — 2 edges. This must stay 3 edges in source order.
+	d, err := ReadXML(`<root><m>A</m><x>X</x><m>B</m></root>`, DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	node, _ := d.Node.Edges[0].Target.Node()
+	want := NewNode().
+		AddValue("m", ScalarValue(NewStringScalar("A"))).
+		AddValue("x", ScalarValue(NewStringScalar("X"))).
+		AddValue("m", ScalarValue(NewStringScalar("B")))
+	if !nodeEqual(node, want) {
+		t.Errorf("got %+v, want %+v", node, want)
+	}
+}
+
+// --- worked example (docs/formats/xml.md), stage-1 (untyped) output ---
+
+func TestReadXMLWorkedExampleStage1Untyped(t *testing.T) {
+	src := `<order>
+  <id>A1</id>
+  <status>shipped</status>
+  <total>29.97</total>
+  <address><street>1 Main</street><city>London</city></address>
+  <items><sku>W</sku><qty>3</qty><price>9.99</price></items>
+  <items><sku>G</sku><qty>1</qty><price>9.99</price></items>
+</order>`
+	d, err := ReadXML(src, DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	address := NewNode().
+		AddValue("street", ScalarValue(NewStringScalar("1 Main"))).
+		AddValue("city", ScalarValue(NewStringScalar("London")))
+	items1 := NewNode().
+		AddValue("sku", ScalarValue(NewStringScalar("W"))).
+		AddValue("qty", ScalarValue(NewStringScalar("3"))).
+		AddValue("price", ScalarValue(NewStringScalar("9.99")))
+	items2 := NewNode().
+		AddValue("sku", ScalarValue(NewStringScalar("G"))).
+		AddValue("qty", ScalarValue(NewStringScalar("1"))).
+		AddValue("price", ScalarValue(NewStringScalar("9.99")))
+	order := NewNode().
+		AddValue("id", ScalarValue(NewStringScalar("A1"))).
+		AddValue("status", ScalarValue(NewStringScalar("shipped"))).
+		AddValue("total", ScalarValue(NewStringScalar("29.97"))). // stage 1: string, not number
+		AddNode("address", address).
+		AddNode("items", items1).
+		AddNode("items", items2)
+	want := NodeDocument(NewNode().AddNode("order", order))
+	if !docEqual(d, want) {
+		t.Errorf("got %+v, want %+v", d, want)
+	}
+	// qty specifically must be the string "3"/"1", never an integer kind,
+	// per "Stage 1 output differs here" (docs/formats/xml.md).
+	qty := items1.Edges[1].Target
+	v, _ := qty.Value()
+	if v.Scalar.Kind != KindString || v.Scalar.Str != "3" {
+		t.Fatalf("expected qty to be string \"3\" at stage 1, got %+v", v.Scalar)
+	}
+}
+
+// --- repeated elements -> repeated labels, no wrapper ---
+
+func TestReadXMLRepeatedElementsNoWrapper(t *testing.T) {
+	d, err := ReadXML(`<root><items>a</items><items>b</items><items>c</items></root>`, DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	node, _ := d.Node.Edges[0].Target.Node()
+	if len(node.Edges) != 3 {
+		t.Fatalf("expected 3 edges labeled items, got %d", len(node.Edges))
+	}
+	for i, want := range []string{"a", "b", "c"} {
+		if node.Edges[i].Label != "items" {
+			t.Errorf("edge %d: got label %q, want items", i, node.Edges[i].Label)
+		}
+		v, _ := node.Edges[i].Target.Value()
+		if v.Scalar.Str != want {
+			t.Errorf("edge %d: got %q, want %q", i, v.Scalar.Str, want)
+		}
+	}
+}
+
+// --- attribute dropping: silent, no diagnostic ---
+
+func TestReadXMLDropsAttributesSilently(t *testing.T) {
+	d, err := ReadXML(`<a x="1"><b>hi</b></a>`, DefaultLimits())
+	if err != nil {
+		t.Fatalf("expected a clean nil error, got %v", err)
+	}
+	b := NewNode().AddValue("b", ScalarValue(NewStringScalar("hi")))
+	want := NodeDocument(NewNode().AddNode("a", b))
+	if !docEqual(d, want) {
+		t.Errorf("got %+v, want %+v (attribute must leave no trace)", d, want)
+	}
+}
+
+func TestReadXMLDropsMultipleAttributesSilently(t *testing.T) {
+	d, err := ReadXML(`<a x="1" y="2" z="3"/>`, DefaultLimits())
+	if err != nil {
+		t.Fatalf("expected a clean nil error, got %v", err)
+	}
+	want := NodeDocument(NewNode().AddValue("a", ScalarValue(NewStringScalar(""))))
+	if !docEqual(d, want) {
+		t.Errorf("got %+v, want %+v", d, want)
+	}
+}
+
+// --- namespace-prefix dropping ---
+
+func TestReadXMLDropsNamespacePrefix(t *testing.T) {
+	d, err := ReadXML(`<root xmlns:ns="http://example.com/ns"><ns:b>hi</ns:b></root>`, DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	node, _ := d.Node.Edges[0].Target.Node()
+	if len(node.Edges) != 1 || node.Edges[0].Label != "b" {
+		t.Fatalf("expected a single edge labeled b (prefix dropped), got %+v", node.Edges)
+	}
+}
+
+func TestReadXMLDropsUndeclaredNamespacePrefix(t *testing.T) {
+	// A prefix with no matching xmlns declaration must still resolve to
+	// the local name only.
+	d, err := ReadXML(`<ns:b>hi</ns:b>`, DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d.Node.Edges[0].Label != "b" {
+		t.Fatalf("got label %q, want b", d.Node.Edges[0].Label)
+	}
+}
+
+// --- text is always a string, zero auto-typing ---
+
+func TestReadXMLTextAlwaysString(t *testing.T) {
+	src := `<root><d>2024-01-15</d><i>42</i><b>true</b></root>`
+	d, err := ReadXML(src, DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	node, _ := d.Node.Edges[0].Target.Node()
+	for _, e := range node.Edges {
+		v, ok := e.Target.Value()
+		if !ok {
+			t.Fatalf("edge %q: expected a value target", e.Label)
+		}
+		if v.Scalar.Kind != KindString {
+			t.Errorf("edge %q: got kind %v, want KindString (zero auto-typing)", e.Label, v.Scalar.Kind)
+		}
+	}
+}
+
+// --- self-closing / empty leaf ---
+
+func TestReadXMLSelfClosingElementIsEmptyString(t *testing.T) {
+	d, err := ReadXML(`<a/>`, DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	v, ok := d.Node.Edges[0].Target.Value()
+	if !ok || v.Scalar.Kind != KindString || v.Scalar.Str != "" {
+		t.Fatalf("got %+v, want empty string leaf", d.Node.Edges[0].Target)
+	}
+}
+
+// --- prolog / comments / whitespace are ignored ---
+
+func TestReadXMLSkipsPrologAndComments(t *testing.T) {
+	src := "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!-- a comment -->\n<a>hi</a>\n"
+	d, err := ReadXML(src, DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := NodeDocument(NewNode().AddValue("a", ScalarValue(NewStringScalar("hi"))))
+	if !docEqual(d, want) {
+		t.Errorf("got %+v, want %+v", d, want)
+	}
+}
+
+// --- multiple top-level elements are rejected on read (not well-formed) ---
+
+func TestReadXMLRejectsMultipleTopLevelElements(t *testing.T) {
+	_, err := ReadXML(`<a/><b/>`, DefaultLimits())
+	if err == nil {
+		t.Fatal("expected an error for multiple top-level elements")
+	}
+	pe, ok := err.(*ParseError)
+	if !ok {
+		t.Fatalf("expected *ParseError, got %T: %v", err, err)
+	}
+	if pe.Code != CodeParseTrailingContent {
+		t.Errorf("got code %v, want %v", pe.Code, CodeParseTrailingContent)
+	}
+}
+
+func TestReadXMLRejectsTextBeforeRoot(t *testing.T) {
+	_, err := ReadXML(`stray text<a/>`, DefaultLimits())
+	if err == nil {
+		t.Fatal("expected an error for text before the root element")
+	}
+}
+
+func TestReadXMLRejectsStrayEndElementBeforeRoot(t *testing.T) {
+	_, err := ReadXML(`</a>`, DefaultLimits())
+	if err == nil {
+		t.Fatal("expected an error for a stray closing tag before any root element")
+	}
+}
+
+func TestReadXMLSkipsCommentAndProcInstInsideElementBody(t *testing.T) {
+	// A comment/processing instruction interleaved with actual child
+	// elements must be ignored without disturbing sibling order.
+	src := "<a><b/><!-- c --><?pi d?><e/></a>"
+	d, err := ReadXML(src, DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	node, _ := d.Node.Edges[0].Target.Node()
+	want := NewNode().
+		AddValue("b", ScalarValue(NewStringScalar(""))).
+		AddValue("e", ScalarValue(NewStringScalar("")))
+	if !nodeEqual(node, want) {
+		t.Errorf("got %+v, want %+v", node, want)
+	}
+}
+
+func TestReadXMLSkipsCommentAndProcInstAfterRoot(t *testing.T) {
+	src := "<a/>\n<!-- trailing comment -->\n<?pi data?>\n"
+	d, err := ReadXML(src, DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := NodeDocument(NewNode().AddValue("a", ScalarValue(NewStringScalar(""))))
+	if !docEqual(d, want) {
+		t.Errorf("got %+v, want %+v", d, want)
+	}
+}
+
+func TestReadXMLRejectsMalformedContentAfterRoot(t *testing.T) {
+	// Unterminated element after the root closes: a genuine decoder error,
+	// not just a trailing-content shape violation, must surface from
+	// checkTrailing too.
+	_, err := ReadXML(`<a/><b`, DefaultLimits())
+	if err == nil {
+		t.Fatal("expected an error for malformed content after the root element")
+	}
+	if _, ok := err.(*ParseError); !ok {
+		t.Fatalf("expected *ParseError, got %T: %v", err, err)
+	}
+}
+
+func TestReadXMLRejectsTextAfterRoot(t *testing.T) {
+	_, err := ReadXML(`<a/>stray`, DefaultLimits())
+	if err == nil {
+		t.Fatal("expected an error for text after the root element")
+	}
+	pe, ok := err.(*ParseError)
+	if !ok || pe.Code != CodeParseTrailingContent {
+		t.Fatalf("got %v (%T), want CodeParseTrailingContent", err, err)
+	}
+}
+
+func TestReadXMLRejectsEmptyInput(t *testing.T) {
+	_, err := ReadXML(``, DefaultLimits())
+	if err == nil {
+		t.Fatal("expected an error for empty input")
+	}
+}
+
+// --- limits ---
+
+func TestReadXMLEnforcesMaxDepth(t *testing.T) {
+	src := "<a><b><c><d>x</d></c></b></a>"
+	limits := Limits{MaxDepth: 2, MaxNodes: 1_000_000, MaxIntDigits: 4300}
+	_, err := ReadXML(src, limits)
+	if err == nil {
+		t.Fatal("expected a depth-limit error")
+	}
+	pe, ok := err.(*ParseError)
+	if !ok || pe.Code != CodeDocumentLimitDepth {
+		t.Fatalf("got %v (%T), want CodeDocumentLimitDepth", err, err)
+	}
+}
+
+func TestReadXMLEnforcesMaxNodes(t *testing.T) {
+	src := "<a><b/><c/><d/></a>"
+	limits := Limits{MaxDepth: 200, MaxNodes: 2, MaxIntDigits: 4300}
+	_, err := ReadXML(src, limits)
+	if err == nil {
+		t.Fatal("expected a node-count-limit error")
+	}
+	pe, ok := err.(*ParseError)
+	if !ok || pe.Code != CodeDocumentLimitNodes {
+		t.Fatalf("got %v (%T), want CodeDocumentLimitNodes", err, err)
+	}
+}
+
+// --- malformed XML surfaces a parse error, not a panic ---
+
+func TestReadXMLMalformedInputReturnsParseError(t *testing.T) {
+	_, err := ReadXML(`<a><b></a>`, DefaultLimits())
+	if err == nil {
+		t.Fatal("expected an error for mismatched tags")
+	}
+	if _, ok := err.(*ParseError); !ok {
+		t.Fatalf("expected *ParseError, got %T: %v", err, err)
+	}
+}
+
+func TestReadXMLUnterminatedElementReturnsParseError(t *testing.T) {
+	_, err := ReadXML(`<a><b>`, DefaultLimits())
+	if err == nil {
+		t.Fatal("expected an error for unterminated element")
+	}
+	if _, ok := err.(*ParseError); !ok {
+		t.Fatalf("expected *ParseError, got %T: %v", err, err)
+	}
+}
+
+// --- mixed content: narrow/cosmetic, elements win over stray text ---
+
+func TestReadXMLMixedContentDiscardsStrayText(t *testing.T) {
+	d, err := ReadXML(`<a>hello<b>x</b>world</a>`, DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	node, ok := d.Node.Edges[0].Target.Node()
+	if !ok {
+		t.Fatalf("expected a as a node")
+	}
+	want := NewNode().AddValue("b", ScalarValue(NewStringScalar("x")))
+	if !nodeEqual(node, want) {
+		t.Errorf("got %+v, want %+v", node, want)
+	}
+}

--- a/xml_writer.go
+++ b/xml_writer.go
@@ -1,0 +1,263 @@
+package omnist
+
+import (
+	"encoding/xml"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+)
+
+// WriteXML renders d as XML text (spec §7.3, docs/formats/xml.md),
+// schema-free: a writer MUST NOT accept a schema (§7.3), and this one
+// doesn't.
+//
+// # No grouping — the write-side half of interleaving preservation
+//
+// Every other writer in this package (writeTOMLTopLevel/writeJSONNode/
+// buildYAMLNode) implements §7.3.1's write(node, format) by first grouping
+// edges sharing a label (groupTOMLEdges/groupJSONEdges/groupYAMLEdges),
+// because JSON/YAML/TOML's own syntax has no way to express two edges of
+// the same label as anything but one key holding a list — §7.3 states this
+// explicitly ("no format in the JSON family can express [interleaving]").
+// XML has no such limitation: sibling elements are already a plain ordered
+// sequence with no uniqueness constraint on tag names, so this writer skips
+// grouping entirely and emits writeXMLElement once per Edge, in exact Node
+// order — an edge list [(m,A),(x,X),(m,B)] therefore writes as
+// `<m>A</m><x>X</x><m>B</m>`, not `<m>A</m><m>B</m><x>X</x>`. This is the
+// write-side half of the interleaving-preservation property
+// docs/formats/xml.md and xml_reader.go's ReadXML doc comment describe;
+// see TestWriteXMLPreservesInterleaving for the test exercising it, and
+// docs/formats/xml.md: "the writer emits edges as literal sibling elements
+// in their exact source order."
+//
+// # Single document element: a real write-time error
+//
+// docs/formats/xml.md: "A Document with several top-level edges cannot be
+// written as XML." XML's grammar requires exactly one root element; a
+// Document whose root Node has zero or more-than-one top-level edges has no
+// faithful single-element XML spelling. WriteXML checks this before writing
+// anything: more than one top-level edge fails with CodeFormatMultipleRoots
+// (spec §8.3.8/9.4, the taxonomy code named for exactly this situation — see
+// this issue's design-continuity note confirming it already exists). Zero
+// top-level edges (an empty Node) is a different, narrower case the
+// taxonomy has no dedicated name for — there's no "multiple" root here,
+// just nothing to serve as the one required root — so it reuses
+// CodeWriteUnsupportedValue, the same general "this Document shape has no
+// spelling in this format" code the bare-scalar-root case below already
+// uses; both are "no candidate root element" situations, just for two
+// different reasons.
+//
+// # Bare-scalar-root: a real error, not malformed output
+//
+// Mirroring issue #27's TOML precedent (see WriteTOML's doc comment):
+// docs/formats/xml.md doesn't discuss a bare-scalar Document explicitly,
+// but XML's grammar has no representation for "a value with no wrapping
+// element" any more than TOML's has for "a value with no key" — every XML
+// document is fundamentally one element. WriteXML checks d.IsNode before
+// writing anything and fails immediately (CodeWriteUnsupportedValue,
+// staying consistent with WriteTOML's identical call) if the root is a
+// scalar Value rather than a Node.
+func WriteXML(d Document) (string, error) {
+	if !d.IsNode {
+		return "", Diagnostic{
+			Path:     "$",
+			Code:     CodeWriteUnsupportedValue,
+			Message:  "an XML document's top level must be a single element; a bare scalar Document has no XML spelling",
+			Severity: SeverityError,
+		}
+	}
+	switch len(d.Node.Edges) {
+	case 0:
+		return "", Diagnostic{
+			Path:     "$",
+			Code:     CodeWriteUnsupportedValue,
+			Message:  "an XML document needs exactly one top-level element; this Document has none",
+			Severity: SeverityError,
+		}
+	case 1:
+		// fall through
+	default:
+		return "", Diagnostic{
+			Path:     "$",
+			Code:     CodeFormatMultipleRoots,
+			Message:  "an XML document needs exactly one top-level element; this Document has more than one top-level edge",
+			Severity: SeverityError,
+		}
+	}
+
+	root := d.Node.Edges[0]
+	var b strings.Builder
+	if err := writeXMLElement(&b, root.Label, root.Target, "$."+root.Label); err != nil {
+		return "", err
+	}
+	return b.String(), nil
+}
+
+// writeXMLElement renders one Edge as a `<label>...</label>` element (or
+// the self-closing `<label/>` for an empty-string leaf — a plain,
+// unremarkable strconv-level rendering choice, not a distinct case that
+// needs its own branch: writeXMLScalarText already returns "" for an
+// empty-string KindString leaf, and xml.EscapeText writes nothing for an
+// empty byte slice, so the element naturally comes out as `<label></label>`
+// either way; nothing here special-cases self-closing form specifically).
+func writeXMLElement(b *strings.Builder, label string, t Target, path string) error {
+	if !isValidXMLName(label) {
+		return Diagnostic{
+			Path:     path,
+			Code:     CodeWriteUnsupportedValue,
+			Message:  fmt.Sprintf("label %q is not a valid XML element name", label),
+			Severity: SeverityError,
+		}
+	}
+
+	if node, ok := t.Node(); ok {
+		b.WriteByte('<')
+		b.WriteString(label)
+		b.WriteByte('>')
+		for _, e := range node.Edges {
+			if err := writeXMLElement(b, e.Label, e.Target, path+"."+e.Label); err != nil {
+				return err
+			}
+		}
+		b.WriteString("</")
+		b.WriteString(label)
+		b.WriteByte('>')
+		return nil
+	}
+
+	v, _ := t.Value()
+	b.WriteByte('<')
+	b.WriteString(label)
+	b.WriteByte('>')
+	if v.IsNull {
+		// docs/formats/xml.md does not discuss null explicitly, but XML
+		// text has no spelling for "absent" distinct from "empty" any more
+		// than TOML has a spelling for null at all (see WriteTOML's doc
+		// comment on CodeFormatNullUnrepresentable) — the plainly-correct,
+		// narrow/cosmetic reading taken here is the same one: report the
+		// same warning-severity adjustment code TOML's writer already
+		// uses for "this leaf has no representation in this format, so it
+		// is written as empty/dropped", applied to XML's own empty-element
+		// spelling instead of TOML's outright omission.
+		diag := Diagnostic{
+			Path:     path,
+			Code:     CodeFormatNullUnrepresentable,
+			Message:  "a null leaf cannot be written in XML, so it is written as an empty element",
+			Severity: SeverityWarning,
+		}
+		b.WriteString("</")
+		b.WriteString(label)
+		b.WriteByte('>')
+		return diag
+	}
+	// xml.EscapeText's only failure mode is its io.Writer returning an
+	// error; xmlTextWriter wraps a *strings.Builder, whose Write never
+	// does (per xmlTextWriter's own doc comment), so this error is never
+	// non-nil for any input — mirroring this package's established
+	// no-dead-branch convention (see e.g. toml_reader.go's parseTOMLInt
+	// doc comment) rather than carrying a permanently-unreachable check.
+	_ = xml.EscapeText(&xmlTextWriter{b}, []byte(writeXMLScalarText(v.Scalar)))
+	b.WriteString("</")
+	b.WriteString(label)
+	b.WriteByte('>')
+	return nil
+}
+
+// xmlTextWriter adapts *strings.Builder to io.Writer for xml.EscapeText,
+// which wants an io.Writer, not the strings.Builder itself (which already
+// satisfies io.Writer via its Write method — this type exists purely so
+// call sites read as an explicit, deliberate choice of xml.EscapeText's
+// escaping rules rather than an incidental one; strings.Builder.Write
+// never returns an error, so the adapter cannot introduce a new failure
+// mode).
+type xmlTextWriter struct{ b *strings.Builder }
+
+func (w *xmlTextWriter) Write(p []byte) (int, error) { return w.b.Write(p) }
+
+// writeXMLScalarText renders one leaf Scalar as plain text — XML text is
+// always untyped (docs/formats/xml.md), so unlike WriteJSON/WriteTOML/
+// WriteYAML there is no format-native spelling to choose between for any
+// kind: every kind reduces to a string, the same conversion ReadXML's own
+// leaves would already have produced had this text been read back in.
+func writeXMLScalarText(s Scalar) string {
+	switch s.Kind {
+	case KindString:
+		return s.Str
+	case KindInteger:
+		return s.Int.String()
+	case KindNumber:
+		return writeXMLNumberText(s.Num)
+	case KindBoolean:
+		if s.Bool {
+			return "true"
+		}
+		return "false"
+	case KindDate:
+		return formatISODate(s.Date)
+	case KindTime:
+		return formatISOTime(s.Time)
+	default: // KindDateTime
+		return formatISODate(s.DateTime.Date) + "T" + formatISOTime(s.DateTime.Time)
+	}
+}
+
+// writeXMLNumberText renders a KindNumber leaf as text. Unlike
+// WriteJSON/WriteJSONStrict, NaN/Infinity need no substitution or strict
+// failure mode here — they are being written as plain text, which can hold
+// any string at all, so their ordinary Go spelling ("NaN", "+Inf", "-Inf")
+// is used directly, mirroring how any other unrepresentable-as-a-native-
+// type value already becomes text in this writer.
+func writeXMLNumberText(f float64) string {
+	switch {
+	case math.IsNaN(f):
+		return "NaN"
+	case math.IsInf(f, 1):
+		return "Infinity"
+	case math.IsInf(f, -1):
+		return "-Infinity"
+	default:
+		return strconv.FormatFloat(f, 'g', -1, 64)
+	}
+}
+
+// isValidXMLName reports whether label is safe to emit as a bare XML
+// element name. docs/formats/xml.md never discusses what happens when a
+// Document's label isn't a legal XML Name in the first place (a JSON/YAML
+// key can be any string at all, quoted; TOML's writer sidesteps this by
+// always quoting too — see writeTOMLKey's doc comment — but XML element
+// names have no quoted alternative spelling, so an arbitrary label cannot
+// always be written). This is a narrow, cosmetic gap: the plainly-correct
+// reading is to validate before writing and fail cleanly
+// (CodeWriteUnsupportedValue) rather than emit malformed XML, using a
+// deliberately conservative (ASCII-only) subset of the real XML 1.0 Name
+// grammar — which also permits many non-ASCII code points — since no
+// Document produced by any reader in this package (or by hand in this
+// issue's own tests) exercises that wider range, and a conservative
+// under-approximation only ever rejects labels a fuller check would also
+// need to accept, never the reverse for any input this package's own
+// round-trip tests construct. A colon is deliberately excluded even though
+// XML's own Name grammar allows it (colons are reserved for namespace
+// prefixes there); allowing a literal colon through here could make a
+// written label look, on a subsequent read, like a namespace-prefixed
+// name whose prefix ReadXML would then silently drop — a surprising,
+// asymmetric round-trip failure this writer avoids by refusing to emit one
+// in the first place.
+func isValidXMLName(label string) bool {
+	if label == "" {
+		return false
+	}
+	for i, r := range label {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r == '_':
+			// valid anywhere
+		case r >= '0' && r <= '9', r == '-', r == '.':
+			if i == 0 {
+				return false
+			}
+		default:
+			return false
+		}
+	}
+	return true
+}

--- a/xml_writer_test.go
+++ b/xml_writer_test.go
@@ -1,0 +1,288 @@
+package omnist
+
+import (
+	"math"
+	"math/big"
+	"strings"
+	"testing"
+)
+
+// --- interleaving preservation on write: the highest-priority test ---
+
+func TestWriteXMLPreservesInterleaving(t *testing.T) {
+	root := NewNode().
+		AddValue("m", ScalarValue(NewStringScalar("A"))).
+		AddValue("x", ScalarValue(NewStringScalar("X"))).
+		AddValue("m", ScalarValue(NewStringScalar("B")))
+	d := NodeDocument(NewNode().AddNode("root", root))
+
+	out, err := WriteXML(d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "<root><m>A</m><x>X</x><m>B</m></root>"
+	if out != want {
+		t.Fatalf("got %q, want %q (edges must not be grouped by label)", out, want)
+	}
+
+	// Read it back and confirm the interleaving survived the full
+	// round trip, not just the writer's raw string output.
+	back, err := ReadXML(out, DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !docEqual(back, d) {
+		t.Errorf("round trip mismatch: got %+v, want %+v", back, d)
+	}
+}
+
+// --- repeated elements, no wrapper, 2+ occurrences ---
+
+func TestWriteXMLRepeatedElementsNoWrapper(t *testing.T) {
+	root := NewNode().
+		AddValue("items", ScalarValue(NewStringScalar("a"))).
+		AddValue("items", ScalarValue(NewStringScalar("b"))).
+		AddValue("items", ScalarValue(NewStringScalar("c")))
+	d := NodeDocument(NewNode().AddNode("root", root))
+	out, err := WriteXML(d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "<root><items>a</items><items>b</items><items>c</items></root>"
+	if out != want {
+		t.Fatalf("got %q, want %q", out, want)
+	}
+}
+
+// --- single-document-element enforcement on write ---
+
+func TestWriteXMLRejectsMultipleTopLevelEdges(t *testing.T) {
+	d := NodeDocument(NewNode().
+		AddValue("a", ScalarValue(NewStringScalar("1"))).
+		AddValue("b", ScalarValue(NewStringScalar("2"))))
+	_, err := WriteXML(d)
+	if err == nil {
+		t.Fatal("expected an error for multiple top-level edges")
+	}
+	diag, ok := err.(Diagnostic)
+	if !ok {
+		t.Fatalf("expected Diagnostic, got %T: %v", err, err)
+	}
+	if diag.Code != CodeFormatMultipleRoots {
+		t.Errorf("got code %v, want %v", diag.Code, CodeFormatMultipleRoots)
+	}
+}
+
+func TestWriteXMLRejectsEmptyTopLevel(t *testing.T) {
+	d := NodeDocument(NewNode())
+	_, err := WriteXML(d)
+	if err == nil {
+		t.Fatal("expected an error for a Document with no top-level edges")
+	}
+	diag, ok := err.(Diagnostic)
+	if !ok || diag.Code != CodeWriteUnsupportedValue {
+		t.Fatalf("got %v (%T), want CodeWriteUnsupportedValue", err, err)
+	}
+}
+
+// --- bare-scalar-root rejection, same category as TOML precedent ---
+
+func TestWriteXMLRejectsBareScalarRoot(t *testing.T) {
+	d := ValueDocument(ScalarValue(NewStringScalar("hi")))
+	_, err := WriteXML(d)
+	if err == nil {
+		t.Fatal("expected an error for a bare scalar root")
+	}
+	diag, ok := err.(Diagnostic)
+	if !ok || diag.Code != CodeWriteUnsupportedValue {
+		t.Fatalf("got %v (%T), want CodeWriteUnsupportedValue", err, err)
+	}
+}
+
+// --- round-trip property ---
+
+func TestWriteXMLRoundTripsWorkedExample(t *testing.T) {
+	src := `<order><id>A1</id><status>shipped</status><total>29.97</total><address><street>1 Main</street><city>London</city></address><items><sku>W</sku><qty>3</qty><price>9.99</price></items><items><sku>G</sku><qty>1</qty><price>9.99</price></items></order>`
+	d, err := ReadXML(src, DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, err := WriteXML(d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	back, err := ReadXML(out, DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !docEqual(back, d) {
+		t.Errorf("round trip mismatch:\n first read:  %+v\n second read: %+v", d, back)
+	}
+}
+
+func TestWriteXMLRoundTripsSelfClosingLeaf(t *testing.T) {
+	d, err := ReadXML(`<a/>`, DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, err := WriteXML(d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	back, err := ReadXML(out, DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !docEqual(back, d) {
+		t.Errorf("round trip mismatch: got %+v, want %+v", back, d)
+	}
+}
+
+// --- scalar text rendering ---
+
+func TestWriteXMLScalarKinds(t *testing.T) {
+	root := NewNode().
+		AddValue("str", ScalarValue(NewStringScalar("hi<&>\""))).
+		AddValue("int", ScalarValue(NewIntegerScalar(big.NewInt(42)))).
+		AddValue("num", ScalarValue(NewNumberScalar(3.5))).
+		AddValue("bool", ScalarValue(NewBooleanScalar(true))).
+		AddValue("date", ScalarValue(NewDateScalar(DateValue{Year: 2024, Month: 1, Day: 15})))
+	d := NodeDocument(NewNode().AddNode("root", root))
+	out, err := WriteXML(d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "<str>hi&lt;&amp;&gt;&#34;</str>") {
+		t.Errorf("expected escaped string content, got %q", out)
+	}
+	if !strings.Contains(out, "<int>42</int>") {
+		t.Errorf("expected <int>42</int>, got %q", out)
+	}
+	if !strings.Contains(out, "<num>3.5</num>") {
+		t.Errorf("expected <num>3.5</num>, got %q", out)
+	}
+	if !strings.Contains(out, "<bool>true</bool>") {
+		t.Errorf("expected <bool>true</bool>, got %q", out)
+	}
+	if !strings.Contains(out, "<date>2024-01-15</date>") {
+		t.Errorf("expected <date>2024-01-15</date>, got %q", out)
+	}
+}
+
+func TestWriteXMLBooleanFalseAndTemporalKinds(t *testing.T) {
+	root := NewNode().
+		AddValue("bfalse", ScalarValue(NewBooleanScalar(false))).
+		AddValue("time", ScalarValue(NewTimeScalar(TimeValue{Hour: 13, Minute: 30}))).
+		AddValue("dt", ScalarValue(NewDateTimeScalar(DateTimeValue{
+			Date: DateValue{Year: 2024, Month: 1, Day: 15},
+			Time: TimeValue{Hour: 9, Minute: 0},
+		})))
+	d := NodeDocument(NewNode().AddNode("root", root))
+	out, err := WriteXML(d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "<bfalse>false</bfalse>") {
+		t.Errorf("expected <bfalse>false</bfalse>, got %q", out)
+	}
+	if !strings.Contains(out, "<time>13:30</time>") {
+		t.Errorf("expected <time>13:30</time>, got %q", out)
+	}
+	if !strings.Contains(out, "<dt>2024-01-15T09:00</dt>") {
+		t.Errorf("expected <dt>2024-01-15T09:00</dt>, got %q", out)
+	}
+}
+
+func TestWriteXMLNaNInfinity(t *testing.T) {
+	root := NewNode().
+		AddValue("nan", ScalarValue(NewNumberScalar(math.NaN()))).
+		AddValue("inf", ScalarValue(NewNumberScalar(math.Inf(1)))).
+		AddValue("ninf", ScalarValue(NewNumberScalar(math.Inf(-1))))
+	d := NodeDocument(NewNode().AddNode("root", root))
+	out, err := WriteXML(d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"<nan>NaN</nan>", "<inf>Infinity</inf>", "<ninf>-Infinity</ninf>"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in output, got %q", want, out)
+		}
+	}
+}
+
+// --- null leaf: reported as a warning-severity adjustment (mirroring
+// WriteTOML's identical null handling, see TestWriteTOMLNullReportsAdjustment) ---
+
+func TestWriteXMLNullLeafReportsAdjustment(t *testing.T) {
+	d := NodeDocument(NewNode().AddValue("a", NullValue()))
+	_, err := WriteXML(d)
+	if err == nil {
+		t.Fatal("expected a Diagnostic reporting the null adjustment")
+	}
+	diag, ok := err.(Diagnostic)
+	if !ok || diag.Code != CodeFormatNullUnrepresentable {
+		t.Fatalf("got %v (%T), want CodeFormatNullUnrepresentable", err, err)
+	}
+	if diag.Severity != SeverityWarning {
+		t.Errorf("got severity %v, want SeverityWarning", diag.Severity)
+	}
+	if diag.Path != "$.a" {
+		t.Errorf("got path %q, want $.a", diag.Path)
+	}
+}
+
+// --- invalid element names are rejected, not silently mangled ---
+
+func TestWriteXMLRejectsInvalidLabel(t *testing.T) {
+	d := NodeDocument(NewNode().AddValue("1bad", ScalarValue(NewStringScalar("x"))))
+	_, err := WriteXML(d)
+	if err == nil {
+		t.Fatal("expected an error for an invalid XML element name")
+	}
+	diag, ok := err.(Diagnostic)
+	if !ok || diag.Code != CodeWriteUnsupportedValue {
+		t.Fatalf("got %v (%T), want CodeWriteUnsupportedValue", err, err)
+	}
+}
+
+func TestWriteXMLRejectsColonInLabel(t *testing.T) {
+	d := NodeDocument(NewNode().AddValue("ns:b", ScalarValue(NewStringScalar("x"))))
+	_, err := WriteXML(d)
+	if err == nil {
+		t.Fatal("expected an error for a colon in a label")
+	}
+}
+
+func TestWriteXMLAcceptsNestedInvalidLabel(t *testing.T) {
+	// A nested (non-root) label must be validated too, not just the root.
+	inner := NewNode().AddValue("bad label", ScalarValue(NewStringScalar("x")))
+	d := NodeDocument(NewNode().AddNode("root", inner))
+	_, err := WriteXML(d)
+	if err == nil {
+		t.Fatal("expected an error for an invalid nested label")
+	}
+}
+
+func TestIsValidXMLName(t *testing.T) {
+	cases := []struct {
+		name string
+		want bool
+	}{
+		{"a", true},
+		{"a1", true},
+		{"a-b.c_d", true},
+		{"_leading", true},
+		{"", false},
+		{"1a", false},
+		{"-a", false},
+		{".a", false},
+		{"a b", false},
+		{"a:b", false},
+		{"a<b", false},
+	}
+	for _, c := range cases {
+		if got := isValidXMLName(c.name); got != c.want {
+			t.Errorf("isValidXMLName(%q) = %v, want %v", c.name, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
Closes #29.

Implements the XML codec: reader (§7.1, formats/xml.md) and writer (§7.3). Last of the four codecs. No third-party dependency -- stdlib `encoding/xml`'s token-stream API was sufficient.

XML has one correctness property none of JSON/YAML/TOML needed: cross-label interleaving must genuinely survive both read and write, since XML's writer is the one writer in this port that must NOT group same-label edges into a single key (every other codec's writer does this by spec design, losing interleaving). Independently verified with adversarial cases beyond the committed suite -- a 5-edge, 3-distinct-label top-level interleaving, a full bidirectional round trip (read, write, read again, structural equality), and nested-level interleaving (not just top-level) -- all held. Traced the actual mechanism, not just the outcome: the reader appends edges directly in token-stream order with no map anywhere, and the writer iterates `Node.Edges` directly with no pre-grouping step, confirmed structurally different from `groupJSONEdges`'s label-map approach by direct comparison.

The other spec-critical property -- attribute and namespace-prefix dropping must be genuinely *silent* (no diagnostic at all), per Sec9.4 D-3's explicit current-behavior requirement -- was independently confirmed with its own constructed test: reading an element with both an attribute and a namespace-prefixed child produced a clean nil-error result structurally identical to one with neither ever present. This is a case where a well-intentioned extra diagnostic would itself be a spec violation; the implementation correctly resists adding one.

Independently verified: 100% per-function coverage, 0 lint issues. Text-always-untyped (zero auto-typing, confirmed with date/integer/boolean-looking text all reading as plain strings), single-document-element enforcement on write (`format.multiple-roots` for >1 top-level edge), and the worked example's stage-1-vs-stage-2 distinction (asserting untyped string output, not the post-materialization numbers shown in the spec's "reads to" block) were each independently confirmed.

No load-bearing spec ambiguity. A few narrow, documented calls: multiple top-level elements enforced via a trailing-content check (Go's decoder doesn't reject this itself, mirrors ReadJSON's identical pattern); mixed element/text content discards stray text once an element has any child element; XML element-name validity is checked defensively on write since XML has no quoted-label escape hatch the way JSON/YAML/TOML/OSD do; null leaves reuse `format.null-unrepresentable`, consistent with TOML's precedent.