### PR TITLE
Conformance harness: referee + Track 2 (JSON-vector) runner

### DIFF
--- a/referee.go
+++ b/referee.go
@@ -1,0 +1,258 @@
+package omnist
+
+import "math"
+
+// This file is the conformance harness's "referee": structural comparison
+// primitives built from this repository's own types and equality, never
+// another port's. See vendor/omnist-spec/docs/porting-a-conformance-runner.md
+// ("What to build, in order", step 1) and issue #31.
+//
+// DocumentsEqual promotes the docEqual/nodeEqual/targetEqual/valueEqual/
+// scalarEqual family that writer_testutil_test.go built as test-only
+// helpers (for oml_writer_test.go/osd_writer_test.go's round-trip
+// properties) to real, non-test-only referee code. SchemasEqual's "exact"
+// mode promotes recordEqual/schemaEqual the same way, with one correction:
+// the test-only recordEqual compared Fields by slice index, which is
+// wrong for a referee (spec §3.1: a record's fields are an unordered set
+// at the model layer, so field *declaration order* must not affect
+// equality — see the referee self-test's case 01). SchemasEqual's
+// "isomorphic" mode is new: no prior code in this repository attempted a
+// schema-graph isomorphism check.
+
+// DocumentsEqual reports whether a and b are the same Document: the same
+// shape (node vs. bare value), the same edges in the same order (edge
+// order is data, per spec §2.3 D-1/D-3 — this is why DocumentsEqual is
+// order-sensitive, unlike SchemasEqual's field-set comparison), and the
+// same scalar values including kind. Two NaN-valued KindNumber scalars
+// compare equal here (plain Scalar.Equal, and Go's == underneath it, does
+// not: NaN != NaN), matching the reserved "nan" OML spelling's intended
+// round-trip semantics.
+func DocumentsEqual(a, b Document) bool {
+	if a.IsNode != b.IsNode {
+		return false
+	}
+	if a.IsNode {
+		return nodesEqual(a.Node, b.Node)
+	}
+	return valuesEqual(a.Value, b.Value)
+}
+
+func valuesEqual(a, b Value) bool {
+	if a.IsNull != b.IsNull {
+		return false
+	}
+	if a.IsNull {
+		return true
+	}
+	return scalarsEqual(a.Scalar, b.Scalar)
+}
+
+// scalarsEqual defers to Scalar.Equal for every kind except KindNumber,
+// where two NaNs compare equal (see DocumentsEqual's doc comment).
+func scalarsEqual(a, b Scalar) bool {
+	if a.Kind != b.Kind {
+		return false
+	}
+	if a.Kind == KindNumber && math.IsNaN(a.Num) && math.IsNaN(b.Num) {
+		return true
+	}
+	return a.Equal(b)
+}
+
+func targetsEqual(a, b Target) bool {
+	an, aok := a.Node()
+	bn, bok := b.Node()
+	if aok != bok {
+		return false
+	}
+	if aok {
+		return nodesEqual(an, bn)
+	}
+	av, _ := a.Value()
+	bv, _ := b.Value()
+	return valuesEqual(av, bv)
+}
+
+func nodesEqual(a, b *Node) bool {
+	if len(a.Edges) != len(b.Edges) {
+		return false
+	}
+	for i := range a.Edges {
+		if a.Edges[i].Label != b.Edges[i].Label {
+			return false
+		}
+		if !targetsEqual(a.Edges[i].Target, b.Edges[i].Target) {
+			return false
+		}
+	}
+	return true
+}
+
+// SchemaEqualityMode selects one of the two schema-comparison modes the
+// porting guide calls for: ModeExact requires every record name and field
+// to match; ModeIsomorphic requires the same structure up to consistent
+// record renaming.
+type SchemaEqualityMode string
+
+const (
+	// ModeExact is used for normalize/prune/extract, whose output naming
+	// is spec-determined (§6's operations fix record names
+	// deterministically, so a naming difference is a real divergence).
+	ModeExact SchemaEqualityMode = "exact"
+	// ModeIsomorphic is used only for infer, since §6.10's infer_type
+	// never normalizes its output — two schemas that differ only in which
+	// arbitrary names infer picked for its records are still the same
+	// answer.
+	ModeIsomorphic SchemaEqualityMode = "isomorphic"
+)
+
+// SchemasEqual reports whether a and b are the same Schema under mode.
+//
+// ModeExact: the root name must match, and every record in a's env must
+// have a same-named counterpart in b's env (and vice versa, via the
+// length check) whose fields are equal as a *set* keyed by label — field
+// declaration order does not participate (spec §3.1; referee self-test
+// case 01). A field is equal when its Type and Cardinality are equal;
+// Type equality for TypeRefKind compares RefName literally in this mode
+// (no renaming is permitted), which is what makes case 04 (same shape,
+// different record names) correctly compare not-equal even though case
+// 03's identical shape compares equal under ModeIsomorphic.
+//
+// ModeIsomorphic: same structure up to a consistent renaming of records,
+// checked by walking both schemas' reference graphs from their respective
+// roots in lock-step and building a bijection between record names as new
+// ones are encountered (see schemaIsomorphic's doc comment for the
+// algorithm and its scope).
+func SchemasEqual(a, b Schema, mode SchemaEqualityMode) bool {
+	switch mode {
+	case ModeIsomorphic:
+		return schemaIsomorphic(a, b)
+	default:
+		return schemaExactEqual(a, b)
+	}
+}
+
+func schemaExactEqual(a, b Schema) bool {
+	if a.Root != b.Root {
+		return false
+	}
+	if len(a.Env) != len(b.Env) {
+		return false
+	}
+	for name, rec := range a.Env {
+		other, ok := b.Env[name]
+		if !ok || !recordFieldSetEqualExact(rec, other) {
+			return false
+		}
+	}
+	return true
+}
+
+// recordFieldSetEqualExact compares two records' fields as a set keyed by
+// label (declaration order is not significant — spec §3.1), requiring
+// literal Type equality (no record renaming permitted).
+func recordFieldSetEqualExact(a, b *Record) bool {
+	if len(a.Fields) != len(b.Fields) {
+		return false
+	}
+	byLabel := make(map[string]Field, len(b.Fields))
+	for _, f := range b.Fields {
+		byLabel[f.Label] = f
+	}
+	for _, fa := range a.Fields {
+		fb, ok := byLabel[fa.Label]
+		if !ok || fa.Cardinality != fb.Cardinality || !typesEqualExact(fa.Type, fb.Type) {
+			return false
+		}
+	}
+	return true
+}
+
+func typesEqualExact(a, b Type) bool {
+	if a.Kind != b.Kind {
+		return false
+	}
+	switch a.Kind {
+	case TypeScalarKind:
+		return a.ScalarKind == b.ScalarKind && a.Nullable == b.Nullable
+	case TypeRefKind:
+		return a.RefName == b.RefName
+	default: // TypeAnyKind
+		return true
+	}
+}
+
+// schemaIsomorphic decides whether a and b are the same schema up to a
+// consistent renaming of records, per the porting guide's step 1 and
+// spec ch.6's use of isomorphism for infer.
+//
+// This walks both schemas' record-reference graphs together, starting
+// from their respective roots, maintaining a bijection between record
+// names discovered so far (aToB/bToA). Field labels are matched exactly
+// (labels are never renamed — only record *names* can differ), so there
+// is no field-pairing ambiguity to resolve by search: for a given pair of
+// records already known to correspond, each field in a has at most one
+// candidate counterpart in b (the field sharing its label), so the walk
+// is a straightforward mutual recursion rather than a general graph-
+// isomorphism search with backtracking. A first-encountered mapping is
+// permanent: if the walk later needs aName to correspond to a different
+// bName than it already committed to (or vice versa), that is treated as
+// a mismatch. This is sufficient for schemas as they occur from OSD
+// parsing and this repository's own operations (records reached from a
+// root via a tree of Ref fields, cycles handled by the visited check
+// below) — it is not a claim of solving general graph automorphism
+// search, which this narrow domain does not need.
+func schemaIsomorphic(a, b Schema) bool {
+	aToB := map[string]string{}
+	bToA := map[string]string{}
+	return recordsIsomorphic(a, a.Root, b, b.Root, aToB, bToA)
+}
+
+func recordsIsomorphic(a Schema, aName string, b Schema, bName string, aToB, bToA map[string]string) bool {
+	if mapped, ok := aToB[aName]; ok {
+		return mapped == bName && bToA[bName] == aName
+	}
+	if _, taken := bToA[bName]; taken {
+		// bName is already claimed by some other aName - not a
+		// consistent bijection.
+		return false
+	}
+	recA, okA := a.Env[aName]
+	recB, okB := b.Env[bName]
+	if !okA || !okB {
+		return false
+	}
+	// Commit the mapping before recursing so cycles (mutual/self
+	// references) terminate instead of looping forever.
+	aToB[aName] = bName
+	bToA[bName] = aName
+
+	if len(recA.Fields) != len(recB.Fields) {
+		return false
+	}
+	byLabel := make(map[string]Field, len(recB.Fields))
+	for _, f := range recB.Fields {
+		byLabel[f.Label] = f
+	}
+	for _, fa := range recA.Fields {
+		fb, ok := byLabel[fa.Label]
+		if !ok || fa.Cardinality != fb.Cardinality {
+			return false
+		}
+		if fa.Type.Kind != fb.Type.Kind {
+			return false
+		}
+		switch fa.Type.Kind {
+		case TypeScalarKind:
+			if fa.Type.ScalarKind != fb.Type.ScalarKind || fa.Type.Nullable != fb.Type.Nullable {
+				return false
+			}
+		case TypeRefKind:
+			if !recordsIsomorphic(a, fa.Type.RefName, b, fb.Type.RefName, aToB, bToA) {
+				return false
+			}
+		default: // TypeAnyKind
+		}
+	}
+	return true
+}

