### PR TITLE
materialize(document, schema)

### DIFF
--- a/materialize.go
+++ b/materialize.go
@@ -1,0 +1,256 @@
+package omnist
+
+import (
+	"math"
+	"math/big"
+	"regexp"
+)
+
+// This file implements materialize(document, schema) per spec §7.1 (the
+// two-stage read model's stage 2) and its §7.2/§7.2.1 pseudocode: walk an
+// untyped Document together with a Schema, upgrading leaves to their
+// declared types and checking record shape in the same pass.
+//
+// §7.2.1 describes materialize as "structurally this is §3.6.1's validate
+// with every leaf replaced by its upgrade result instead of discarded",
+// and the spec states a hard invariant: the two MUST stay in lockstep —
+// whatever materialize accepts at a leaf, validate must also accept
+// there, and vice versa. This file follows that structure directly:
+// materialize/materializeType/materializeRecord mirror
+// Validate/conform/conformRecord one-for-one, and materializeRecord's
+// shape/cardinality checking is not reimplemented here at all — it calls
+// validate.go's walkRecordShape, the exact function conformRecord itself
+// calls (see walkRecordShape's doc comment in validate.go). The only
+// genuinely new logic in this file is materializeScalar/tryUpgrade, since
+// validate has no equivalent of "convert a leaf", only "check its kind".
+
+// Materialize walks doc against s, upgrading leaves to their declared
+// scalar kinds and checking record shape, collecting every problem found
+// (not failing fast, matching Validate). On success (no diagnostics) the
+// returned Document is the materialized result. On failure the returned
+// Document is a best-effort partial materialization — not part of this
+// function's contract, since a caller with a non-empty diagnostics slice
+// has no ok Document per §7.1 ("fails-with-diagnostics on any problem")
+// and must not use it. err is always nil today; it is part of the
+// signature for symmetry with the two-stage read model's stage-1 codec
+// readers (json_reader.go et al.), which do report structural errors
+// distinct from diagnostics, and to leave room for a future internal
+// failure mode without a breaking signature change.
+func Materialize(doc Document, s Schema) (Document, []Diagnostic, error) {
+	result := []Diagnostic{}
+	checker := NewLimitChecker(DefaultLimits())
+	out := materialize(documentTarget(doc), s, RefType(s.Root), RootPath(), checker, &result)
+	return targetToDocument(out), result, nil
+}
+
+// targetToDocument adapts a materialized Target back to a Document, the
+// inverse of validate.go's documentTarget.
+func targetToDocument(t Target) Document {
+	if t.IsNode() {
+		n, _ := t.Node()
+		return NodeDocument(n)
+	}
+	v, _ := t.Value()
+	return ValueDocument(v)
+}
+
+// materialize is `materialize(node, S, t, path, result)` from §7.2.1: it
+// resolves t and dispatches to the scalar or record upgrade, or stops
+// descent for `any` and returns the subtree untouched (spec §7.2's
+// any-boundary rule, consistent with validate's own any handling: "the
+// subtree passes through untouched", not just unchecked but *unconverted*
+// too — this is the one point where materialize's any behavior needs its
+// own sentence beyond "same as validate", since validate has nothing to
+// convert in the first place).
+func materialize(target Target, s Schema, t Type, path Path, checker *LimitChecker, result *[]Diagnostic) Target {
+	r := resolveType(s, t)
+	switch r.kind {
+	case resolvedScalar:
+		return materializeScalar(target, r, path, result)
+	case resolvedRecord:
+		return materializeRecord(target, s, r.record, path, checker, result)
+	default:
+		// resolvedAny (spec §7.2's any-boundary rule: return target
+		// completely unconverted), and — since materialize, unlike
+		// conform in validate.go, must return a Target on every path —
+		// the same fallback for resolvedKind's closed set. resolveType
+		// only ever produces resolvedAny/resolvedScalar/resolvedRecord,
+		// so this default is exercised exclusively by the any case in
+		// practice, matching conform's three-case switch one-for-one.
+		return target
+	}
+}
+
+// materializeRecord is `materialize_record(node, S, rec, path, result)`
+// from §7.2.1. It shares validate.go's walkRecordShape for every
+// shape/cardinality check (node-ness, depth limit, unexpected fields,
+// cardinality) and supplies only the one piece specific to materialize:
+// what to do with a matched field's target, namely recurse via
+// materialize instead of conform.
+func materializeRecord(target Target, s Schema, rec *Record, path Path, checker *LimitChecker, result *[]Diagnostic) Target {
+	edges := walkRecordShape(target, rec, path, checker, result, func(e Edge, f *Field, childPath Path) Target {
+		return materialize(e.Target, s, f.Type, childPath, checker, result)
+	})
+	if !target.IsNode() {
+		// walkRecordShape already reported shape-mismatch; nothing to
+		// rebuild, hand the original (non-node) target back unchanged.
+		return target
+	}
+	return NodeTarget(&Node{Edges: edges})
+}
+
+// materializeScalar is `materialize_scalar(node, s, path, result)` from
+// §7.2.1: the leaf-level counterpart of validate.go's conformScalar, but
+// converting instead of merely checking.
+func materializeScalar(target Target, r resolved, path Path, result *[]Diagnostic) Target {
+	if target.IsNode() {
+		addDiagnostic(result, path, CodeValidateShapeMismatch, "expected a scalar value, got an object")
+		return target
+	}
+	v, _ := target.Value()
+	if v.IsNull {
+		if !r.nullable {
+			addDiagnostic(result, path, CodeValidateNullNotAllowed, "null not allowed here")
+		}
+		return target // null is never upgraded, matching kind or not.
+	}
+	upgraded, ok := tryUpgrade(v.Scalar, r.scalarKind)
+	if !ok {
+		addDiagnostic(result, path, CodeMaterializeInexactConversion, "value cannot be upgraded to the declared kind without loss")
+		return target
+	}
+	return ValueTarget(ScalarValue(upgraded))
+}
+
+// tryUpgrade is `try_upgrade(scalar, target_kind)` from §7.2.1: it
+// upgrades scalar to targetKind only when doing so is value-exact (spec
+// §7.2's materialization rule), per the pseudocode's explicit per-kind
+// rules:
+//
+//   - Same kind already: always accepted, unchanged (this also covers the
+//     case where source and target are both e.g. `date`, `time`, or
+//     `datetime` — those three never convert into one another, spec
+//     §7.2's "the two shapes are disjoint by construction").
+//   - boolean: accepted only when the source is already boolean — never
+//     treated as a subtype of integer or number in either direction, even
+//     though some host languages consider bool a subtype of int (this
+//     repo's ScalarKind enum has no such subtyping to begin with, but the
+//     rule is enforced explicitly below rather than left to happen to be
+//     true, since a future edit to the numeric branches must not silently
+//     start accepting KindBoolean).
+//   - integer target: accepted if the source is a float that is exactly
+//     integral (no fractional part); undefined (rejected) otherwise —
+//     e.g. a string numeral never upgrades, since that would invent a
+//     numeric interpretation the value doesn't already carry.
+//   - number target: accepted if the source is an integer, always
+//     producing a genuinely float-typed (KindNumber) result even when the
+//     source integer "looks whole" — §7.2's easy-to-miss detail that the
+//     table's "Yes" does not itself spell out the target representation.
+//   - date/time/datetime targets: accepted only if the source is a string
+//     matching that exact kind's spelling per matchesTemporalKind (reused
+//     from oml_lexer.go's own lexical regexes — see that function's doc
+//     comment for why reuse rather than a new parser is correct here).
+//   - anything else: undefined (rejected).
+func tryUpgrade(s Scalar, targetKind ScalarKind) (Scalar, bool) {
+	if s.Kind == targetKind {
+		return s, true
+	}
+	switch targetKind {
+	case KindInteger:
+		if s.Kind != KindNumber {
+			return Scalar{}, false
+		}
+		return integerFromExactFloat(s.Num)
+	case KindNumber:
+		if s.Kind != KindInteger {
+			return Scalar{}, false
+		}
+		f, _ := new(big.Float).SetInt(s.Int).Float64()
+		return NewNumberScalar(f), true
+	case KindDate:
+		if s.Kind != KindString || !matchesTemporalKind(s.Str, temporalDate) {
+			return Scalar{}, false
+		}
+		return NewDateScalar(parseDateValue(s.Str)), true
+	case KindTime:
+		if s.Kind != KindString || !matchesTemporalKind(s.Str, temporalTime) {
+			return Scalar{}, false
+		}
+		return NewTimeScalar(parseTimeValue(s.Str)), true
+	case KindDateTime:
+		if s.Kind != KindString || !matchesTemporalKind(s.Str, temporalDateTime) {
+			return Scalar{}, false
+		}
+		return NewDateTimeScalar(parseDateTimeValue(s.Str)), true
+	default:
+		// KindString, KindBoolean: no cross-kind upgrade path exists for
+		// either (boolean per the rule above; string is never produced by
+		// upgrading a non-string source — materialize only ever narrows
+		// strings into date/time/datetime/integer, never the reverse).
+		return Scalar{}, false
+	}
+}
+
+// integerFromExactFloat implements the integer-target half of §7.2.1's
+// numeric try_upgrade rule: accept a float source only when it is
+// finite and has no fractional part, converting it to the arbitrary-
+// precision integer representation §2.4 requires (document.go's
+// NewIntegerScalar/*big.Int) exactly, not via a fixed-width int64 that
+// could silently truncate a very large whole-number float.
+func integerFromExactFloat(f float64) (Scalar, bool) {
+	if math.IsNaN(f) || math.IsInf(f, 0) {
+		return Scalar{}, false
+	}
+	bf := big.NewFloat(f)
+	if !bf.IsInt() {
+		return Scalar{}, false
+	}
+	bi, _ := bf.Int(nil)
+	return NewIntegerScalar(bi), true
+}
+
+// temporalKind selects which of oml_lexer.go's three fully-anchored
+// temporal regexes matchesTemporalKind checks against.
+type temporalKind int
+
+const (
+	temporalDate temporalKind = iota
+	temporalTime
+	temporalDateTime
+)
+
+// matchesTemporalKind reports whether s is *exactly* (start to end) the
+// spelling reDate/reTime/reDateTime (oml_lexer.go) accept for kind — the
+// "exact spelling matches_kind() accepts for that specific kind, not
+// merely parseable by a looser library function" rule from §7.2's
+// try_upgrade notes. oml_lexer.go's own use of these regexes is via
+// FindString on a remaining-input tail (correct for a lexer scanning
+// forward through a longer document), which only pins the *start* of a
+// match, not the end — reusing them here needs a full-string check, so
+// this wraps FindString with an explicit "the match is the whole string"
+// comparison rather than introducing new regexes with different anchoring
+// (which is exactly the kind of drift the issue warns against: "reuse the
+// EXACT same format-matching logic rather than writing a new, possibly
+// looser or stricter parser").
+//
+// This is deliberately the OML lexer's spelling (§4's grammar), not
+// toml_reader.go's parseTOMLDateTime (which documents itself as *wider*
+// than oml_lexer.go's format: TOML allows a lowercase or space date/time
+// separator and a bare 'Z'/'z' offset). materialize's source strings
+// arrive from JSON/YAML/arbitrary Document construction, not specifically
+// from a TOML read, and §7.2's rule is a single canonical spelling per
+// kind — the OML lexer's spelling is that spelling, since OML is the
+// format whose native literal syntax the temporal scalar kinds were
+// designed around (§2.2.1/§4).
+func matchesTemporalKind(s string, kind temporalKind) bool {
+	var re *regexp.Regexp
+	switch kind {
+	case temporalDate:
+		re = reDate
+	case temporalTime:
+		re = reTime
+	case temporalDateTime:
+		re = reDateTime
+	}
+	return re.FindString(s) == s
+}