--- a/referee_coverage_test.go
+++ b/referee_coverage_test.go
@@ -1,0 +1,256 @@
+package omnist
+
+import "testing"
+
+// This file closes the remaining branch coverage in referee.go that the
+// 10-case spec self-test (referee_test.go) doesn't happen to exercise --
+// referee.go is core comparison logic (like Scalar.Equal from issue #1),
+// not conformance-harness execution plumbing, so it holds the repo's
+// normal 100%-per-function coverage bar rather than tools/conformance/**'s
+// documented exception (see .github/workflows/ci.yml).
+
+func TestRefereeCoverageDocumentsEqualNodeVsValueMismatch(t *testing.T) {
+	node := mustOML(t, "a: 1")
+	value := mustOML(t, "42")
+	if DocumentsEqual(node, value) {
+		t.Fatal("a node-shaped and a value-shaped Document must not compare equal")
+	}
+	if DocumentsEqual(value, node) {
+		t.Fatal("comparison must be symmetric")
+	}
+}
+
+func TestRefereeCoverageValuesEqualNullMismatch(t *testing.T) {
+	null := mustOML(t, "null")
+	nonNull := mustOML(t, "1")
+	if DocumentsEqual(null, nonNull) {
+		t.Fatal("null and non-null bare values must not compare equal")
+	}
+}
+
+func TestRefereeCoverageValuesEqualBothNull(t *testing.T) {
+	a := mustOML(t, "null")
+	b := mustOML(t, "null")
+	if !DocumentsEqual(a, b) {
+		t.Fatal("two null bare values must compare equal")
+	}
+}
+
+func TestRefereeCoverageScalarsEqualBothNaN(t *testing.T) {
+	a := mustOML(t, "nan")
+	b := mustOML(t, "nan")
+	if !DocumentsEqual(a, b) {
+		t.Fatal("two NaN-valued number scalars must compare equal under the referee (unlike plain Scalar.Equal / Go's ==)")
+	}
+}
+
+func TestRefereeCoverageScalarsEqualKindMismatch(t *testing.T) {
+	integer := mustOML(t, "1")
+	number := mustOML(t, "1.0")
+	if DocumentsEqual(integer, number) {
+		t.Fatal("an integer-kind and a number-kind scalar of the same magnitude must not compare equal (spec D-5)")
+	}
+}
+
+func TestRefereeCoverageTargetsEqualNodeVsValueMismatch(t *testing.T) {
+	a := mustOML(t, "m: {}")
+	b := mustOML(t, "m: 1")
+	if DocumentsEqual(a, b) {
+		t.Fatal("an edge whose target is a node must not compare equal to one whose target is a value")
+	}
+}
+
+func TestRefereeCoverageNodesEqualLengthMismatch(t *testing.T) {
+	a := mustOML(t, "a: 1")
+	b := mustOML(t, "a: 1; b: 2")
+	if DocumentsEqual(a, b) {
+		t.Fatal("nodes with a different edge count must not compare equal")
+	}
+}
+
+func TestRefereeCoverageNodesEqualLabelMismatch(t *testing.T) {
+	a := mustOML(t, "a: 1")
+	b := mustOML(t, "b: 1")
+	if DocumentsEqual(a, b) {
+		t.Fatal("nodes whose edges have different labels must not compare equal")
+	}
+}
+
+func TestRefereeCoverageSchemaExactEqualRootMismatch(t *testing.T) {
+	a := mustOSD(t, `record R { "x": string } root R`)
+	b := mustOSD(t, `record R { "x": string } record S { "x": string } root S`)
+	if SchemasEqual(a, b, ModeExact) {
+		t.Fatal("schemas with different roots must not compare equal")
+	}
+}
+
+func TestRefereeCoverageSchemaExactEqualEnvLengthMismatch(t *testing.T) {
+	a := mustOSD(t, `record R { "x": string } root R`)
+	b := mustOSD(t, `record R { "x": string } record S { "y": string } root R`)
+	if SchemasEqual(a, b, ModeExact) {
+		t.Fatal("schemas with a different number of records must not compare equal")
+	}
+}
+
+func TestRefereeCoverageSchemaExactEqualMissingRecordInOther(t *testing.T) {
+	a := mustOSD(t, `record R { "x": string } record S { "y": string } root R`)
+	b := mustOSD(t, `record R { "x": string } record T { "y": string } root R`)
+	if SchemasEqual(a, b, ModeExact) {
+		t.Fatal("a record name present in one env but absent from the other must not compare equal")
+	}
+}
+
+func TestRefereeCoverageRecordFieldSetEqualExactFieldCountMismatch(t *testing.T) {
+	a := mustOSD(t, `record R { "x": string } root R`)
+	b := mustOSD(t, `record R { "x": string, "y": string } root R`)
+	if SchemasEqual(a, b, ModeExact) {
+		t.Fatal("records with a different field count must not compare equal")
+	}
+}
+
+func TestRefereeCoverageRecordFieldSetEqualExactMissingLabel(t *testing.T) {
+	a := mustOSD(t, `record R { "x": string } root R`)
+	b := mustOSD(t, `record R { "y": string } root R`)
+	if SchemasEqual(a, b, ModeExact) {
+		t.Fatal("records whose fields have different labels must not compare equal")
+	}
+}
+
+func TestRefereeCoverageTypesEqualExactKindMismatch(t *testing.T) {
+	a := mustOSD(t, `record R { "x": string } root R`)
+	b := mustOSD(t, `record R { "x": R } root R`)
+	if SchemasEqual(a, b, ModeExact) {
+		t.Fatal("a scalar-typed field and a ref-typed field must not compare equal")
+	}
+}
+
+func TestRefereeCoverageTypesEqualExactRefNameMismatch(t *testing.T) {
+	a := mustOSD(t, `record R { "x": S } record S { "y": string } root R`)
+	b := mustOSD(t, `record R { "x": T } record T { "y": string } root R`)
+	if SchemasEqual(a, b, ModeExact) {
+		t.Fatal("ref fields pointing at differently-named records must not compare equal under exact mode (no renaming permitted)")
+	}
+}
+
+func TestRefereeCoverageTypesEqualExactAnyKind(t *testing.T) {
+	a := mustOSD(t, `record R { "x": any } root R`)
+	b := mustOSD(t, `record R { "x": any } root R`)
+	if !SchemasEqual(a, b, ModeExact) {
+		t.Fatal("two any-typed fields must compare equal")
+	}
+}
+
+// recordsIsomorphic's "bName already claimed by a different aName" branch
+// needs a genuine non-isomorphic pair: two records in A mapping to the
+// same single record in B is impossible from well-formed distinct A
+// records unless B's graph is smaller/differently shaped, so build one
+// side where two different A records would both need to match the same B
+// record.
+func TestRefereeCoverageIsomorphicBNameAlreadyClaimed(t *testing.T) {
+	// Left and Right are structurally identical (both single field "v":
+	// string) so the first pairing (Left<->Same) succeeds fully on its own
+	// merits, rather than short-circuiting early on a shape mismatch --
+	// only then does the second pairing attempt (Right vs Same) reach the
+	// "bName already claimed by a different aName" branch.
+	a := mustOSD(t, `
+		record Left  { "v": string }
+		record Right { "v": string }
+		record Root  { "p": Left, "q": Right }
+		root Root
+	`)
+	b := mustOSD(t, `
+		record Same { "v": string }
+		record Root { "p": Same, "q": Same }
+		root Root
+	`)
+	if SchemasEqual(a, b, ModeIsomorphic) {
+		t.Fatal("Left and Right cannot both isomorphically map to the same B record Same")
+	}
+}
+
+func TestRefereeCoverageIsomorphicDanglingRef(t *testing.T) {
+	// Not constructible through ReadOSD (S-6 rejects a dangling ref), so
+	// build the Schema directly to exercise recordsIsomorphic's
+	// !okA || !okB branch.
+	a := Schema{
+		Root:     "R",
+		EnvOrder: []string{"R"},
+		Env: map[string]*Record{
+			"R": {Name: "R", Fields: []Field{
+				{Label: "x", Type: Type{Kind: TypeRefKind, RefName: "Missing"}, Cardinality: Cardinality{Min: 1, Max: 1}},
+			}},
+		},
+	}
+	b := mustOSD(t, `record R { "x": S } record S { "y": string } root R`)
+	if SchemasEqual(a, b, ModeIsomorphic) {
+		t.Fatal("a dangling ref on one side must not compare isomorphic")
+	}
+}
+
+func TestRefereeCoverageIsomorphicFieldCountMismatch(t *testing.T) {
+	a := mustOSD(t, `record S { "x": string } record R { "a": S } root R`)
+	b := mustOSD(t, `record S { "x": string, "y": string } record R { "a": S } root R`)
+	if SchemasEqual(a, b, ModeIsomorphic) {
+		t.Fatal("records with a different field count must not compare isomorphic")
+	}
+}
+
+func TestRefereeCoverageIsomorphicMissingLabel(t *testing.T) {
+	a := mustOSD(t, `record S { "x": string } record R { "a": S } root R`)
+	b := mustOSD(t, `record S { "y": string } record R { "a": S } root R`)
+	if SchemasEqual(a, b, ModeIsomorphic) {
+		t.Fatal("records whose fields have different labels must not compare isomorphic")
+	}
+}
+
+func TestRefereeCoverageIsomorphicCardinalityMismatch(t *testing.T) {
+	a := mustOSD(t, `record S { "x" [0,1]: string } record R { "a": S } root R`)
+	b := mustOSD(t, `record S { "x": string } record R { "a": S } root R`)
+	if SchemasEqual(a, b, ModeIsomorphic) {
+		t.Fatal("differing cardinality on a matched field must not compare isomorphic")
+	}
+}
+
+func TestRefereeCoverageIsomorphicTypeKindMismatch(t *testing.T) {
+	a := mustOSD(t, `record S { "x": string } record R { "a": S } root R`)
+	b := mustOSD(t, `record T { "x": T } record R { "a": T } root R`)
+	if SchemasEqual(a, b, ModeIsomorphic) {
+		t.Fatal("a scalar-typed field and a ref-typed field must not compare isomorphic")
+	}
+}
+
+func TestRefereeCoverageIsomorphicScalarKindMismatch(t *testing.T) {
+	a := mustOSD(t, `record S { "x": string } record R { "a": S } root R`)
+	b := mustOSD(t, `record S { "x": integer } record R { "a": S } root R`)
+	if SchemasEqual(a, b, ModeIsomorphic) {
+		t.Fatal("differing scalar kind on a matched field must not compare isomorphic")
+	}
+}
+
+func TestRefereeCoverageIsomorphicNullableMismatch(t *testing.T) {
+	a := mustOSD(t, `record S { "x": string } record R { "a": S } root R`)
+	b := mustOSD(t, `record S { "x": string? } record R { "a": S } root R`)
+	if SchemasEqual(a, b, ModeIsomorphic) {
+		t.Fatal("differing nullability on a matched field must not compare isomorphic")
+	}
+}
+
+// A record reachable via two different fields back to an already-mapped
+// name exercises recordsIsomorphic's "already mapped, consistent" early
+// return (as opposed to the dangling/first-encounter path every other
+// isomorphic test above exercises).
+func TestRefereeCoverageIsomorphicRevisitsAlreadyMappedName(t *testing.T) {
+	a := mustOSD(t, `record R { "a": R, "b": R } root R`)
+	b := mustOSD(t, `record S { "a": S, "b": S } root S`)
+	if !SchemasEqual(a, b, ModeIsomorphic) {
+		t.Fatal("a self-referential record reached twice must still compare isomorphic once R<->S is committed")
+	}
+}
+
+func TestRefereeCoverageIsomorphicAnyKind(t *testing.T) {
+	a := mustOSD(t, `record R { "x": any } root R`)
+	b := mustOSD(t, `record R { "x": any } root R`)
+	if !SchemasEqual(a, b, ModeIsomorphic) {
+		t.Fatal("two any-typed fields must compare isomorphic")
+	}
+}

--- a/referee_test.go
+++ b/referee_test.go
@@ -1,0 +1,134 @@
+package omnist
+
+import "testing"
+
+// This file hand-ports the spec's own 10-case referee self-test
+// (vendor/omnist-spec/conformance/fixtures/_referee-self-test/) as real Go
+// tests, per the porting guide's step 1: "Prove the referee trustworthy
+// before it judges anything ... all three existing ports did this as
+// their literal step one." Each test's name and comment quote the
+// fixture's own purpose.txt. This MUST pass before tools/conformance's
+// vector runner is trusted to judge anything using SchemasEqual/
+// DocumentsEqual.
+
+func mustOSD(t *testing.T, text string) Schema {
+	t.Helper()
+	s, err := ReadOSD(text)
+	if err != nil {
+		t.Fatalf("ReadOSD failed: %v", err)
+	}
+	return s
+}
+
+func mustOML(t *testing.T, text string) Document {
+	t.Helper()
+	d, err := ReadOML(text, DefaultLimits())
+	if err != nil {
+		t.Fatalf("ReadOML failed: %v", err)
+	}
+	return d
+}
+
+// Case 01: fields are an unordered set at the model layer (§3.1) --
+// declaration order must not affect equality.
+func TestReferee01SchemaExactEqualDifferentFieldOrder(t *testing.T) {
+	a := mustOSD(t, "record R {\n    \"x\": string,\n    \"y\": integer,\n}\nroot R\n")
+	b := mustOSD(t, "record R {\n    \"y\": integer,\n    \"x\": string,\n}\nroot R\n")
+	if !SchemasEqual(a, b, ModeExact) {
+		t.Fatal("want equal (field order must not affect exact equality)")
+	}
+}
+
+// Case 02: one field's cardinality differs ([1,1] vs [0,1]) -- must not
+// compare equal even though everything else matches.
+func TestReferee02SchemaExactNotEqualCardinalityDiff(t *testing.T) {
+	a := mustOSD(t, "record R {\n    \"x\": string,\n}\nroot R\n")
+	b := mustOSD(t, "record R {\n    \"x\" [0,1]: string,\n}\nroot R\n")
+	if SchemasEqual(a, b, ModeExact) {
+		t.Fatal("want not-equal (cardinality differs)")
+	}
+}
+
+// Case 03: same structure, different record name -- isomorphic mode
+// (used for infer, §6.2) must treat these as equal.
+func TestReferee03SchemaIsomorphicEqualRenamedRecords(t *testing.T) {
+	a := mustOSD(t, "record A {\n    \"x\": string,\n}\nroot A\n")
+	b := mustOSD(t, "record B {\n    \"x\": string,\n}\nroot B\n")
+	if !SchemasEqual(a, b, ModeIsomorphic) {
+		t.Fatal("want equal under isomorphic mode")
+	}
+}
+
+// Case 04: same two schemas as case 03, but exact mode (used for
+// normalize/prune/extract, §6.2) must treat a record-name difference as
+// NOT equal -- the companion case proving the two modes genuinely differ.
+func TestReferee04SchemaExactNotEqualRenamedRecords(t *testing.T) {
+	a := mustOSD(t, "record A {\n    \"x\": string,\n}\nroot A\n")
+	b := mustOSD(t, "record B {\n    \"x\": string,\n}\nroot B\n")
+	if SchemasEqual(a, b, ModeExact) {
+		t.Fatal("want not-equal under exact mode")
+	}
+}
+
+// Case 05: edge order is data (D-1/D-3, §2.3) -- two documents with the
+// same edges in a different order are genuinely different documents, not
+// a false mismatch to paper over.
+func TestReferee05DocumentNotEqualReorderedEdges(t *testing.T) {
+	a := mustOML(t, "a: 1\nb: 2\n")
+	b := mustOML(t, "b: 2\na: 1\n")
+	if DocumentsEqual(a, b) {
+		t.Fatal("want not-equal (edge order differs)")
+	}
+}
+
+// Case 06: array sugar desugars into repeated labels at parse time (§2)
+// -- both spellings must produce the identical Document.
+func TestReferee06DocumentEqualArraySugarVsRepeatedLabels(t *testing.T) {
+	a := mustOML(t, "tag: [\"x\", \"y\"]\n")
+	b := mustOML(t, "tag: \"x\"\ntag: \"y\"\n")
+	if !DocumentsEqual(a, b) {
+		t.Fatal("want equal (array sugar == repeated labels)")
+	}
+}
+
+// Case 07: record declaration order in the schema's env is preserved for
+// OSD-text readability (§3.1) but is not semantically significant --
+// equality must not be sensitive to it.
+func TestReferee07SchemaExactEqualDifferentEnvDeclarationOrder(t *testing.T) {
+	a := mustOSD(t, "record Zeta {\n    \"x\": string,\n}\nrecord Root {\n    \"z\": Zeta,\n}\nroot Root\n")
+	b := mustOSD(t, "record Root {\n    \"z\": Zeta,\n}\nrecord Zeta {\n    \"x\": string,\n}\nroot Root\n")
+	if !SchemasEqual(a, b, ModeExact) {
+		t.Fatal("want equal (env declaration order must not affect equality)")
+	}
+}
+
+// Case 08: one field's scalar kind differs -- must not compare equal.
+func TestReferee08SchemaExactNotEqualScalarKindDiff(t *testing.T) {
+	a := mustOSD(t, "record R {\n    \"x\": string,\n}\nroot R\n")
+	b := mustOSD(t, "record R {\n    \"x\": integer,\n}\nroot R\n")
+	if SchemasEqual(a, b, ModeExact) {
+		t.Fatal("want not-equal (scalar kind differs)")
+	}
+}
+
+// Case 09: one field's nullable flag differs (string vs string?) -- must
+// not compare equal.
+func TestReferee09SchemaExactNotEqualNullableDiff(t *testing.T) {
+	a := mustOSD(t, "record R {\n    \"x\": string,\n}\nroot R\n")
+	b := mustOSD(t, "record R {\n    \"x\": string?,\n}\nroot R\n")
+	if SchemasEqual(a, b, ModeExact) {
+		t.Fatal("want not-equal (nullable flag differs)")
+	}
+}
+
+// Case 10: two byte-identical nested documents (repeated item labels,
+// same order) -- the baseline case confirming equal really means equal,
+// not just "not obviously different."
+func TestReferee10DocumentEqualIdenticalNestedStructure(t *testing.T) {
+	text := "order: {\n    id: \"A1\"\n    item: { sku: \"W\"; qty: 3 }\n    item: { sku: \"G\"; qty: 1 }\n}\n"
+	a := mustOML(t, text)
+	b := mustOML(t, text)
+	if !DocumentsEqual(a, b) {
+		t.Fatal("want equal (identical nested structure)")
+	}
+}

--- a/tools/conformance/cmd/conformance/main.go
+++ b/tools/conformance/cmd/conformance/main.go
@@ -1,0 +1,151 @@
+// Command conformance runs omnist-go against every Track 2 (JSON-vector)
+// test in vendor/omnist-spec/test-suite/, per spec §8.5 and issue #31. It
+// prints a per-operation and overall pass/fail/skip report and exits
+// nonzero iff the fail count is nonzero (§8.5.5 -- skip is not failure).
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+
+	conformance "github.com/omnist-dev/omnist-go/tools/conformance"
+)
+
+func main() {
+	suiteDir := flag.String("suite", "", "path to vendor/omnist-spec/test-suite (default: relative to this repo's root)")
+	verbose := flag.Bool("v", false, "print every fail/skip with its reason")
+	flag.Parse()
+
+	dir := *suiteDir
+	if dir == "" {
+		dir = findSuiteDir()
+	}
+	if dir == "" {
+		fmt.Fprintln(os.Stderr, "conformance: could not locate vendor/omnist-spec/test-suite; pass -suite explicitly")
+		os.Exit(2)
+	}
+
+	var files []string
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() && filepath.Ext(path) == ".json" {
+			files = append(files, path)
+		}
+		return nil
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "conformance: walking %s: %v\n", dir, err)
+		os.Exit(2)
+	}
+	sort.Strings(files)
+	if len(files) == 0 {
+		fmt.Fprintf(os.Stderr, "conformance: no *.json vector files found under %s\n", dir)
+		os.Exit(2)
+	}
+
+	type tally struct{ pass, fail, skip int }
+	byOp := map[string]*tally{}
+	overall := &tally{}
+	var fails, skips []conformance.Result
+
+	for _, path := range files {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "conformance: reading %s: %v\n", path, err)
+			os.Exit(2)
+		}
+		vectors, err := conformance.LoadVectorFile(data)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "conformance: parsing %s: %v\n", path, err)
+			os.Exit(2)
+		}
+		for _, v := range vectors {
+			res := conformance.RunVector(v)
+			t, ok := byOp[v.Operation]
+			if !ok {
+				t = &tally{}
+				byOp[v.Operation] = t
+			}
+			switch res.Status {
+			case conformance.StatusPass:
+				t.pass++
+				overall.pass++
+			case conformance.StatusFail:
+				t.fail++
+				overall.fail++
+				fails = append(fails, res)
+			case conformance.StatusSkip:
+				t.skip++
+				overall.skip++
+				skips = append(skips, res)
+			}
+		}
+	}
+
+	fmt.Println("omnist-go Track 2 (JSON-vector) conformance report")
+	fmt.Println("mode: exact-code diagnostics matching (this repository emits the full §8.3")
+	fmt.Println("taxonomy from issue #1 onward; see report for empirical verification detail)")
+	fmt.Println()
+	ops := make([]string, 0, len(byOp))
+	for op := range byOp {
+		ops = append(ops, op)
+	}
+	sort.Strings(ops)
+	for _, op := range ops {
+		t := byOp[op]
+		fmt.Printf("  %-20s pass=%-4d fail=%-4d skip=%-4d\n", op, t.pass, t.fail, t.skip)
+	}
+	fmt.Println()
+	fmt.Printf("TOTAL: pass=%d fail=%d skip=%d (of %d vectors)\n", overall.pass, overall.fail, overall.skip, overall.pass+overall.fail+overall.skip)
+
+	if len(skips) > 0 {
+		fmt.Println()
+		fmt.Println("Skips (every skip cites a reason, per §8.5.5):")
+		for _, r := range skips {
+			fmt.Printf("  SKIP %-70s %s\n", r.Vector.Name, r.Reason)
+		}
+	}
+	if len(fails) > 0 {
+		fmt.Println()
+		fmt.Println("Failures:")
+		for _, r := range fails {
+			fmt.Printf("  FAIL %-70s %s\n", r.Vector.Name, r.Reason)
+			if *verbose {
+				b, _ := json.MarshalIndent(r.Vector, "    ", "  ")
+				fmt.Printf("    %s\n", b)
+			}
+		}
+	}
+
+	if overall.fail != 0 {
+		os.Exit(1)
+	}
+}
+
+// findSuiteDir walks upward from the working directory looking for
+// vendor/omnist-spec/test-suite, so `go run ./tools/conformance` works
+// from the repo root without requiring -suite.
+func findSuiteDir() string {
+	wd, err := os.Getwd()
+	if err != nil {
+		return ""
+	}
+	for dir := wd; ; {
+		candidate := filepath.Join(dir, "vendor", "omnist-spec", "test-suite")
+		if info, err := os.Stat(candidate); err == nil && info.IsDir() {
+			return candidate
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return ""
+		}
+		dir = parent
+	}
+}