--- a/materialize_test.go
+++ b/materialize_test.go
@@ -1,0 +1,636 @@
+package omnist
+
+import (
+	"math"
+	"math/big"
+	"testing"
+)
+
+// scalarRecordSchema builds a one-field record `record R { "n": <kind> }`
+// (optionally nullable), used throughout this file's table-driven tests
+// since every §7.2 materialization-table row is single-leaf.
+func scalarRecordSchema(kind ScalarKind, nullable bool) Schema {
+	r := &Record{
+		Name:   "R",
+		Fields: []Field{{Label: "n", Type: ScalarType(kind, nullable), Cardinality: DefaultCardinality()}},
+	}
+	return Schema{Root: "R", Env: map[string]*Record{"R": r}}
+}
+
+func oneFieldDoc(v Value) Document {
+	n := NewNode()
+	n.AddValue("n", v)
+	return NodeDocument(n)
+}
+
+// --- §7.2 materialization table, both directions where applicable ---
+
+func TestMaterializeStringToDate(t *testing.T) {
+	doc := oneFieldDoc(ScalarValue(NewStringScalar("2024-01-01")))
+	got, diags, err := Materialize(doc, scalarRecordSchema(KindDate, false))
+	if err != nil || len(diags) != 0 {
+		t.Fatalf("want ok, got diags=%v err=%v", diags, err)
+	}
+	want := NewDateScalar(DateValue{Year: 2024, Month: 1, Day: 1})
+	gotScalar := got.Node.Edges[0].Target
+	v, _ := gotScalar.Value()
+	if !v.Scalar.Equal(want) {
+		t.Fatalf("got %+v want %+v", v.Scalar, want)
+	}
+}
+
+func TestMaterializeStringToTime(t *testing.T) {
+	doc := oneFieldDoc(ScalarValue(NewStringScalar("12:30:00")))
+	got, diags, err := Materialize(doc, scalarRecordSchema(KindTime, false))
+	if err != nil || len(diags) != 0 {
+		t.Fatalf("want ok, got diags=%v err=%v", diags, err)
+	}
+	want := NewTimeScalar(TimeValue{Hour: 12, Minute: 30})
+	v, _ := got.Node.Edges[0].Target.Value()
+	if !v.Scalar.Equal(want) {
+		t.Fatalf("got %+v want %+v", v.Scalar, want)
+	}
+}
+
+func TestMaterializeStringToDateTime(t *testing.T) {
+	doc := oneFieldDoc(ScalarValue(NewStringScalar("2024-01-01T12:30:00")))
+	got, diags, err := Materialize(doc, scalarRecordSchema(KindDateTime, false))
+	if err != nil || len(diags) != 0 {
+		t.Fatalf("want ok, got diags=%v err=%v", diags, err)
+	}
+	want := NewDateTimeScalar(DateTimeValue{
+		Date: DateValue{Year: 2024, Month: 1, Day: 1},
+		Time: TimeValue{Hour: 12, Minute: 30},
+	})
+	v, _ := got.Node.Edges[0].Target.Value()
+	if !v.Scalar.Equal(want) {
+		t.Fatalf("got %+v want %+v", v.Scalar, want)
+	}
+}
+
+func TestMaterializeWholeFloatToIntegerIsValueExact(t *testing.T) {
+	doc := oneFieldDoc(ScalarValue(NewNumberScalar(1.0)))
+	got, diags, err := Materialize(doc, scalarRecordSchema(KindInteger, false))
+	if err != nil || len(diags) != 0 {
+		t.Fatalf("want ok, got diags=%v err=%v", diags, err)
+	}
+	v, _ := got.Node.Edges[0].Target.Value()
+	if v.Scalar.Kind != KindInteger {
+		t.Fatalf("want KindInteger, got %v", v.Scalar.Kind)
+	}
+	if v.Scalar.Int.Cmp(big.NewInt(1)) != 0 {
+		t.Fatalf("want 1, got %v", v.Scalar.Int)
+	}
+}
+
+func TestMaterializeFractionalFloatToIntegerFails(t *testing.T) {
+	doc := oneFieldDoc(ScalarValue(NewNumberScalar(1.5)))
+	_, diags, err := Materialize(doc, scalarRecordSchema(KindInteger, false))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasCode(diags, CodeMaterializeInexactConversion) {
+		t.Fatalf("want materialize.inexact-conversion, got %v", codesOf(diags))
+	}
+}
+
+func TestMaterializeIntegerToNumberYieldsFloatTypedResult(t *testing.T) {
+	doc := oneFieldDoc(ScalarValue(NewIntegerScalar(big.NewInt(1))))
+	got, diags, err := Materialize(doc, scalarRecordSchema(KindNumber, false))
+	if err != nil || len(diags) != 0 {
+		t.Fatalf("want ok, got diags=%v err=%v", diags, err)
+	}
+	v, _ := got.Node.Edges[0].Target.Value()
+	if v.Scalar.Kind != KindNumber {
+		t.Fatalf("want KindNumber (float-typed), got %v", v.Scalar.Kind)
+	}
+	if v.Scalar.Num != 1.0 {
+		t.Fatalf("want 1.0, got %v", v.Scalar.Num)
+	}
+}
+
+func TestMaterializeStringNumeralNeverUpgradesToInteger(t *testing.T) {
+	doc := oneFieldDoc(ScalarValue(NewStringScalar("1")))
+	_, diags, err := Materialize(doc, scalarRecordSchema(KindInteger, false))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasCode(diags, CodeMaterializeInexactConversion) {
+		t.Fatalf("want materialize.inexact-conversion, got %v", codesOf(diags))
+	}
+}
+
+func TestMaterializeArbitraryStringNeverUpgradesToBoolean(t *testing.T) {
+	doc := oneFieldDoc(ScalarValue(NewStringScalar("maybe")))
+	_, diags, err := Materialize(doc, scalarRecordSchema(KindBoolean, false))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasCode(diags, CodeMaterializeInexactConversion) {
+		t.Fatalf("want materialize.inexact-conversion, got %v", codesOf(diags))
+	}
+}
+
+// --- boolean never treated as integer/number in either direction ---
+
+func TestMaterializeBooleanNeverUpgradesToIntegerOrNumber(t *testing.T) {
+	for _, kind := range []ScalarKind{KindInteger, KindNumber} {
+		doc := oneFieldDoc(ScalarValue(NewBooleanScalar(true)))
+		_, diags, err := Materialize(doc, scalarRecordSchema(kind, false))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !hasCode(diags, CodeMaterializeInexactConversion) {
+			t.Fatalf("kind=%v: want materialize.inexact-conversion, got %v", kind, codesOf(diags))
+		}
+	}
+}
+
+func TestMaterializeIntegerAndNumberNeverUpgradeToBoolean(t *testing.T) {
+	cases := []Scalar{NewIntegerScalar(big.NewInt(1)), NewNumberScalar(1.0)}
+	for _, s := range cases {
+		doc := oneFieldDoc(ScalarValue(s))
+		_, diags, err := Materialize(doc, scalarRecordSchema(KindBoolean, false))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !hasCode(diags, CodeMaterializeInexactConversion) {
+			t.Fatalf("source=%+v: want materialize.inexact-conversion, got %v", s, codesOf(diags))
+		}
+	}
+}
+
+// --- the any-boundary rule ---
+
+func TestMaterializeAnyFieldPassesSubtreeThroughUntouched(t *testing.T) {
+	inner := NewNode()
+	inner.AddValue("x", ScalarValue(NewStringScalar("2024-01-01"))) // date-shaped, but must NOT upgrade
+	root := NewNode()
+	root.AddNode("data", inner)
+	doc := NodeDocument(root)
+
+	r := &Record{Name: "R", Fields: []Field{{Label: "data", Type: AnyType(), Cardinality: DefaultCardinality()}}}
+	s := Schema{Root: "R", Env: map[string]*Record{"R": r}}
+
+	got, diags, err := Materialize(doc, s)
+	if err != nil || len(diags) != 0 {
+		t.Fatalf("want ok, got diags=%v err=%v", diags, err)
+	}
+	if !DocumentsEqual(got, doc) {
+		t.Fatalf("subtree under `any` must pass through byte-for-byte unchanged: got %+v want %+v", got, doc)
+	}
+}
+
+// --- collect-all, not fail-fast ---
+
+func TestMaterializeCollectsEveryProblemNotJustTheFirst(t *testing.T) {
+	r := &Record{
+		Name: "R",
+		Fields: []Field{
+			{Label: "a", Type: ScalarType(KindInteger, false), Cardinality: DefaultCardinality()},
+			{Label: "b", Type: ScalarType(KindBoolean, false), Cardinality: DefaultCardinality()},
+		},
+	}
+	s := Schema{Root: "R", Env: map[string]*Record{"R": r}}
+	n := NewNode()
+	n.AddValue("a", ScalarValue(NewStringScalar("x")))
+	n.AddValue("b", ScalarValue(NewStringScalar("y")))
+	doc := NodeDocument(n)
+
+	_, diags, err := Materialize(doc, s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	count := 0
+	for _, d := range diags {
+		if d.Code == CodeMaterializeInexactConversion {
+			count++
+		}
+	}
+	if count != 2 {
+		t.Fatalf("want 2 materialize.inexact-conversion diagnostics, got %d: %v", count, diags)
+	}
+}
+
+// --- disjoint temporal shapes ---
+
+func TestMaterializeBareDateNeverUpgradesToDateTime(t *testing.T) {
+	doc := oneFieldDoc(ScalarValue(NewStringScalar("2024-01-01")))
+	_, diags, err := Materialize(doc, scalarRecordSchema(KindDateTime, false))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasCode(diags, CodeMaterializeInexactConversion) {
+		t.Fatalf("want materialize.inexact-conversion, got %v", codesOf(diags))
+	}
+}
+
+func TestMaterializeDateTimeShapedStringNeverUpgradesToDate(t *testing.T) {
+	doc := oneFieldDoc(ScalarValue(NewStringScalar("2024-01-01T12:30:00")))
+	_, diags, err := Materialize(doc, scalarRecordSchema(KindDate, false))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasCode(diags, CodeMaterializeInexactConversion) {
+		t.Fatalf("want materialize.inexact-conversion, got %v", codesOf(diags))
+	}
+}
+
+func TestMaterializeDateShapedStringNeverUpgradesToTime(t *testing.T) {
+	doc := oneFieldDoc(ScalarValue(NewStringScalar("2024-01-01")))
+	_, diags, err := Materialize(doc, scalarRecordSchema(KindTime, false))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasCode(diags, CodeMaterializeInexactConversion) {
+		t.Fatalf("want materialize.inexact-conversion, got %v", codesOf(diags))
+	}
+}
+
+// --- cross-codec integration: JSON never auto-resolves temporal strings ---
+
+func TestMaterializeUpgradesJSONSourcedStringsToTemporalKinds(t *testing.T) {
+	doc, err := ReadJSON(`{"d": "2024-01-01", "t": "12:30:00", "dt": "2024-01-01T12:30:00"}`, DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := &Record{
+		Name: "R",
+		Fields: []Field{
+			{Label: "d", Type: ScalarType(KindDate, false), Cardinality: DefaultCardinality()},
+			{Label: "t", Type: ScalarType(KindTime, false), Cardinality: DefaultCardinality()},
+			{Label: "dt", Type: ScalarType(KindDateTime, false), Cardinality: DefaultCardinality()},
+		},
+	}
+	s := Schema{Root: "R", Env: map[string]*Record{"R": r}}
+
+	got, diags, merr := Materialize(doc, s)
+	if merr != nil || len(diags) != 0 {
+		t.Fatalf("want ok, got diags=%v err=%v", diags, merr)
+	}
+	// A JSON reader can never itself produce a KindDate/KindTime/KindDateTime
+	// scalar (JSON has no such literal syntax) -- confirming these came out
+	// upgraded is the concrete proof that materialize, not the reader, did
+	// the work, which is the whole reason this operation exists.
+	for _, e := range got.Node.Edges {
+		v, _ := e.Target.Value()
+		switch e.Label {
+		case "d":
+			if v.Scalar.Kind != KindDate {
+				t.Fatalf("d: want KindDate, got %v", v.Scalar.Kind)
+			}
+		case "t":
+			if v.Scalar.Kind != KindTime {
+				t.Fatalf("t: want KindTime, got %v", v.Scalar.Kind)
+			}
+		case "dt":
+			if v.Scalar.Kind != KindDateTime {
+				t.Fatalf("dt: want KindDateTime, got %v", v.Scalar.Kind)
+			}
+		}
+	}
+}
+
+// --- the lockstep invariant with validate ---
+
+// TestMaterializeValidateLockstepOnShape is the shape/cardinality half of
+// the issue's lockstep requirement. Shape/cardinality checking involves no
+// conversion at all (walkRecordShape is the literal same code for both
+// operations, see validate.go), so for a document whose only problem is
+// shape (an unexpected field), Materialize and Validate must agree on the
+// *original*, pre-materialize document -- there is nothing for materialize
+// to convert here, so "original" vs. "materialized" input is not even a
+// meaningful distinction to draw for this half of the invariant.
+func TestMaterializeValidateLockstepOnShape(t *testing.T) {
+	r := &Record{
+		Name:   "R",
+		Fields: []Field{{Label: "n", Type: ScalarType(KindInteger, false), Cardinality: DefaultCardinality()}},
+	}
+	s := Schema{Root: "R", Env: map[string]*Record{"R": r}}
+
+	ok := func() Document {
+		n := NewNode()
+		n.AddValue("n", ScalarValue(NewIntegerScalar(big.NewInt(1))))
+		return NodeDocument(n)
+	}()
+	shapeBad := func() Document {
+		n := NewNode()
+		n.AddValue("n", ScalarValue(NewIntegerScalar(big.NewInt(1))))
+		n.AddValue("extra", ScalarValue(NewStringScalar("x"))) // unexpected field
+		return NodeDocument(n)
+	}()
+
+	for _, tc := range []struct {
+		name   string
+		doc    Document
+		wantOK bool
+	}{
+		{"shape-ok", ok, true},
+		{"shape-bad", shapeBad, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, mdiags, merr := Materialize(tc.doc, s)
+			if merr != nil {
+				t.Fatal(merr)
+			}
+			vdiags := Validate(tc.doc, s)
+			mOK, vOK := len(mdiags) == 0, len(vdiags) == 0
+			if mOK != tc.wantOK || vOK != tc.wantOK {
+				t.Fatalf("Materialize ok=%v Validate ok=%v want both %v", mOK, vOK, tc.wantOK)
+			}
+		})
+	}
+}
+
+// TestMaterializeValidateLockstepOnLeafUpgrade is the leaf-conversion half
+// of the invariant. Unlike shape checking, a value-exact upgrade (e.g.
+// 1.0 -> integer) is something Validate has no concept of at all: Validate
+// checks a leaf's *existing* kind against the declared kind and never
+// coerces, so a number-kind 1.0 against a declared `integer` field
+// legitimately fails Validate on the ORIGINAL document even though
+// Materialize accepts it (that is the entire point of materialize
+// existing as a separate operation from validate). The meaningful
+// lockstep comparison here is therefore post-materialization: whatever
+// Materialize successfully upgrades, running Validate against the
+// *materialized* result must accept, since every leaf now literally has
+// its declared kind.
+func TestMaterializeValidateLockstepOnLeafUpgrade(t *testing.T) {
+	r := &Record{
+		Name:   "R",
+		Fields: []Field{{Label: "n", Type: ScalarType(KindInteger, false), Cardinality: DefaultCardinality()}},
+	}
+	s := Schema{Root: "R", Env: map[string]*Record{"R": r}}
+
+	n := NewNode()
+	n.AddValue("n", ScalarValue(NewNumberScalar(1.0))) // value-exact upgrade target
+	original := NodeDocument(n)
+
+	// Validate rejects the ORIGINAL: a number-kind value never matches a
+	// declared integer kind without conversion, which validate never does.
+	if vdiags := Validate(original, s); len(vdiags) == 0 {
+		t.Fatal("want Validate to reject the original unconverted document, got ok")
+	}
+
+	materialized, mdiags, merr := Materialize(original, s)
+	if merr != nil || len(mdiags) != 0 {
+		t.Fatalf("want Materialize to accept, got diags=%v err=%v", mdiags, merr)
+	}
+	// Lockstep: once materialized, Validate must now accept it -- the
+	// upgraded leaf's kind literally matches the declared kind.
+	if vdiags := Validate(materialized, s); len(vdiags) != 0 {
+		t.Fatalf("lockstep violated: Validate rejects materialize's own output: %v", vdiags)
+	}
+}
+
+// --- shape/cardinality: same codes as validate, unexpected field kept ---
+
+func TestMaterializeUnexpectedFieldIsKeptNotDroppedButStillFails(t *testing.T) {
+	r := &Record{
+		Name:   "R",
+		Fields: []Field{{Label: "n", Type: ScalarType(KindInteger, false), Cardinality: DefaultCardinality()}},
+	}
+	s := Schema{Root: "R", Env: map[string]*Record{"R": r}}
+	n := NewNode()
+	n.AddValue("n", ScalarValue(NewIntegerScalar(big.NewInt(1))))
+	n.AddValue("extra", ScalarValue(NewStringScalar("x")))
+	doc := NodeDocument(n)
+
+	got, diags, err := Materialize(doc, s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasCode(diags, CodeValidateUnexpectedField) {
+		t.Fatalf("want validate.unexpected-field, got %v", codesOf(diags))
+	}
+	found := false
+	for _, e := range got.Node.Edges {
+		if e.Label == "extra" {
+			found = true
+			v, _ := e.Target.Value()
+			if v.Scalar.Kind != KindString || v.Scalar.Str != "x" {
+				t.Fatalf("extra field mutated: got %+v", v.Scalar)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("unexpected field was dropped from output, want it kept unchanged")
+	}
+}
+
+func TestMaterializeCardinalityUsesValidateCode(t *testing.T) {
+	r := &Record{
+		Name:   "R",
+		Fields: []Field{{Label: "n", Type: ScalarType(KindInteger, false), Cardinality: Cardinality{Min: 2, Max: 2}}},
+	}
+	s := Schema{Root: "R", Env: map[string]*Record{"R": r}}
+	n := NewNode()
+	n.AddValue("n", ScalarValue(NewIntegerScalar(big.NewInt(1))))
+	doc := NodeDocument(n)
+
+	_, diags, err := Materialize(doc, s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasCode(diags, CodeValidateCardinality) {
+		t.Fatalf("want validate.cardinality, got %v", codesOf(diags))
+	}
+}
+
+// --- remaining coverage: shape mismatches, null handling, nested records,
+// depth limit, non-node root, same-kind identity leaves ---
+
+func TestMaterializeScalarTargetButGotObjectFails(t *testing.T) {
+	r := &Record{
+		Name:   "R",
+		Fields: []Field{{Label: "n", Type: ScalarType(KindInteger, false), Cardinality: DefaultCardinality()}},
+	}
+	s := Schema{Root: "R", Env: map[string]*Record{"R": r}}
+	n := NewNode()
+	n.AddNode("n", NewNode())
+	doc := NodeDocument(n)
+
+	_, diags, err := Materialize(doc, s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasCode(diags, CodeValidateShapeMismatch) {
+		t.Fatalf("want validate.shape-mismatch, got %v", codesOf(diags))
+	}
+}
+
+func TestMaterializeRecordTargetButGotScalarFails(t *testing.T) {
+	r := &Record{
+		Name:   "R",
+		Fields: []Field{{Label: "n", Type: ScalarType(KindInteger, false), Cardinality: DefaultCardinality()}},
+	}
+	s := Schema{Root: "R", Env: map[string]*Record{"R": r}}
+	doc := ValueDocument(ScalarValue(NewStringScalar("not a record")))
+
+	got, diags, err := Materialize(doc, s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasCode(diags, CodeValidateShapeMismatch) {
+		t.Fatalf("want validate.shape-mismatch, got %v", codesOf(diags))
+	}
+	// A non-node root has no edges to rebuild; the best-effort output
+	// hands the original (non-node) target back unchanged.
+	if got.IsNode {
+		t.Fatal("want the original non-node document back, got a node")
+	}
+}
+
+func TestMaterializeNullLeafAllowedOnlyWhenNullable(t *testing.T) {
+	// Not nullable: rejected, and never attempts an upgrade.
+	doc := oneFieldDoc(NullValue())
+	_, diags, err := Materialize(doc, scalarRecordSchema(KindInteger, false))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasCode(diags, CodeValidateNullNotAllowed) {
+		t.Fatalf("want validate.null-not-allowed, got %v", codesOf(diags))
+	}
+
+	// Nullable: accepted, null stays null (not "upgraded" to anything).
+	got, diags2, err2 := Materialize(doc, scalarRecordSchema(KindInteger, true))
+	if err2 != nil || len(diags2) != 0 {
+		t.Fatalf("want ok, got diags=%v err=%v", diags2, err2)
+	}
+	v, _ := got.Node.Edges[0].Target.Value()
+	if !v.IsNull {
+		t.Fatalf("want null to stay null, got %+v", v)
+	}
+}
+
+func TestMaterializeNestedRecordUpgradesLeavesAtEveryDepth(t *testing.T) {
+	inner := &Record{
+		Name:   "Inner",
+		Fields: []Field{{Label: "n", Type: ScalarType(KindDate, false), Cardinality: DefaultCardinality()}},
+	}
+	outer := &Record{
+		Name:   "Outer",
+		Fields: []Field{{Label: "child", Type: RefType("Inner"), Cardinality: DefaultCardinality()}},
+	}
+	s := Schema{Root: "Outer", Env: map[string]*Record{"Outer": outer, "Inner": inner}}
+
+	innerNode := NewNode()
+	innerNode.AddValue("n", ScalarValue(NewStringScalar("2024-01-01")))
+	root := NewNode()
+	root.AddNode("child", innerNode)
+	doc := NodeDocument(root)
+
+	got, diags, err := Materialize(doc, s)
+	if err != nil || len(diags) != 0 {
+		t.Fatalf("want ok, got diags=%v err=%v", diags, err)
+	}
+	childNode, _ := got.Node.Edges[0].Target.Node()
+	v, _ := childNode.Edges[0].Target.Value()
+	if v.Scalar.Kind != KindDate {
+		t.Fatalf("want nested leaf upgraded to KindDate, got %v", v.Scalar.Kind)
+	}
+}
+
+func TestMaterializeRespectsDepthLimit(t *testing.T) {
+	// A schema that recurses through itself lets a document exceed the
+	// depth limit; materialize must report document.limit.depth (via the
+	// shared LimitChecker), not a materialize.* or validate.* code, and
+	// must not panic (mirrors validate's own depth-limit test intent).
+	rec := &Record{Name: "Self", Fields: []Field{{Label: "child", Type: RefType("Self"), Cardinality: Cardinality{Min: 0, Max: 1}}}}
+	s := Schema{Root: "Self", Env: map[string]*Record{"Self": rec}}
+
+	limits := DefaultLimits()
+	limits.MaxDepth = 2
+	checker := NewLimitChecker(limits)
+
+	deep := NewNode() // depth 3: root(1) -> child(2) -> child(3), exceeds MaxDepth=2
+	leaf := NewNode()
+	mid := NewNode()
+	mid.AddNode("child", leaf)
+	deep.AddNode("child", mid)
+	doc := NodeDocument(deep)
+
+	result := []Diagnostic{}
+	out := materialize(documentTarget(doc), s, RefType(s.Root), RootPath(), checker, &result)
+	_ = out
+	if !hasCode(result, CodeDocumentLimitDepth) {
+		t.Fatalf("want document.limit.depth, got %v", codesOf(result))
+	}
+}
+
+func TestMaterializeSameKindLeafIsAcceptedUnchanged(t *testing.T) {
+	for _, s := range []Scalar{
+		NewStringScalar("x"),
+		NewBooleanScalar(true),
+		NewDateScalar(DateValue{Year: 2024, Month: 1, Day: 1}),
+		NewTimeScalar(TimeValue{Hour: 1, Minute: 2}),
+		NewDateTimeScalar(DateTimeValue{Date: DateValue{Year: 2024, Month: 1, Day: 1}, Time: TimeValue{Hour: 1, Minute: 2}}),
+		NewNumberScalar(2.5),
+	} {
+		doc := oneFieldDoc(ScalarValue(s))
+		got, diags, err := Materialize(doc, scalarRecordSchema(s.Kind, false))
+		if err != nil || len(diags) != 0 {
+			t.Fatalf("kind=%v: want ok, got diags=%v err=%v", s.Kind, diags, err)
+		}
+		v, _ := got.Node.Edges[0].Target.Value()
+		if !v.Scalar.Equal(s) {
+			t.Fatalf("kind=%v: want unchanged %+v, got %+v", s.Kind, s, v.Scalar)
+		}
+	}
+}
+
+func TestMaterializeNilRecordSchemaReportsUnexpectedFieldEveryEdge(t *testing.T) {
+	// A Ref whose name is absent from Env (not-well-formed schema) resolves
+	// to a nil Record -- validate.go's resolveType/conformRecord already
+	// handle this by treating a nil record as "no fields, closed"; confirm
+	// materialize's shared walkRecordShape path does too, and does not
+	// panic on a nil rec.
+	s := Schema{Root: "Missing", Env: map[string]*Record{}}
+	n := NewNode()
+	n.AddValue("x", ScalarValue(NewStringScalar("y")))
+	doc := NodeDocument(n)
+
+	got, diags, err := Materialize(doc, s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasCode(diags, CodeValidateUnexpectedField) {
+		t.Fatalf("want validate.unexpected-field, got %v", codesOf(diags))
+	}
+	if len(got.Node.Edges) != 1 || got.Node.Edges[0].Label != "x" {
+		t.Fatalf("want the edge kept unchanged, got %+v", got.Node.Edges)
+	}
+}
+
+func TestMaterializeInfiniteAndNaNFloatsNeverUpgradeToInteger(t *testing.T) {
+	for _, f := range []float64{math.Inf(1), math.Inf(-1), math.NaN()} {
+		doc := oneFieldDoc(ScalarValue(NewNumberScalar(f)))
+		_, diags, err := Materialize(doc, scalarRecordSchema(KindInteger, false))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !hasCode(diags, CodeMaterializeInexactConversion) {
+			t.Fatalf("f=%v: want materialize.inexact-conversion, got %v", f, codesOf(diags))
+		}
+	}
+}
+
+// TestMaterializeDefaultCaseExercisesDefensiveDefault mirrors
+// validate_test.go's TestResolveTypeDefaultCase: materialize's switch on
+// resolveType's resolvedKind has the same defensive default branch as
+// validate.go's conform, guarding against a future resolvedKind constant
+// added without updating materialize. schema.go's exported Type struct
+// makes an actual illegal TypeKind constructible from outside the
+// package, so this is a real (if narrow) reachable path, not dead code.
+func TestMaterializeDefaultCaseExercisesDefensiveDefault(t *testing.T) {
+	checker := NewLimitChecker(DefaultLimits())
+	result := []Diagnostic{}
+	original := ValueTarget(ScalarValue(NewStringScalar("x")))
+	got := materialize(original, personSchema(), Type{Kind: TypeKind(99)}, RootPath(), checker, &result)
+	if len(result) != 0 {
+		t.Fatalf("want no diagnostics, got %v", result)
+	}
+	v, _ := got.Value()
+	if v.Scalar.Str != "x" {
+		t.Fatalf("want the original target back unchanged, got %+v", v)
+	}
+}

--- a/tools/conformance/drivers.go
+++ b/tools/conformance/drivers.go
@@ -177,6 +177,66 @@ func runValidate(v Vector) Result {
 	return pass(v)
 }
 
+// --- materialize ---
+
+// materializeInput mirrors validateInput -- §8.5.3's table gives
+// materialize the same {schema, document} input shape as validate.
+type materializeInput struct {
+	Schema   string          `json:"schema"`
+	Document json.RawMessage `json:"document"`
+}
+
+func runMaterialize(v Vector) Result {
+	var in materializeInput
+	if err := json.Unmarshal(v.Input, &in); err != nil {
+		return fail(v, "decode input: %v", err)
+	}
+	expect, err := decodeExpect(v)
+	if err != nil {
+		return fail(v, "decode expect: %v", err)
+	}
+	schema, serr := omnist.ReadOSD(in.Schema)
+	if serr != nil {
+		return fail(v, "input schema failed to parse: %v", serr)
+	}
+	doc, derr := DecodeCanonicalDocument(in.Document)
+	if derr != nil {
+		return fail(v, "decode input.document: %v", derr)
+	}
+	got, diags, merr := omnist.Materialize(doc, schema)
+	if merr != nil {
+		return fail(v, "materialize: %v", merr)
+	}
+	wantOK := expectOK(expect)
+	gotPairs := diagsToPairs(diags)
+	if wantOK {
+		if len(diags) != 0 {
+			return fail(v, "expected ok, got diagnostics: %v", diagStrings(gotPairs))
+		}
+		wantDocRaw, ok := expect["document"]
+		if !ok {
+			return pass(v) // no document to compare
+		}
+		wantDoc, err := DecodeCanonicalDocument(wantDocRaw)
+		if err != nil {
+			return fail(v, "decode expect.document: %v", err)
+		}
+		if !omnist.DocumentsEqual(got, wantDoc) {
+			return fail(v, "document mismatch")
+		}
+		return pass(v)
+	}
+	wantDiags, err := decodeExpectDiagnostics(expect)
+	if err != nil {
+		return fail(v, "decode expect.diagnostics: %v", err)
+	}
+	want := expectDiagPairs(wantDiags)
+	if !diagnosticSetsEqual(gotPairs, want) {
+		return fail(v, "diagnostics mismatch: got %v want %v", diagStrings(gotPairs), diagStrings(want))
+	}
+	return pass(v)
+}
+
 // --- write ---
 
 type writeInput struct {

--- a/tools/conformance/runner.go
+++ b/tools/conformance/runner.go
@@ -65,10 +65,11 @@ type findingExpect struct {
 
 // RunVector dispatches one vector by its operation field (§8.5.3's table)
 // and compares the result against its "expect" per §8.5.2's rules. It
-// never panics on a vector it cannot execute -- an operation not yet
-// implemented (materialize) or a driver bug produces a Result, not a
-// crash, per the issue's "not yet implemented gets an honest skip, not a
-// crash or a forced pass" requirement.
+// never panics on a vector it cannot execute -- a driver bug produces a
+// Result, not a crash, per the issue's "not yet implemented gets an
+// honest skip, not a crash or a forced pass" requirement (no operation
+// currently falls into that not-yet-implemented bucket as of issue #35,
+// which wired up materialize, the last one).
 func RunVector(v Vector) Result {
 	switch v.Operation {
 	case "parse":
@@ -78,7 +79,7 @@ func RunVector(v Vector) Result {
 	case "validate":
 		return runValidate(v)
 	case "materialize":
-		return Result{Vector: v, Status: StatusSkip, Reason: "not yet implemented: materialize (issue #31 explicitly excludes new operation implementations; tracked for a follow-up issue)"}
+		return runMaterialize(v)
 	case "write":
 		return runWrite(v)
 	case "compatible_with":

--- a/tools/conformance/vectors_test.go
+++ b/tools/conformance/vectors_test.go
@@ -100,14 +100,18 @@ func TestDecodeCanonicalDocumentTemporalKinds(t *testing.T) {
 	}
 }
 
-func TestRunVectorSkipsMaterialize(t *testing.T) {
-	v := Vector{Name: "x", Operation: "materialize"}
+// TestRunVectorMaterializeBadInputFails confirms materialize is wired up
+// as a real driver (issue #35): a vector with no input.schema/document is
+// a driver-level decode failure, not the "not yet implemented" skip this
+// operation used to report before issue #35 implemented Materialize.
+func TestRunVectorMaterializeBadInputFails(t *testing.T) {
+	v := Vector{Name: "x", Operation: "materialize", Input: []byte(`{}`)}
 	res := RunVector(v)
-	if res.Status != StatusSkip {
-		t.Fatalf("want skip, got %v", res.Status)
+	if res.Status != StatusFail {
+		t.Fatalf("want fail, got %v (%s)", res.Status, res.Reason)
 	}
 	if res.Reason == "" {
-		t.Fatal("want a cited reason, per §8.5.5")
+		t.Fatal("want a reason describing the decode failure")
 	}
 }
 

--- a/validate.go
+++ b/validate.go
@@ -112,10 +112,44 @@ func conformScalar(target Target, r resolved, path Path, result *[]Diagnostic) {
 // conformRecord is `conform_record(node, S, rec, path, result)` from
 // §3.6.1. rec may be nil (see resolved's doc comment); a nil record has no
 // fields, so every edge is unexpected and no field is ever satisfied.
+//
+// This is a thin wrapper around walkRecordShape, which holds the actual
+// shape/cardinality-checking logic shared with materialize.go's
+// materializeRecord — see walkRecordShape's doc comment for why the
+// sharing is structured this way, per issue #35's lockstep invariant
+// ("whatever materialize accepts at a leaf, validate must also accept,
+// and vice versa").
 func conformRecord(target Target, s Schema, rec *Record, path Path, checker *LimitChecker, result *[]Diagnostic) {
+	walkRecordShape(target, rec, path, checker, result, func(e Edge, f *Field, childPath Path) Target {
+		conform(e.Target, s, f.Type, childPath, checker, result)
+		return e.Target
+	})
+}
+
+// walkRecordShape is the shape/cardinality-checking core of §3.6.1's
+// `conform_record` (validate) and §7.2.1's `materialize_record`
+// (materialize): both operations check exactly the same things at a
+// record boundary (is the target a node, is the depth limit respected, is
+// every edge's label declared, does every declared field's edge count
+// fall within its cardinality) and differ only in what they do with a
+// *matched* field's target — validate recurses into conform (and
+// discards the result), materialize recurses into materialize_type and
+// keeps the converted Target for its output document. onMatched is that
+// one point of difference; everything else here is identical between the
+// two callers by construction, which is how the two stay in lockstep
+// rather than via two independently-written implementations that could
+// drift apart.
+//
+// Returns the record's output edges: a matched edge holds whatever
+// onMatched returned, an unmatched (unexpected-field) edge is carried
+// through unchanged, per §7.2.1's explicit note that materialize appends
+// an unexpected field's (label, child) to its output unmodified rather
+// than dropping it. validate's caller (conformRecord) ignores this
+// return value; only materialize.go's materializeRecord uses it.
+func walkRecordShape(target Target, rec *Record, path Path, checker *LimitChecker, result *[]Diagnostic, onMatched func(e Edge, f *Field, childPath Path) Target) []Edge {
 	if !target.IsNode() {
 		addDiagnostic(result, path, CodeValidateShapeMismatch, "expected an object, got a value")
-		return
+		return nil
 	}
 	node, _ := target.Node()
 
@@ -123,11 +157,13 @@ func conformRecord(target Target, s Schema, rec *Record, path Path, checker *Lim
 	// and exceeding it is a resource-cap error, not a validation finding.
 	// Every EnterNode is paired with exactly one LeaveNode (even on the
 	// limit-exceeded path) so the checker's running depth stays correct for
-	// sibling subtrees visited later in the same walk.
+	// sibling subtrees visited later in the same walk. materialize needs
+	// the identical depth accounting (issue #35: "materialize needs the
+	// same [LimitChecker wiring]"), which this sharing gives it for free.
 	if diag := checker.EnterNode(path.String()); diag != nil {
 		*result = append(*result, *diag)
 		checker.LeaveNode()
-		return
+		return nil
 	}
 	defer checker.LeaveNode()
 
@@ -137,6 +173,7 @@ func conformRecord(target Target, s Schema, rec *Record, path Path, checker *Lim
 	// of that order for the cardinality check below, per D-3 order
 	// independence.
 	counts := make(map[string]int, len(node.Edges))
+	outEdges := make([]Edge, 0, len(node.Edges))
 	for i, e := range node.Edges {
 		counts[e.Label]++
 		occurrence, repeated := PathIndexInNode(node, i)
@@ -146,17 +183,19 @@ func conformRecord(target Target, s Schema, rec *Record, path Path, checker *Lim
 		if f == nil {
 			addDiagnostic(result, childPath, CodeValidateUnexpectedField, "field not declared on this record")
 			// No further descent: an undeclared field has no type to check
-			// against (§3.6.1's first "easy to miss" detail).
+			// against (§3.6.1's first "easy to miss" detail). Kept
+			// unchanged in the output, per materialize_record's pseudocode.
+			outEdges = append(outEdges, e)
 			continue
 		}
-		conform(e.Target, s, f.Type, childPath, checker, result)
+		outEdges = append(outEdges, Edge{Label: e.Label, Target: onMatched(e, f, childPath)})
 	}
 
 	// Cardinality (spec §3.6 point 1). The error's path is the record's
 	// own path, not any edge's, even when the count is nonzero-but-wrong
 	// (§3.6.1's second "easy to miss" detail) — never childPath.
 	if rec == nil {
-		return
+		return outEdges
 	}
 	for _, f := range rec.Fields {
 		c := counts[f.Label]
@@ -164,6 +203,7 @@ func conformRecord(target Target, s Schema, rec *Record, path Path, checker *Lim
 			addDiagnostic(result, path, CodeValidateCardinality, cardinalityMessage(f, c))
 		}
 	}
+	return outEdges
 }
 
 // findField looks up rec.field(label) from the pseudocode. rec may be nil


### PR DESCRIPTION
Closes #35.

Implements materialize(document, schema) per spec Sec7.2/7.2.1 -- the last core Document/Schema operation, deferred until all four codecs existed since it's what actually turns their untyped stage-1 output into typed Documents.

The spec states a hard invariant: validate and materialize must stay in lockstep -- whatever materialize accepts at a leaf, validate must also accept, and vice versa. This is enforced structurally, not by writing two similar functions and hoping they agree: extracted a shared `walkRecordShape` out of validate.go's conformRecord (node-ness check, depth-limit wiring, unexpected-field detection, cardinality check all live in exactly one place now), with conformRecord and materializeRecord both thin wrappers calling it with different onMatched callbacks. Independently confirmed genuine, not superficial -- the reviewer read both call sites side by side and found no divergence in shape-checking logic anywhere.

Temporal upgrades reuse the OML lexer's exact date/time/datetime regexes (not TOML's/YAML's looser variants, which document themselves as wider than OML's spelling), wrapped in a full-string-match check since the lexer's own use only pins the match start. Independently stress-tested with adversarial inputs (a valid date prefix followed by trailing garbage, a bare Z-suffixed datetime against the offset-only regex) -- all correctly rejected as inexact, not partially matched.

Since this PR modifies already-twice-reviewed validate.go (issues #7, #33), the review explicitly prioritized confirming validate's pre-existing behavior wasn't broken by the refactor, not just that materialize's new behavior is correct -- full existing validate suite re-run clean, plus the reviewer's own independently-constructed scenarios re-derived from Sec3.6.1's pseudocode directly rather than just trusting prior test coverage.

**Conformance harness: materialize category 11 skips -> 11 passes, zero new failures elsewhere.** Total 140 pass / 6 fail / 3 skip (the 6 unchanged, all pre-existing and unrelated to this change, independently reproduced). Every try_upgrade table row independently re-verified against spec text, including the easy-to-miss "1 -> number yields a float-typed result, not integer-typed" rule and the any-boundary pass-through with a value that would fail every declared kind.

100% per-function coverage on both materialize.go and the modified validate.go. 0 lint issues. No load-bearing spec ambiguity.