--- a/tools/conformance/drivers.go
+++ b/tools/conformance/drivers.go
@@ -1,0 +1,701 @@
+package conformance
+
+import (
+	"encoding/json"
+	"fmt"
+
+	omnist "github.com/omnist-dev/omnist-go"
+)
+
+// This file holds one driver function per §8.5.3 operation, each parsing
+// its vector's "input" per that section's table, calling the matching
+// real omnist-go function, and comparing against "expect" per §8.5.2.
+
+// --- parse ---
+
+type parseInput struct {
+	Format               string `json:"format"`
+	Text                 string `json:"text"`
+	DeclaredMaxDepth     *int   `json:"declared_max_depth"`
+	DeclaredMaxNodes     *int   `json:"declared_max_nodes"`
+	DeclaredMaxIntDigits *int   `json:"declared_max_int_digits"`
+}
+
+func limitsFromInput(in parseInput) omnist.Limits {
+	l := omnist.DefaultLimits()
+	if in.DeclaredMaxDepth != nil {
+		l.MaxDepth = *in.DeclaredMaxDepth
+	}
+	if in.DeclaredMaxNodes != nil {
+		l.MaxNodes = *in.DeclaredMaxNodes
+	}
+	if in.DeclaredMaxIntDigits != nil {
+		l.MaxIntDigits = *in.DeclaredMaxIntDigits
+	}
+	return l
+}
+
+func readByFormat(format, text string, limits omnist.Limits) (omnist.Document, error) {
+	switch format {
+	case "oml":
+		return omnist.ReadOML(text, limits)
+	case "json":
+		return omnist.ReadJSON(text, limits)
+	case "yaml":
+		return omnist.ReadYAML(text, limits)
+	case "toml":
+		return omnist.ReadTOML(text, limits)
+	case "xml":
+		return omnist.ReadXML(text, limits)
+	default:
+		return omnist.Document{}, fmt.Errorf("unrecognized format %q", format)
+	}
+}
+
+func runParse(v Vector) Result {
+	var in parseInput
+	if err := json.Unmarshal(v.Input, &in); err != nil {
+		return fail(v, "decode input: %v", err)
+	}
+	expect, err := decodeExpect(v)
+	if err != nil {
+		return fail(v, "decode expect: %v", err)
+	}
+	doc, rerr := readByFormat(in.Format, in.Text, limitsFromInput(in))
+	wantOK := expectOK(expect)
+	if rerr != nil {
+		if wantOK {
+			return fail(v, "expected ok, got error: %v", rerr)
+		}
+		wantDiags, err := decodeExpectDiagnostics(expect)
+		if err != nil {
+			return fail(v, "decode expect.diagnostics: %v", err)
+		}
+		got := []diagPair{singleErrDiag(rerr)}
+		want := expectDiagPairs(wantDiags)
+		if !diagnosticSetsEqual(got, want) {
+			return fail(v, "diagnostics mismatch: got %v want %v", diagStrings(got), diagStrings(want))
+		}
+		return pass(v)
+	}
+	if !wantOK {
+		return fail(v, "expected error, got ok document")
+	}
+	wantDocRaw, ok := expect["document"]
+	if !ok {
+		return pass(v) // no document to compare (shouldn't happen for parse, but not this driver's call to invent one)
+	}
+	wantDoc, err := DecodeCanonicalDocument(wantDocRaw)
+	if err != nil {
+		return fail(v, "decode expect.document: %v", err)
+	}
+	if !omnist.DocumentsEqual(doc, wantDoc) {
+		return fail(v, "document mismatch")
+	}
+	return pass(v)
+}
+
+// --- parse_schema ---
+
+type parseSchemaInput struct {
+	Text string `json:"text"`
+}
+
+func runParseSchema(v Vector) Result {
+	var in parseSchemaInput
+	if err := json.Unmarshal(v.Input, &in); err != nil {
+		return fail(v, "decode input: %v", err)
+	}
+	expect, err := decodeExpect(v)
+	if err != nil {
+		return fail(v, "decode expect: %v", err)
+	}
+	_, serr := omnist.ReadOSD(in.Text)
+	wantOK := expectOK(expect)
+	if serr != nil {
+		if wantOK {
+			return fail(v, "expected ok, got error: %v", serr)
+		}
+		wantDiags, err := decodeExpectDiagnostics(expect)
+		if err != nil {
+			return fail(v, "decode expect.diagnostics: %v", err)
+		}
+		got := []diagPair{singleErrDiag(serr)}
+		want := expectDiagPairs(wantDiags)
+		if !diagnosticSetsEqual(got, want) {
+			return fail(v, "diagnostics mismatch: got %v want %v", diagStrings(got), diagStrings(want))
+		}
+		return pass(v)
+	}
+	if !wantOK {
+		return fail(v, "expected error, got ok schema")
+	}
+	return pass(v)
+}
+
+// --- validate ---
+
+type validateInput struct {
+	Schema   string          `json:"schema"`
+	Document json.RawMessage `json:"document"`
+}
+
+func runValidate(v Vector) Result {
+	var in validateInput
+	if err := json.Unmarshal(v.Input, &in); err != nil {
+		return fail(v, "decode input: %v", err)
+	}
+	expect, err := decodeExpect(v)
+	if err != nil {
+		return fail(v, "decode expect: %v", err)
+	}
+	schema, serr := omnist.ReadOSD(in.Schema)
+	if serr != nil {
+		return fail(v, "input schema failed to parse: %v", serr)
+	}
+	doc, derr := DecodeCanonicalDocument(in.Document)
+	if derr != nil {
+		return fail(v, "decode input.document: %v", derr)
+	}
+	diags := omnist.Validate(doc, schema)
+	wantOK := expectOK(expect)
+	got := diagsToPairs(diags)
+	if wantOK {
+		if len(diags) != 0 {
+			return fail(v, "expected ok, got diagnostics: %v", diagStrings(got))
+		}
+		return pass(v)
+	}
+	wantDiags, err := decodeExpectDiagnostics(expect)
+	if err != nil {
+		return fail(v, "decode expect.diagnostics: %v", err)
+	}
+	want := expectDiagPairs(wantDiags)
+	if !diagnosticSetsEqual(got, want) {
+		return fail(v, "diagnostics mismatch: got %v want %v", diagStrings(got), diagStrings(want))
+	}
+	return pass(v)
+}
+
+// --- write ---
+
+type writeInput struct {
+	Format   string          `json:"format"`
+	Document json.RawMessage `json:"document"`
+	Strict   bool            `json:"strict"`
+}
+
+func runWrite(v Vector) Result {
+	var in writeInput
+	if err := json.Unmarshal(v.Input, &in); err != nil {
+		return fail(v, "decode input: %v", err)
+	}
+	expect, err := decodeExpect(v)
+	if err != nil {
+		return fail(v, "decode expect: %v", err)
+	}
+	doc, derr := DecodeCanonicalDocument(in.Document)
+	if derr != nil {
+		return fail(v, "decode input.document: %v", derr)
+	}
+
+	var text string
+	var werr error
+	switch in.Format {
+	case "json":
+		if in.Strict {
+			text, werr = omnist.WriteJSONStrict(doc)
+		} else {
+			text, werr = omnist.WriteJSON(doc)
+		}
+	case "oml":
+		text = omnist.WriteOML(doc, false)
+	case "yaml":
+		text, werr = omnist.WriteYAML(doc)
+	case "toml":
+		if in.Strict {
+			return Result{Vector: v, Status: StatusSkip, Reason: "not yet implemented: WriteTOML has no strict-mode parameter in this repository (WriteTOML(d Document) (string, error) only) -- flagged for a follow-up issue, not fixed here per issue #31's scope"}
+		}
+		text, werr = omnist.WriteTOML(doc)
+	case "xml":
+		text, werr = omnist.WriteXML(doc)
+	default:
+		return fail(v, "unrecognized format %q", in.Format)
+	}
+
+	wantOK := expectOK(expect)
+	if werr != nil {
+		if wantOK {
+			return fail(v, "expected ok, got error: %v", werr)
+		}
+		wantDiags, err := decodeExpectDiagnostics(expect)
+		if err != nil {
+			return fail(v, "decode expect.diagnostics: %v", err)
+		}
+		got := []diagPair{singleErrDiag(werr)}
+		want := expectDiagPairs(wantDiags)
+		if !diagnosticSetsEqual(got, want) {
+			return fail(v, "diagnostics mismatch: got %v want %v", diagStrings(got), diagStrings(want))
+		}
+		return pass(v)
+	}
+	if !wantOK {
+		return fail(v, "expected error, got ok write")
+	}
+	// write is the one operation where ok:true and diagnostics can
+	// coexist (§8.5.3) -- WriteYAML/WriteTOML/WriteXML/WriteJSONStrict
+	// return only (string, error), with no side-channel for a non-fatal
+	// adjustment diagnostic alongside success. If the vector expects
+	// diagnostics alongside ok:true, this repo's writers cannot surface
+	// them today, so treat that case as a driver-detected gap rather than
+	// silently ignoring the expected diagnostics.
+	if wantDiags, _ := decodeExpectDiagnostics(expect); len(wantDiags) > 0 {
+		return Result{Vector: v, Status: StatusSkip, Reason: "not yet implemented: this repository's Write* functions return (string, error) only, with no channel to report a non-fatal adjustment diagnostic alongside a successful write (spec allows ok:true + diagnostics together for write) -- flagged for a follow-up issue"}
+	}
+	wantText, ok := expect["text"]
+	if !ok {
+		return pass(v)
+	}
+	var wantTextStr string
+	if err := json.Unmarshal(wantText, &wantTextStr); err != nil {
+		return fail(v, "decode expect.text: %v", err)
+	}
+	if text != wantTextStr {
+		return fail(v, "text mismatch: got %q want %q", text, wantTextStr)
+	}
+	return pass(v)
+}
+
+// --- compatible_with / equivalent ---
+
+type abInput struct {
+	A string `json:"a"`
+	B string `json:"b"`
+}
+
+func runCompatibleWith(v Vector) Result {
+	var in abInput
+	if err := json.Unmarshal(v.Input, &in); err != nil {
+		return fail(v, "decode input: %v", err)
+	}
+	a, aerr := omnist.ReadOSD(in.A)
+	if aerr != nil {
+		return fail(v, "input.a failed to parse: %v", aerr)
+	}
+	b, berr := omnist.ReadOSD(in.B)
+	if berr != nil {
+		return fail(v, "input.b failed to parse: %v", berr)
+	}
+	got := omnist.CompatibleWith(a, b)
+	return compareBoolResult(v, got)
+}
+
+func runEquivalent(v Vector) Result {
+	var in abInput
+	if err := json.Unmarshal(v.Input, &in); err != nil {
+		return fail(v, "decode input: %v", err)
+	}
+	a, aerr := omnist.ReadOSD(in.A)
+	if aerr != nil {
+		return fail(v, "input.a failed to parse: %v", aerr)
+	}
+	b, berr := omnist.ReadOSD(in.B)
+	if berr != nil {
+		return fail(v, "input.b failed to parse: %v", berr)
+	}
+	got := omnist.Equivalent(a, b)
+	return compareBoolResult(v, got)
+}
+
+func compareBoolResult(v Vector, got bool) Result {
+	expect, err := decodeExpect(v)
+	if err != nil {
+		return fail(v, "decode expect: %v", err)
+	}
+	raw, ok := expect["result"]
+	if !ok {
+		return fail(v, "expect has no \"result\" field")
+	}
+	var want bool
+	if err := json.Unmarshal(raw, &want); err != nil {
+		return fail(v, "decode expect.result: %v", err)
+	}
+	if got != want {
+		return fail(v, "result mismatch: got %v want %v", got, want)
+	}
+	return pass(v)
+}
+
+// --- normalize / prune ---
+
+type schemaOnlyInput struct {
+	Schema string `json:"schema"`
+}
+
+func runNormalize(v Vector) Result {
+	var in schemaOnlyInput
+	if err := json.Unmarshal(v.Input, &in); err != nil {
+		return fail(v, "decode input: %v", err)
+	}
+	s, serr := omnist.ReadOSD(in.Schema)
+	if serr != nil {
+		return fail(v, "input.schema failed to parse: %v", serr)
+	}
+	got := omnist.WriteOSD(omnist.Normalize(s), false)
+	return compareCanonicalSchemaText(v, got)
+}
+
+func runPrune(v Vector) Result {
+	var in schemaOnlyInput
+	if err := json.Unmarshal(v.Input, &in); err != nil {
+		return fail(v, "decode input: %v", err)
+	}
+	s, serr := omnist.ReadOSD(in.Schema)
+	if serr != nil {
+		return fail(v, "input.schema failed to parse: %v", serr)
+	}
+	got := omnist.WriteOSD(omnist.Prune(s), false)
+	return compareCanonicalSchemaText(v, got)
+}
+
+// compareCanonicalSchemaText compares got against expect.schema *byte for
+// byte* (spec §9.2 "Algebra results ... compared as canonical OSD text
+// byte for byte"), not via the referee -- normalize/prune's whole point is
+// pinning canonical output text, so a structural-equality comparison here
+// would under-test the very thing the vector exists to check.
+func compareCanonicalSchemaText(v Vector, got string) Result {
+	expect, err := decodeExpect(v)
+	if err != nil {
+		return fail(v, "decode expect: %v", err)
+	}
+	raw, ok := expect["schema"]
+	if !ok {
+		return fail(v, "expect has no \"schema\" field")
+	}
+	var want string
+	if err := json.Unmarshal(raw, &want); err != nil {
+		return fail(v, "decode expect.schema: %v", err)
+	}
+	if got != want {
+		return fail(v, "canonical schema text mismatch: got %q want %q", got, want)
+	}
+	return pass(v)
+}
+
+// --- is_empty ---
+
+func runIsEmpty(v Vector) Result {
+	var in schemaOnlyInput
+	if err := json.Unmarshal(v.Input, &in); err != nil {
+		return fail(v, "decode input: %v", err)
+	}
+	s, serr := omnist.ReadOSD(in.Schema)
+	if serr != nil {
+		return fail(v, "input.schema failed to parse: %v", serr)
+	}
+	got := omnist.IsEmpty(s)
+	expect, err := decodeExpect(v)
+	if err != nil {
+		return fail(v, "decode expect: %v", err)
+	}
+	raw, ok := expect["empty"]
+	if !ok {
+		return fail(v, "expect has no \"empty\" field")
+	}
+	var want bool
+	if err := json.Unmarshal(raw, &want); err != nil {
+		return fail(v, "decode expect.empty: %v", err)
+	}
+	if got != want {
+		return fail(v, "empty mismatch: got %v want %v", got, want)
+	}
+	return pass(v)
+}
+
+// --- extract ---
+
+type extractInput struct {
+	Schema string   `json:"schema"`
+	Keep   []string `json:"keep"`
+}
+
+func runExtract(v Vector) Result {
+	var in extractInput
+	if err := json.Unmarshal(v.Input, &in); err != nil {
+		return fail(v, "decode input: %v", err)
+	}
+	expect, err := decodeExpect(v)
+	if err != nil {
+		return fail(v, "decode expect: %v", err)
+	}
+	s, serr := omnist.ReadOSD(in.Schema)
+	if serr != nil {
+		return fail(v, "input.schema failed to parse: %v", serr)
+	}
+	keep := make(map[string]bool, len(in.Keep))
+	for _, k := range in.Keep {
+		keep[k] = true
+	}
+	result, eerr := omnist.Extract(s, keep)
+	wantOK := expectOK(expect)
+	if eerr != nil {
+		if wantOK {
+			return fail(v, "expected ok, got error: %v", eerr)
+		}
+		wantDiags, err := decodeExpectDiagnostics(expect)
+		if err != nil {
+			return fail(v, "decode expect.diagnostics: %v", err)
+		}
+		got := []diagPair{singleErrDiag(eerr)}
+		want := expectDiagPairs(wantDiags)
+		if !diagnosticSetsEqual(got, want) {
+			return fail(v, "diagnostics mismatch: got %v want %v", diagStrings(got), diagStrings(want))
+		}
+		return pass(v)
+	}
+	if !wantOK {
+		return fail(v, "expected error, got ok extract")
+	}
+	wantRaw, ok := expect["schema"]
+	if !ok {
+		return fail(v, "expect has no \"schema\" field")
+	}
+	var wantText string
+	if err := json.Unmarshal(wantRaw, &wantText); err != nil {
+		return fail(v, "decode expect.schema: %v", err)
+	}
+	wantSchema, werr := omnist.ReadOSD(wantText)
+	if werr != nil {
+		return fail(v, "expect.schema failed to parse: %v", werr)
+	}
+	// extract's output naming is spec-determined (§6.9), so ModeExact --
+	// same reasoning as normalize/prune, but extract returns a Schema
+	// value rather than pinning canonical text directly, so the referee
+	// (not a byte comparison) is the right tool here.
+	if !omnist.SchemasEqual(result, wantSchema, omnist.ModeExact) {
+		return fail(v, "schema mismatch (exact mode): got %q want %q", omnist.WriteOSD(result, false), wantText)
+	}
+	return pass(v)
+}
+
+// --- infer / infer_with_report ---
+
+type inferInput struct {
+	Samples  []string `json:"samples"`
+	AllowAny bool     `json:"allow_any"`
+}
+
+func inferSampleDocs(samples []string) ([]omnist.Document, error) {
+	docs := make([]omnist.Document, len(samples))
+	for i, s := range samples {
+		d, err := omnist.ReadOML(s, omnist.DefaultLimits())
+		if err != nil {
+			return nil, fmt.Errorf("sample %d: %w", i, err)
+		}
+		docs[i] = d
+	}
+	return docs, nil
+}
+
+func runInfer(v Vector) Result {
+	var in inferInput
+	if err := json.Unmarshal(v.Input, &in); err != nil {
+		return fail(v, "decode input: %v", err)
+	}
+	expect, err := decodeExpect(v)
+	if err != nil {
+		return fail(v, "decode expect: %v", err)
+	}
+	docs, derr := inferSampleDocs(in.Samples)
+	if derr != nil {
+		return fail(v, "decode input.samples: %v", derr)
+	}
+	result, ierr := omnist.Infer(docs, "Root", in.AllowAny)
+	wantOK := expectOK(expect)
+	if ierr != nil {
+		if wantOK {
+			return fail(v, "expected ok, got error: %v", ierr)
+		}
+		wantDiags, err := decodeExpectDiagnostics(expect)
+		if err != nil {
+			return fail(v, "decode expect.diagnostics: %v", err)
+		}
+		got := []diagPair{singleErrDiag(ierr)}
+		want := expectDiagPairs(wantDiags)
+		if !diagnosticSetsEqual(got, want) {
+			return fail(v, "diagnostics mismatch: got %v want %v", diagStrings(got), diagStrings(want))
+		}
+		return pass(v)
+	}
+	if !wantOK {
+		return fail(v, "expected error, got ok infer")
+	}
+	wantRaw, ok := expect["schema"]
+	if !ok {
+		return fail(v, "expect has no \"schema\" field")
+	}
+	var wantText string
+	if err := json.Unmarshal(wantRaw, &wantText); err != nil {
+		return fail(v, "decode expect.schema: %v", err)
+	}
+	wantSchema, werr := omnist.ReadOSD(wantText)
+	if werr != nil {
+		return fail(v, "expect.schema failed to parse: %v", werr)
+	}
+	// infer never normalizes its output (§6.10), so ModeIsomorphic --
+	// this is the operation the porting guide specifically calls out
+	// isomorphic mode for.
+	if !omnist.SchemasEqual(result, wantSchema, omnist.ModeIsomorphic) {
+		return fail(v, "schema mismatch (isomorphic mode): got %q want %q", omnist.WriteOSD(result, false), wantText)
+	}
+	return pass(v)
+}
+
+type fallbackExpect struct {
+	Location string `json:"location"`
+	Reason   string `json:"reason"`
+}
+
+func runInferWithReport(v Vector) Result {
+	var in inferInput
+	if err := json.Unmarshal(v.Input, &in); err != nil {
+		return fail(v, "decode input: %v", err)
+	}
+	expect, err := decodeExpect(v)
+	if err != nil {
+		return fail(v, "decode expect: %v", err)
+	}
+	docs, derr := inferSampleDocs(in.Samples)
+	if derr != nil {
+		return fail(v, "decode input.samples: %v", derr)
+	}
+	result, fallbacks, ierr := omnist.InferWithReport(docs, "Root", in.AllowAny)
+	wantOK := expectOK(expect)
+	if ierr != nil {
+		if wantOK {
+			return fail(v, "expected ok, got error: %v", ierr)
+		}
+		wantDiags, err := decodeExpectDiagnostics(expect)
+		if err != nil {
+			return fail(v, "decode expect.diagnostics: %v", err)
+		}
+		got := []diagPair{singleErrDiag(ierr)}
+		want := expectDiagPairs(wantDiags)
+		if !diagnosticSetsEqual(got, want) {
+			return fail(v, "diagnostics mismatch: got %v want %v", diagStrings(got), diagStrings(want))
+		}
+		return pass(v)
+	}
+	if !wantOK {
+		return fail(v, "expected error, got ok infer_with_report")
+	}
+	wantRaw, ok := expect["schema"]
+	if !ok {
+		return fail(v, "expect has no \"schema\" field")
+	}
+	var wantText string
+	if err := json.Unmarshal(wantRaw, &wantText); err != nil {
+		return fail(v, "decode expect.schema: %v", err)
+	}
+	wantSchema, werr := omnist.ReadOSD(wantText)
+	if werr != nil {
+		return fail(v, "expect.schema failed to parse: %v", werr)
+	}
+	if !omnist.SchemasEqual(result, wantSchema, omnist.ModeIsomorphic) {
+		return fail(v, "schema mismatch (isomorphic mode): got %q want %q", omnist.WriteOSD(result, false), wantText)
+	}
+	// fallbacks is always present on success (spec §8.5.3), compared as a
+	// set of (location, reason) -- reason is prose but the spec's own
+	// operation table lists it as part of the compared shape (unlike a
+	// diagnostic's "message"), so this driver compares it exactly rather
+	// than treating it as message text under §8.5.2 rule 1 (that rule
+	// governs *diagnostics*, and a fallback report is not a diagnostic).
+	fbRaw, ok := expect["fallbacks"]
+	if !ok {
+		return fail(v, "expect has no \"fallbacks\" field")
+	}
+	var wantFallbacks []fallbackExpect
+	if err := json.Unmarshal(fbRaw, &wantFallbacks); err != nil {
+		return fail(v, "decode expect.fallbacks: %v", err)
+	}
+	if len(fallbacks) != len(wantFallbacks) {
+		return fail(v, "fallbacks count mismatch: got %d want %d", len(fallbacks), len(wantFallbacks))
+	}
+	gotSet := map[string]int{}
+	for _, f := range fallbacks {
+		gotSet[f.Location+"\x00"+f.Reason]++
+	}
+	for _, f := range wantFallbacks {
+		k := f.Location + "\x00" + f.Reason
+		if gotSet[k] == 0 {
+			return fail(v, "fallbacks mismatch: missing {location:%q reason:%q}", f.Location, f.Reason)
+		}
+		gotSet[k]--
+	}
+	return pass(v)
+}
+
+// --- lint ---
+
+func runLint(v Vector) Result {
+	var in schemaOnlyInput
+	if err := json.Unmarshal(v.Input, &in); err != nil {
+		return fail(v, "decode input: %v", err)
+	}
+	expect, err := decodeExpect(v)
+	if err != nil {
+		return fail(v, "decode expect: %v", err)
+	}
+	s, serr := omnist.ReadOSD(in.Schema)
+	if serr != nil {
+		return fail(v, "input.schema failed to parse: %v", serr)
+	}
+	findings := omnist.Lint(s)
+	// lint.json's own vectors establish: ok is false iff any finding has
+	// a severity other than info (lint/any-field-is-informational-not-a-
+	// warning expects ok:true despite a nonempty findings list, since its
+	// one finding is info-severity; the three warning-severity examples
+	// all expect ok:false).
+	gotOK := true
+	for _, f := range findings {
+		if f.Severity != omnist.SeverityInfo {
+			gotOK = false
+			break
+		}
+	}
+	wantOK := expectOK(expect)
+	if gotOK != wantOK {
+		return fail(v, "ok mismatch: got %v want %v (findings: %v)", gotOK, wantOK, findings)
+	}
+	wantRaw, ok := expect["findings"]
+	if !ok {
+		return fail(v, "expect has no \"findings\" field")
+	}
+	var wantFindings []findingExpect
+	if err := json.Unmarshal(wantRaw, &wantFindings); err != nil {
+		return fail(v, "decode expect.findings: %v", err)
+	}
+	if len(findings) != len(wantFindings) {
+		return fail(v, "findings count mismatch: got %d want %d", len(findings), len(wantFindings))
+	}
+	gotSet := map[string]int{}
+	for _, f := range findings {
+		gotSet[string(f.Code)+"\x00"+f.Severity.String()+"\x00"+f.Location]++
+	}
+	for _, f := range wantFindings {
+		k := f.Code + "\x00" + f.Severity + "\x00" + f.Location
+		if gotSet[k] == 0 {
+			return fail(v, "findings mismatch: missing {code:%q severity:%q location:%q}", f.Code, f.Severity, f.Location)
+		}
+		gotSet[k]--
+	}
+	return pass(v)
+}
+
+func expectDiagPairs(ds []diagExpect) []diagPair {
+	out := make([]diagPair, len(ds))
+	for i, d := range ds {
+		out[i] = diagPair(d)
+	}
+	return out
+}

--- a/tools/conformance/runner.go
+++ b/tools/conformance/runner.go
@@ -1,0 +1,211 @@
+package conformance
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+
+	omnist "github.com/omnist-dev/omnist-go"
+)
+
+// Result is one vector's outcome.
+type Result struct {
+	Vector Vector
+	Status Status
+	// Reason is populated for Skip (a cited reason, per §8.5.5) and Fail
+	// (a short description of what mismatched) results.
+	Reason string
+}
+
+// Status is a vector's pass/fail/skip outcome, per §8.5.5.
+type Status int
+
+const (
+	StatusPass Status = iota
+	StatusFail
+	StatusSkip
+)
+
+func (s Status) String() string {
+	switch s {
+	case StatusPass:
+		return "pass"
+	case StatusFail:
+		return "fail"
+	case StatusSkip:
+		return "skip"
+	default:
+		return "unknown"
+	}
+}
+
+// diagPair is the (path, code) pair §8.5.2 rule 2 compares diagnostics as
+// a set of.
+type diagPair struct {
+	Path string
+	Code string
+}
+
+// diagExpect is one entry of an "expect.diagnostics" list in a vector.
+type diagExpect struct {
+	Path string `json:"path"`
+	Code string `json:"code"`
+}
+
+// findingExpect is one entry of lint's "expect.findings" list. Unlike
+// diagnostics, §8.5.3's operation-driver table documents findings as
+// {code, severity, location} -- severity participates in lint's
+// comparison (it is not a diagnostic in the §8.5.2 sense, message text
+// still never compared per rule 1, hence no "message" field here).
+type findingExpect struct {
+	Code     string `json:"code"`
+	Severity string `json:"severity"`
+	Location string `json:"location"`
+}
+
+// RunVector dispatches one vector by its operation field (§8.5.3's table)
+// and compares the result against its "expect" per §8.5.2's rules. It
+// never panics on a vector it cannot execute -- an operation not yet
+// implemented (materialize) or a driver bug produces a Result, not a
+// crash, per the issue's "not yet implemented gets an honest skip, not a
+// crash or a forced pass" requirement.
+func RunVector(v Vector) Result {
+	switch v.Operation {
+	case "parse":
+		return runParse(v)
+	case "parse_schema":
+		return runParseSchema(v)
+	case "validate":
+		return runValidate(v)
+	case "materialize":
+		return Result{Vector: v, Status: StatusSkip, Reason: "not yet implemented: materialize (issue #31 explicitly excludes new operation implementations; tracked for a follow-up issue)"}
+	case "write":
+		return runWrite(v)
+	case "compatible_with":
+		return runCompatibleWith(v)
+	case "equivalent":
+		return runEquivalent(v)
+	case "normalize":
+		return runNormalize(v)
+	case "prune":
+		return runPrune(v)
+	case "is_empty":
+		return runIsEmpty(v)
+	case "extract":
+		return runExtract(v)
+	case "infer":
+		return runInfer(v)
+	case "infer_with_report":
+		return runInferWithReport(v)
+	case "lint":
+		return runLint(v)
+	default:
+		return Result{Vector: v, Status: StatusFail, Reason: fmt.Sprintf("unknown operation %q", v.Operation)}
+	}
+}
+
+// --- helpers shared by drivers ---
+
+func fail(v Vector, format string, args ...any) Result {
+	return Result{Vector: v, Status: StatusFail, Reason: fmt.Sprintf(format, args...)}
+}
+
+func pass(v Vector) Result { return Result{Vector: v, Status: StatusPass} }
+
+// expectOK reports whether expect.ok is true (defaulting to true when the
+// field is absent, since not every success shape in §8.5.3's table
+// actually carries an "ok" key -- e.g. normalize/prune/is_empty/
+// compatible_with/equivalent never do).
+func expectOK(expect map[string]json.RawMessage) bool {
+	raw, present := expect["ok"]
+	if !present {
+		return true
+	}
+	var ok bool
+	_ = json.Unmarshal(raw, &ok)
+	return ok
+}
+
+func decodeExpect(v Vector) (map[string]json.RawMessage, error) {
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(v.Expect, &m); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+func decodeExpectDiagnostics(expect map[string]json.RawMessage) ([]diagExpect, error) {
+	raw, ok := expect["diagnostics"]
+	if !ok {
+		return nil, nil
+	}
+	var d []diagExpect
+	if err := json.Unmarshal(raw, &d); err != nil {
+		return nil, err
+	}
+	return d, nil
+}
+
+// diagnosticSetsEqual implements §8.5.2's matching rules: compared as a
+// set of (path, code), never severity, message text never compared
+// (rule 1), no partial matching (rule 3) -- every expected diagnostic
+// present, no unexpected one.
+func diagnosticSetsEqual(actual, expected []diagPair) bool {
+	if len(actual) != len(expected) {
+		return false
+	}
+	toKey := func(p diagPair) string { return p.Path + "\x00" + p.Code }
+	got := map[string]int{}
+	for _, p := range actual {
+		got[toKey(p)]++
+	}
+	for _, p := range expected {
+		k := toKey(p)
+		if got[k] == 0 {
+			return false
+		}
+		got[k]--
+	}
+	for _, n := range got {
+		if n != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func diagStrings(pairs []diagPair) []string {
+	out := make([]string, len(pairs))
+	for i, p := range pairs {
+		out[i] = fmt.Sprintf("%s:%s", p.Path, p.Code)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// singleErrDiag converts one error returned by a reader/parser/operation
+// (either *omnist.ParseError, a bare omnist.Diagnostic used as an error
+// per schemaError's convention, or some other error) into a diagPair. It
+// never returns a zero-value silently -- an error whose shape it does not
+// recognize still yields a diagPair (empty code), which will correctly
+// fail a diagnosticSetsEqual comparison rather than being swallowed.
+func singleErrDiag(err error) diagPair {
+	switch e := err.(type) {
+	case *omnist.ParseError:
+		return diagPair{Path: e.Path, Code: string(e.Code)}
+	case omnist.ParseError:
+		return diagPair{Path: e.Path, Code: string(e.Code)}
+	case omnist.Diagnostic:
+		return diagPair{Path: e.Path, Code: string(e.Code)}
+	default:
+		return diagPair{Path: "", Code: fmt.Sprintf("<unrecognized error type: %T: %v>", err, err)}
+	}
+}
+
+func diagsToPairs(diags []omnist.Diagnostic) []diagPair {
+	out := make([]diagPair, len(diags))
+	for i, d := range diags {
+		out[i] = diagPair{Path: d.Path, Code: string(d.Code)}
+	}
+	return out
+}

--- a/tools/conformance/vectors.go
+++ b/tools/conformance/vectors.go
@@ -1,0 +1,297 @@
+// Package conformance is the Track 2 (JSON-vector) conformance harness for
+// omnist-go, per issue #31 and vendor/omnist-spec/docs/08-conformance-and-
+// errors.md §8.5. It walks vendor/omnist-spec/test-suite/*.json, dispatches
+// each vector by its "operation" field, calls the corresponding real
+// omnist-go function, and compares the result against the vector's
+// "expect" using the referee (github.com/omnist-dev/omnist-go's
+// DocumentsEqual/SchemasEqual).
+package conformance
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"math/big"
+	"regexp"
+	"strconv"
+	"strings"
+
+	omnist "github.com/omnist-dev/omnist-go"
+)
+
+// Vector is one JSON-vector test case, per spec §8.5.1's common envelope.
+type Vector struct {
+	Name      string          `json:"name"`
+	Spec      string          `json:"spec"`
+	Operation string          `json:"operation"`
+	Purpose   string          `json:"purpose"`
+	Input     json.RawMessage `json:"input"`
+	Expect    json.RawMessage `json:"expect"`
+	Comment   string          `json:"comment,omitempty"`
+}
+
+// vectorFile is the top-level shape of a test-suite/*.json file: a single
+// "vectors" array.
+type vectorFile struct {
+	Vectors []Vector `json:"vectors"`
+}
+
+// LoadVectorFile parses one test-suite/*.json file's vectors.
+func LoadVectorFile(data []byte) ([]Vector, error) {
+	var f vectorFile
+	if err := json.Unmarshal(data, &f); err != nil {
+		return nil, fmt.Errorf("decode vector file: %w", err)
+	}
+	return f.Vectors, nil
+}
+
+// --- §8.5.4 canonical Document JSON encoding -> omnist.Document ---
+//
+// This is deliberately independent of json_reader.go's ReadJSON: ReadJSON
+// parses actual JSON-*format* documents (JSON's own map/array shape,
+// requiring the array-becomes-repeated-edges desugaring JSON's format page
+// describes). The vector suite's canonical encoding is a different,
+// explicit thing per §8.5.4 precisely so a vector file does not depend on
+// the reader's JSON library to decide whether "1" is an integer or a
+// number, or on desugaring rules a vector might be testing in the first
+// place (e.g. formats-json/json.json's own vectors test ReadJSON; a
+// materialize vector's "document" input must not silently re-exercise
+// ReadJSON's array-desugaring on the way in).
+
+// canonNode is the raw shape of a canonical-encoding node or scalar.
+type canonNode struct {
+	Edges  [][2]json.RawMessage `json:"edges"`
+	Scalar *canonScalar         `json:"scalar"`
+}
+
+type canonScalar struct {
+	Kind  *string         `json:"kind"`
+	Value json.RawMessage `json:"value"`
+}
+
+// DecodeCanonicalDocument decodes one §8.5.4-encoded Document (a bare
+// canonNode at the top: either {"edges": [...]} or {"scalar": {...}}).
+func DecodeCanonicalDocument(raw json.RawMessage) (omnist.Document, error) {
+	var cn canonNode
+	if err := json.Unmarshal(raw, &cn); err != nil {
+		return omnist.Document{}, fmt.Errorf("decode canonical document: %w", err)
+	}
+	if cn.Scalar != nil {
+		v, err := decodeCanonicalValue(*cn.Scalar)
+		if err != nil {
+			return omnist.Document{}, err
+		}
+		return omnist.ValueDocument(v), nil
+	}
+	n, err := decodeCanonicalEdges(cn.Edges)
+	if err != nil {
+		return omnist.Document{}, err
+	}
+	return omnist.NodeDocument(n), nil
+}
+
+func decodeCanonicalTarget(raw json.RawMessage) (omnist.Target, error) {
+	var cn canonNode
+	if err := json.Unmarshal(raw, &cn); err != nil {
+		return omnist.Target{}, fmt.Errorf("decode canonical target: %w", err)
+	}
+	if cn.Scalar != nil {
+		v, err := decodeCanonicalValue(*cn.Scalar)
+		if err != nil {
+			return omnist.Target{}, err
+		}
+		return omnist.ValueTarget(v), nil
+	}
+	n, err := decodeCanonicalEdges(cn.Edges)
+	if err != nil {
+		return omnist.Target{}, err
+	}
+	return omnist.NodeTarget(n), nil
+}
+
+func decodeCanonicalEdges(edges [][2]json.RawMessage) (*omnist.Node, error) {
+	n := omnist.NewNode()
+	for _, pair := range edges {
+		var label string
+		if err := json.Unmarshal(pair[0], &label); err != nil {
+			return nil, fmt.Errorf("decode edge label: %w", err)
+		}
+		target, err := decodeCanonicalTarget(pair[1])
+		if err != nil {
+			return nil, err
+		}
+		if node, ok := target.Node(); ok {
+			n.AddNode(label, node)
+		} else {
+			v, _ := target.Value()
+			n.AddValue(label, v)
+		}
+	}
+	return n, nil
+}
+
+// decodeCanonicalValue decodes a {"kind": K, "value": V} pair. Per §8.5.4,
+// null is {"scalar": {"kind": null, "value": null}} -- Kind is a JSON null
+// literal, not the four-character string "null", which is why Kind is
+// *string here rather than string.
+func decodeCanonicalValue(cs canonScalar) (omnist.Value, error) {
+	if cs.Kind == nil {
+		return omnist.NullValue(), nil
+	}
+	switch *cs.Kind {
+	case "string":
+		var s string
+		if err := json.Unmarshal(cs.Value, &s); err != nil {
+			return omnist.Value{}, fmt.Errorf("decode string scalar: %w", err)
+		}
+		return omnist.ScalarValue(omnist.NewStringScalar(s)), nil
+	case "integer":
+		i, err := decodeCanonicalInteger(cs.Value)
+		if err != nil {
+			return omnist.Value{}, err
+		}
+		return omnist.ScalarValue(omnist.NewIntegerScalar(i)), nil
+	case "number":
+		f, err := decodeCanonicalNumber(cs.Value)
+		if err != nil {
+			return omnist.Value{}, err
+		}
+		return omnist.ScalarValue(omnist.NewNumberScalar(f)), nil
+	case "boolean":
+		var b bool
+		if err := json.Unmarshal(cs.Value, &b); err != nil {
+			return omnist.Value{}, fmt.Errorf("decode boolean scalar: %w", err)
+		}
+		return omnist.ScalarValue(omnist.NewBooleanScalar(b)), nil
+	case "date":
+		var s string
+		if err := json.Unmarshal(cs.Value, &s); err != nil {
+			return omnist.Value{}, fmt.Errorf("decode date scalar: %w", err)
+		}
+		d, err := parseISODate(s)
+		if err != nil {
+			return omnist.Value{}, err
+		}
+		return omnist.ScalarValue(omnist.NewDateScalar(d)), nil
+	case "time":
+		var s string
+		if err := json.Unmarshal(cs.Value, &s); err != nil {
+			return omnist.Value{}, fmt.Errorf("decode time scalar: %w", err)
+		}
+		tm, err := parseISOTime(s)
+		if err != nil {
+			return omnist.Value{}, err
+		}
+		return omnist.ScalarValue(omnist.NewTimeScalar(tm)), nil
+	case "datetime":
+		var s string
+		if err := json.Unmarshal(cs.Value, &s); err != nil {
+			return omnist.Value{}, fmt.Errorf("decode datetime scalar: %w", err)
+		}
+		dt, err := parseISODateTime(s)
+		if err != nil {
+			return omnist.Value{}, err
+		}
+		return omnist.ScalarValue(omnist.NewDateTimeScalar(dt)), nil
+	default:
+		return omnist.Value{}, fmt.Errorf("unknown canonical scalar kind %q", *cs.Kind)
+	}
+}
+
+// decodeCanonicalInteger handles §8.5.4's "integer values are JSON numbers
+// when they fit exactly and decimal strings otherwise."
+func decodeCanonicalInteger(raw json.RawMessage) (*big.Int, error) {
+	s := strings.TrimSpace(string(raw))
+	s = strings.Trim(s, `"`)
+	i, ok := new(big.Int).SetString(s, 10)
+	if !ok {
+		return nil, fmt.Errorf("decode integer scalar: %q is not a valid integer literal", s)
+	}
+	return i, nil
+}
+
+func decodeCanonicalNumber(raw json.RawMessage) (float64, error) {
+	s := strings.TrimSpace(string(raw))
+	s = strings.Trim(s, `"`)
+	switch s {
+	case "nan", "NaN":
+		return math.NaN(), nil
+	case "inf", "Infinity", "+inf", "+Infinity":
+		return math.Inf(1), nil
+	case "-inf", "-Infinity":
+		return math.Inf(-1), nil
+	}
+	f, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return 0, fmt.Errorf("decode number scalar: %w", err)
+	}
+	return f, nil
+}
+
+var (
+	reISODate     = regexp.MustCompile(`^(\d{4})-(\d{2})-(\d{2})$`)
+	reISOTime     = regexp.MustCompile(`^(\d{2}):(\d{2})(?::(\d{2})(?:\.(\d{1,9}))?)?(Z|[+-]\d{2}:\d{2})?$`)
+	reISODateTime = regexp.MustCompile(`^(\d{4}-\d{2}-\d{2})T(.+)$`)
+)
+
+func parseISODate(s string) (omnist.DateValue, error) {
+	m := reISODate.FindStringSubmatch(s)
+	if m == nil {
+		return omnist.DateValue{}, fmt.Errorf("decode date scalar: %q is not an ISO-8601 date", s)
+	}
+	y, _ := strconv.Atoi(m[1])
+	mo, _ := strconv.Atoi(m[2])
+	d, _ := strconv.Atoi(m[3])
+	return omnist.DateValue{Year: y, Month: mo, Day: d}, nil
+}
+
+func parseISOTime(s string) (omnist.TimeValue, error) {
+	m := reISOTime.FindStringSubmatch(s)
+	if m == nil {
+		return omnist.TimeValue{}, fmt.Errorf("decode time scalar: %q is not an ISO-8601 time", s)
+	}
+	hh, _ := strconv.Atoi(m[1])
+	mm, _ := strconv.Atoi(m[2])
+	tv := omnist.TimeValue{Hour: hh, Minute: mm}
+	if m[3] != "" {
+		ss, _ := strconv.Atoi(m[3])
+		tv.Second = ss
+	}
+	if m[4] != "" {
+		padded := (m[4] + "000000000")[:9]
+		n, _ := strconv.Atoi(padded)
+		tv.Nanosecond = n
+	}
+	if m[5] != "" {
+		if m[5] == "Z" {
+			tv.HasOffset = true
+			tv.OffsetSeconds = 0
+		} else {
+			sign := 1
+			if m[5][0] == '-' {
+				sign = -1
+			}
+			oh, _ := strconv.Atoi(m[5][1:3])
+			om, _ := strconv.Atoi(m[5][4:6])
+			tv.HasOffset = true
+			tv.OffsetSeconds = sign * (oh*3600 + om*60)
+		}
+	}
+	return tv, nil
+}
+
+func parseISODateTime(s string) (omnist.DateTimeValue, error) {
+	m := reISODateTime.FindStringSubmatch(s)
+	if m == nil {
+		return omnist.DateTimeValue{}, fmt.Errorf("decode datetime scalar: %q is not an ISO-8601 datetime", s)
+	}
+	d, err := parseISODate(m[1])
+	if err != nil {
+		return omnist.DateTimeValue{}, err
+	}
+	t, err := parseISOTime(m[2])
+	if err != nil {
+		return omnist.DateTimeValue{}, err
+	}
+	return omnist.DateTimeValue{Date: d, Time: t}, nil
+}

--- a/tools/conformance/vectors_test.go
+++ b/tools/conformance/vectors_test.go
@@ -1,0 +1,120 @@
+package conformance
+
+import (
+	"testing"
+
+	omnist "github.com/omnist-dev/omnist-go"
+)
+
+// This file unit-tests the §8.5.4 canonical Document decoder directly,
+// independent of running it against the real test-suite (which
+// cmd/conformance's report is this package's primary verification, per
+// issue #31's note that the runner's coverage can reasonably come from
+// actually running it against the real vectors). These cases pin the
+// decoder's handling of null and the two trickiest kinds (integer as a
+// decimal string, and a temporal ISO-8601 string), which the real vector
+// suite exercises but not always in isolation.
+
+func TestDecodeCanonicalDocumentScalar(t *testing.T) {
+	doc, err := DecodeCanonicalDocument([]byte(`{"scalar": {"kind": "string", "value": "hi"}}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if doc.IsNode {
+		t.Fatal("want a bare-value Document")
+	}
+	if doc.Value.IsNull || doc.Value.Scalar.Kind != omnist.KindString || doc.Value.Scalar.Str != "hi" {
+		t.Fatalf("got %+v", doc.Value)
+	}
+}
+
+func TestDecodeCanonicalDocumentNull(t *testing.T) {
+	doc, err := DecodeCanonicalDocument([]byte(`{"scalar": {"kind": null, "value": null}}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !doc.Value.IsNull {
+		t.Fatal("want IsNull true")
+	}
+}
+
+func TestDecodeCanonicalDocumentIntegerAsDecimalString(t *testing.T) {
+	doc, err := DecodeCanonicalDocument([]byte(`{"scalar": {"kind": "integer", "value": "123456789012345678901234567890"}}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if doc.Value.Scalar.Kind != omnist.KindInteger {
+		t.Fatalf("want KindInteger, got %v", doc.Value.Scalar.Kind)
+	}
+	if doc.Value.Scalar.Int.String() != "123456789012345678901234567890" {
+		t.Fatalf("got %s", doc.Value.Scalar.Int.String())
+	}
+}
+
+func TestDecodeCanonicalDocumentEdgesPreserveOrderAndRepetition(t *testing.T) {
+	doc, err := DecodeCanonicalDocument([]byte(`{"edges": [["tag", {"scalar": {"kind": "string", "value": "x"}}], ["tag", {"scalar": {"kind": "string", "value": "y"}}]]}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !doc.IsNode || len(doc.Node.Edges) != 2 {
+		t.Fatalf("got %+v", doc)
+	}
+	if doc.Node.Edges[0].Label != "tag" || doc.Node.Edges[1].Label != "tag" {
+		t.Fatalf("want two repeated 'tag' edges, got %+v", doc.Node.Edges)
+	}
+	v0, _ := doc.Node.Edges[0].Target.Value()
+	v1, _ := doc.Node.Edges[1].Target.Value()
+	if v0.Scalar.Str != "x" || v1.Scalar.Str != "y" {
+		t.Fatalf("got %q, %q", v0.Scalar.Str, v1.Scalar.Str)
+	}
+}
+
+func TestDecodeCanonicalDocumentTemporalKinds(t *testing.T) {
+	cases := []struct {
+		json string
+		kind omnist.ScalarKind
+	}{
+		{`{"scalar": {"kind": "date", "value": "2024-01-01"}}`, omnist.KindDate},
+		{`{"scalar": {"kind": "time", "value": "12:00:00"}}`, omnist.KindTime},
+		{`{"scalar": {"kind": "datetime", "value": "2024-01-01T12:30:00"}}`, omnist.KindDateTime},
+	}
+	for _, c := range cases {
+		doc, err := DecodeCanonicalDocument([]byte(c.json))
+		if err != nil {
+			t.Fatalf("%s: unexpected error: %v", c.json, err)
+		}
+		if doc.Value.Scalar.Kind != c.kind {
+			t.Fatalf("%s: got kind %v want %v", c.json, doc.Value.Scalar.Kind, c.kind)
+		}
+	}
+	dt, err := DecodeCanonicalDocument([]byte(`{"scalar": {"kind": "datetime", "value": "2024-01-01T12:30:00"}}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := omnist.DateTimeValue{
+		Date: omnist.DateValue{Year: 2024, Month: 1, Day: 1},
+		Time: omnist.TimeValue{Hour: 12, Minute: 30, Second: 0},
+	}
+	if dt.Value.Scalar.DateTime != want {
+		t.Fatalf("got %+v want %+v", dt.Value.Scalar.DateTime, want)
+	}
+}
+
+func TestRunVectorSkipsMaterialize(t *testing.T) {
+	v := Vector{Name: "x", Operation: "materialize"}
+	res := RunVector(v)
+	if res.Status != StatusSkip {
+		t.Fatalf("want skip, got %v", res.Status)
+	}
+	if res.Reason == "" {
+		t.Fatal("want a cited reason, per §8.5.5")
+	}
+}
+
+func TestRunVectorUnknownOperationFails(t *testing.T) {
+	v := Vector{Name: "x", Operation: "not-a-real-operation"}
+	res := RunVector(v)
+	if res.Status != StatusFail {
+		t.Fatalf("want fail, got %v", res.Status)
+	}
+}


### PR DESCRIPTION
Closes #31.

Builds the conformance harness: referee (structural Document/Schema comparison, promoted from a test-only helper with a real bug fix -- field comparison was positional, now correctly label-set-based per Sec3.3's "fields form an unordered set" rule), the referee's own 10-case self-test (all passing, hand-ported from vendor/omnist-spec's `_referee-self-test` fixtures), and the Track 2 (JSON-vector) runner against all 149 vectors in `vendor/omnist-spec/test-suite/`.

**Real numbers: 109 pass / 26 fail / 14 skip.** This is the first point in the port where everything built across the prior 17 issues gets checked against the spec's own real test vectors, not just our hand-written tests -- and it surfaced 26 real, itemized bugs (position-tracking in the OML lexer, wrong-code-selection, `document.*`-family diagnostics using text-position paths instead of Document paths in violation of this repo's own path convention, a missing `schema.quoted-type` code, a validate/compatible_with inconsistency on integer->number subtyping, canonical-output spacing mismatches, and more) plus a few vectors that are themselves likely construction defects (indentation-based OML nesting that Core OML's grammar doesn't support). None of the 26 are fixed here -- correctly out of scope for a harness-bootstrap issue, reported with enough detail for follow-up issues to act on each one.

Independently verified, with unusually heavy scrutiny since this issue's deliverable is a measurement instrument, not a feature: the 109/26/14 numbers were reproduced exactly from clean state (both by me before dispatching review, and again by the reviewer). The referee's order-sensitivity and strictness were stress-tested with the reviewer's own constructed Documents/Records, not just the committed self-test. All 10 self-test fixtures were checked against the spec's actual fixture files directly, not just confirmed to pass. The canonical-vector decoder was checked against real vector JSON for both integer encoding paths (bare number and decimal string). The dispatch table was spot-checked to confirm it calls real repo functions, not stubs. Five of the 26 findings were independently re-derived by the reviewer, including the trickiest one to get right -- distinguishing a genuine Go bug from a vector-construction defect (`depth-at-declared-limit-succeeds` relies on OML indentation nesting, which Sec4 explicitly says OML doesn't have -- confirmed a vector defect, not a Go bug).

Diagnostics matching runs in exact-code mode (not code-agnostic), empirically confirmed correct rather than assumed, since this repo emits the full Sec8.3 taxonomy from day one unlike the three existing ports.

No CI gating job yet and no Track 1 (fixture-based) runner -- both explicitly deferred to follow-up issues per this issue's own scope.