### PR TITLE
CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,30 +41,28 @@ jobs:
           # of its branches are per-operation drivers that only make sense
           # exercised against real vectors, not synthesized in isolation.
           #
-          # cmd/omnist/** is also excluded (issue #37, same reasoning
-          # cited by that issue for possibly needing this treatment):
-          # main() itself calls os.Exit and can't be driven from a normal
-          # Go test without terminating the test binary, so it's verified
-          # instead by real subprocess invocations of the built binary
-          # (cmd/omnist/subprocess_test.go) rather than unit coverage.
-          # Every actual command-logic function in cmd/omnist reached
-          # 97-100% line coverage from run_test.go's in-process tests
-          # before this exclusion was added (99.2% package-wide with only
-          # main() and one now-dead error branch in cmdMaterialize
-          # uncovered -- Materialize's err return is documented in
-          # materialize.go as "always nil today", kept only for future
-          # signature stability, so there is currently no way to make
-          # that branch return a non-nil error to exercise it). A
-          # regression that drops real command-logic coverage in this
-          # package won't be caught by this gate; watch it the same way
-          # tools/conformance/** is watched, by review rather than CI.
-          uncovered=$(go tool cover -func=coverage.out | grep -v '^total:' | grep -v '100.0%$' | grep -v '^github.com/omnist-dev/omnist-go/tools/conformance/' | grep -v '^github.com/omnist-dev/omnist-go/cmd/omnist/' || true)
+          # Two specific functions in cmd/omnist are excluded (issue #37),
+          # scoped tightly rather than excluding the whole package -- every
+          # other function in cmd/omnist holds the normal 100% bar via
+          # run_test.go's in-process tests, so a regression anywhere else
+          # in that package still fails this gate:
+          #   - app.go's main(): calls os.Exit, can't be driven from a
+          #     normal `go test` without terminating the test binary.
+          #     Verified instead by real subprocess invocations of the
+          #     built binary (cmd/omnist/subprocess_test.go).
+          #   - cmd_materialize.go's cmdMaterialize (97.1%): one branch
+          #     handling a non-nil error from Materialize, which
+          #     materialize.go's own doc comment says is "always nil
+          #     today" (kept only for future signature stability) -- there
+          #     is currently no way to make that branch return a non-nil
+          #     error to exercise it.
+          uncovered=$(go tool cover -func=coverage.out | grep -v '^total:' | grep -v '100.0%$' | grep -v '^github.com/omnist-dev/omnist-go/tools/conformance/' | grep -v '^github.com/omnist-dev/omnist-go/cmd/omnist/app.go:.*[[:space:]]main[[:space:]]' | grep -v '^github.com/omnist-dev/omnist-go/cmd/omnist/cmd_materialize.go:.*[[:space:]]cmdMaterialize[[:space:]]' || true)
           if [ -n "$uncovered" ]; then
             echo "The following functions are not fully covered:"
             echo "$uncovered"
             exit 1
           fi
-          echo "100% line coverage confirmed (tools/conformance/** and cmd/omnist/** excluded, see comment)."
+          echo "100% line coverage confirmed (tools/conformance/** and two cmd/omnist functions excluded, see comment)."
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,13 +40,31 @@ jobs:
           # `conformance` job below), not exhaustive unit coverage -- most
           # of its branches are per-operation drivers that only make sense
           # exercised against real vectors, not synthesized in isolation.
-          uncovered=$(go tool cover -func=coverage.out | grep -v '^total:' | grep -v '100.0%$' | grep -v '^github.com/omnist-dev/omnist-go/tools/conformance/' || true)
+          #
+          # cmd/omnist/** is also excluded (issue #37, same reasoning
+          # cited by that issue for possibly needing this treatment):
+          # main() itself calls os.Exit and can't be driven from a normal
+          # Go test without terminating the test binary, so it's verified
+          # instead by real subprocess invocations of the built binary
+          # (cmd/omnist/subprocess_test.go) rather than unit coverage.
+          # Every actual command-logic function in cmd/omnist reached
+          # 97-100% line coverage from run_test.go's in-process tests
+          # before this exclusion was added (99.2% package-wide with only
+          # main() and one now-dead error branch in cmdMaterialize
+          # uncovered -- Materialize's err return is documented in
+          # materialize.go as "always nil today", kept only for future
+          # signature stability, so there is currently no way to make
+          # that branch return a non-nil error to exercise it). A
+          # regression that drops real command-logic coverage in this
+          # package won't be caught by this gate; watch it the same way
+          # tools/conformance/** is watched, by review rather than CI.
+          uncovered=$(go tool cover -func=coverage.out | grep -v '^total:' | grep -v '100.0%$' | grep -v '^github.com/omnist-dev/omnist-go/tools/conformance/' | grep -v '^github.com/omnist-dev/omnist-go/cmd/omnist/' || true)
           if [ -n "$uncovered" ]; then
             echo "The following functions are not fully covered:"
             echo "$uncovered"
             exit 1
           fi
-          echo "100% line coverage confirmed (tools/conformance/** excluded, see comment)."
+          echo "100% line coverage confirmed (tools/conformance/** and cmd/omnist/** excluded, see comment)."
 
   lint:
     runs-on: ubuntu-latest

--- a/cmd/omnist/app.go
+++ b/cmd/omnist/app.go
@@ -1,0 +1,102 @@
+// Package main implements omnist, a thin CLI wrapper over this repo's
+// exported library functions: the stage-1 readers/writers, OSD
+// read/write, Validate, Materialize, and the schema algebra (Normalize,
+// Prune, Extract, CompatibleWith, Equivalent, IsEmpty, Infer, Lint).
+//
+// There is no spec-mandated CLI contract (omnist-spec documents Python's
+// CLI shape as one worked example of a binding, not a mandate -- see
+// issue #37's discussion). This CLI's shape, flag names, and exit-code
+// convention are this port's own deliberate design, described in
+// exit.go and in each subcommand's --help text.
+//
+// CLI framework: this package uses only the stdlib flag package, one
+// flag.FlagSet per subcommand. A third-party framework (e.g. cobra) was
+// considered and rejected: this CLI has a shallow, one-level-deep
+// subcommand tree (schema is the only subcommand with sub-subcommands),
+// no need for shell-completion generation, and flag.FlagSet's
+// ContinueOnError mode plus a small hand-written dispatcher in run()
+// below covers per-subcommand flags cleanly without adding an external
+// dependency for a CLI this size.
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+func main() {
+	os.Exit(run(os.Args[1:], os.Stdin, os.Stdout, os.Stderr))
+}
+
+// run is the CLI's argument-parsing-and-dispatch entry point, kept
+// separate from main() so tests can invoke it directly (with fake
+// stdin/stdout/stderr) without spawning a subprocess for every case. A
+// smaller number of real subprocess tests (subprocess_test.go) cover the
+// actual compiled binary end to end.
+func run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
+	if len(args) == 0 {
+		printTopLevelUsage(stderr)
+		return ExitUsage
+	}
+
+	switch args[0] {
+	case "-h", "--help", "help":
+		printTopLevelUsage(stdout)
+		return ExitOK
+	case "parse":
+		return cmdParse(args[1:], stdin, stdout, stderr)
+	case "validate":
+		return cmdValidate(args[1:], stdin, stdout, stderr)
+	case "materialize":
+		return cmdMaterialize(args[1:], stdin, stdout, stderr)
+	case "schema":
+		return cmdSchema(args[1:], stdin, stdout, stderr)
+	case "infer":
+		return cmdInfer(args[1:], stdin, stdout, stderr)
+	case "lint":
+		return cmdLint(args[1:], stdin, stdout, stderr)
+	default:
+		_, _ = fmt.Fprintf(stderr, "omnist: unknown subcommand %q\n\n", args[0])
+		printTopLevelUsage(stderr)
+		return ExitUsage
+	}
+}
+
+func printTopLevelUsage(w io.Writer) {
+	_, _ = fmt.Fprint(w, `omnist -- read, write, validate, and materialize Omnist documents and
+schemas (JSON/YAML/TOML/XML/OML documents, OSD schemas).
+
+Usage:
+  omnist parse --from FORMAT [--to FORMAT] [-o FILE] INPUT
+  omnist validate --from FORMAT --schema SCHEMA INPUT
+  omnist materialize --from FORMAT --schema SCHEMA [--to FORMAT] [-o FILE] INPUT
+  omnist schema normalize [-o FILE] SCHEMA
+  omnist schema prune [-o FILE] SCHEMA
+  omnist schema extract --keep label1,label2,... [-o FILE] SCHEMA
+  omnist schema compatible-with A B
+  omnist schema equivalent A B
+  omnist schema is-empty SCHEMA
+  omnist infer --from FORMAT [--allow-any] [-o FILE] FILE [FILE...]
+  omnist lint SCHEMA
+
+NOTE: flags must come before the positional INPUT/SCHEMA/FILE argument(s)
+-- a stdlib flag.FlagSet limitation (it stops parsing flags at the first
+non-flag argument, unlike getopt-style permutation). This was accepted
+as a reasonable tradeoff for staying dependency-free; see the package
+doc comment above for the framework choice.
+
+INPUT, SCHEMA, and FILE accept "-" (or, for INPUT, an omitted argument in
+some commands) to mean stdin; -o omitted means stdout.
+
+Formats: json, yaml, toml, xml, oml.
+
+Exit codes: 0 success, 1 usage/tool error, 2 operation reported a
+problem (parse error, validation/materialize diagnostics, infer
+failure, lint findings). See exit.go's doc comment for the full
+convention. The three boolean schema commands (compatible-with,
+equivalent, is-empty) always exit 0 and print "true"/"false".
+
+Run "omnist SUBCOMMAND -h" for a subcommand's own flags.
+`)
+}

--- a/cmd/omnist/cmd_infer.go
+++ b/cmd/omnist/cmd_infer.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+
+	omnist "github.com/omnist-dev/omnist-go"
+)
+
+// cmdInfer implements `omnist infer`: read one or more sample documents
+// in --from format and draft an OSD schema from them via
+// InferWithReport. With --allow-any, fields that mix shapes or scalar
+// kinds are opened to `any` instead of failing; any such fallbacks are
+// reported to stderr as informational (exit 0 still, since --allow-any
+// is the caller opting into that lenience).
+func cmdInfer(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
+	const name = "omnist infer"
+	fs := flag.NewFlagSet(name, flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	from := fs.String("from", "", "input format: json, yaml, toml, xml, oml (required)")
+	allowAny := fs.Bool("allow-any", false, "open mixed-shape/mixed-scalar-kind fields to `any` instead of failing")
+	out := fs.String("o", "", "output file (default: stdout)")
+	fs.Usage = func() {
+		_, _ = fmt.Fprintf(stderr, "usage: %s --from FORMAT [--allow-any] [-o FILE] FILE [FILE...]\n", name)
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		return ExitUsage
+	}
+	if fs.NArg() == 0 {
+		_, _ = fmt.Fprintf(stderr, "%s: expected at least one FILE argument\n", name)
+		fs.Usage()
+		return ExitUsage
+	}
+	if *from == "" {
+		_, _ = fmt.Fprintf(stderr, "%s: --from is required\n", name)
+		return ExitUsage
+	}
+
+	reader, err := lookupReader(*from)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "%s: %v\n", name, err)
+		return ExitUsage
+	}
+
+	samples := make([]omnist.Document, 0, fs.NArg())
+	for _, path := range fs.Args() {
+		text, rerr := readInput(path, stdin)
+		if rerr != nil {
+			_, _ = fmt.Fprintf(stderr, "%s: %v\n", name, rerr)
+			return ExitUsage
+		}
+		doc, perr := reader(text, omnist.DefaultLimits())
+		if perr != nil {
+			_, _ = fmt.Fprintf(stderr, "%s: %s: %v\n", name, path, perr)
+			return ExitProblem
+		}
+		samples = append(samples, doc)
+	}
+
+	schema, fallbacks, err := omnist.InferWithReport(samples, "", *allowAny)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "%s: %v\n", name, err)
+		return ExitProblem
+	}
+	for _, fb := range fallbacks {
+		_, _ = fmt.Fprintf(stderr, "%s: opened to any: %s\n", fb.Location, fb.Reason)
+	}
+	if err := writeOutput(*out, omnist.WriteOSD(schema, false), stdout); err != nil {
+		_, _ = fmt.Fprintf(stderr, "%s: %v\n", name, err)
+		return ExitUsage
+	}
+	return ExitOK
+}

--- a/cmd/omnist/cmd_lint.go
+++ b/cmd/omnist/cmd_lint.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+
+	omnist "github.com/omnist-dev/omnist-go"
+)
+
+// cmdLint implements `omnist lint`: read one SCHEMA and print each
+// Lint(s) Finding as "location: severity: code: message". Findings are
+// never SeverityError (lint's own taxonomy only produces warning/info,
+// per lint.go's doc comment), so this command's problem/no-problem line
+// is drawn at warning: any warning-level finding makes this an
+// operation-reported-a-problem (ExitProblem); a schema with only
+// info-level findings (or none) exits 0, since info findings are
+// advisory rather than something-is-wrong.
+func cmdLint(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
+	const name = "omnist lint"
+	fs := flag.NewFlagSet(name, flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	fs.Usage = func() {
+		_, _ = fmt.Fprintf(stderr, "usage: %s SCHEMA\n", name)
+	}
+	if err := fs.Parse(args); err != nil {
+		return ExitUsage
+	}
+	if fs.NArg() != 1 {
+		_, _ = fmt.Fprintf(stderr, "%s: expected exactly one SCHEMA argument\n", name)
+		fs.Usage()
+		return ExitUsage
+	}
+
+	schema, code, ok := loadSchema(name, fs.Arg(0), stdin, stderr)
+	if !ok {
+		return code
+	}
+
+	findings := omnist.Lint(schema)
+	problem := false
+	for _, f := range findings {
+		_, _ = fmt.Fprintf(stdout, "%s: %s: %s: %s\n", f.Location, f.Severity, f.Code, f.Message)
+		if f.Severity <= omnist.SeverityWarning {
+			problem = true
+		}
+	}
+	if problem {
+		return ExitProblem
+	}
+	return ExitOK
+}

--- a/cmd/omnist/cmd_materialize.go
+++ b/cmd/omnist/cmd_materialize.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+
+	omnist "github.com/omnist-dev/omnist-go"
+)
+
+// cmdMaterialize implements `omnist materialize`: stage-1 read INPUT,
+// read the OSD --schema, run Materialize, print its diagnostics one per
+// line, and -- only if the caller asked for output via --to and/or -o --
+// also serialize the materialized document. Diagnostics are printed
+// regardless of whether output was requested, since Materialize is
+// best-effort: it returns a document even when diagnostics were raised.
+func cmdMaterialize(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("omnist materialize", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	from := fs.String("from", "", "input format: json, yaml, toml, xml, oml (required)")
+	schemaPath := fs.String("schema", "", "OSD schema file (required)")
+	to := fs.String("to", "", "output format for the materialized document (implies output; defaults to --from if -o is given)")
+	out := fs.String("o", "", "output file for the materialized document (default: stdout if --to is given)")
+	fs.Usage = func() {
+		_, _ = fmt.Fprintln(stderr, "usage: omnist materialize --from FORMAT --schema SCHEMA [--to FORMAT] [-o FILE] INPUT")
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		return ExitUsage
+	}
+	if fs.NArg() != 1 {
+		_, _ = fmt.Fprintln(stderr, "omnist materialize: expected exactly one INPUT argument")
+		fs.Usage()
+		return ExitUsage
+	}
+	input := fs.Arg(0)
+	if *from == "" {
+		_, _ = fmt.Fprintln(stderr, "omnist materialize: --from is required")
+		return ExitUsage
+	}
+	if *schemaPath == "" {
+		_, _ = fmt.Fprintln(stderr, "omnist materialize: --schema is required")
+		return ExitUsage
+	}
+
+	reader, err := lookupReader(*from)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "omnist materialize: %v\n", err)
+		return ExitUsage
+	}
+
+	wantsOutput := *to != "" || *out != ""
+	var writer formatWriterFunc
+	if wantsOutput {
+		toFormat := *to
+		if toFormat == "" {
+			toFormat = *from
+		}
+		writer, err = lookupWriter(toFormat)
+		if err != nil {
+			_, _ = fmt.Fprintf(stderr, "omnist materialize: %v\n", err)
+			return ExitUsage
+		}
+	}
+
+	text, err := readInput(input, stdin)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "omnist materialize: %v\n", err)
+		return ExitUsage
+	}
+	schemaText, err := readInput(*schemaPath, stdin)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "omnist materialize: %v\n", err)
+		return ExitUsage
+	}
+
+	doc, err := reader(text, omnist.DefaultLimits())
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "omnist materialize: %v\n", err)
+		return ExitProblem
+	}
+	schema, err := omnist.ReadOSD(schemaText)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "omnist materialize: %v\n", err)
+		return ExitProblem
+	}
+
+	result, diags, err := omnist.Materialize(doc, schema)
+	for _, d := range diags {
+		_, _ = fmt.Fprintf(stdout, "%s: %s: %s\n", d.Path, d.Code, d.Message)
+	}
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "omnist materialize: %v\n", err)
+		return ExitProblem
+	}
+
+	if wantsOutput {
+		outText, werr := writer(result)
+		if werr != nil {
+			_, _ = fmt.Fprintf(stderr, "omnist materialize: %v\n", werr)
+			return ExitProblem
+		}
+		if werr := writeOutput(*out, outText, stdout); werr != nil {
+			_, _ = fmt.Fprintf(stderr, "omnist materialize: %v\n", werr)
+			return ExitUsage
+		}
+	}
+
+	if len(diags) > 0 {
+		return ExitProblem
+	}
+	return ExitOK
+}

--- a/cmd/omnist/cmd_parse.go
+++ b/cmd/omnist/cmd_parse.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+
+	omnist "github.com/omnist-dev/omnist-go"
+)
+
+// cmdParse implements `omnist parse`: stage-1 read INPUT in --from
+// format, then re-serialize (optionally to a different --to format).
+// This is the CLI's format-conversion command: json/yaml/toml/xml/oml
+// interchange without needing a schema.
+func cmdParse(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("omnist parse", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	from := fs.String("from", "", "input format: json, yaml, toml, xml, oml (required)")
+	to := fs.String("to", "", "output format (defaults to --from)")
+	out := fs.String("o", "", "output file (default: stdout)")
+	fs.Usage = func() {
+		_, _ = fmt.Fprintln(stderr, "usage: omnist parse --from FORMAT [--to FORMAT] [-o FILE] INPUT")
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		return ExitUsage
+	}
+	if fs.NArg() != 1 {
+		_, _ = fmt.Fprintln(stderr, "omnist parse: expected exactly one INPUT argument")
+		fs.Usage()
+		return ExitUsage
+	}
+	input := fs.Arg(0)
+	if *from == "" {
+		_, _ = fmt.Fprintln(stderr, "omnist parse: --from is required")
+		return ExitUsage
+	}
+	toFormat := *to
+	if toFormat == "" {
+		toFormat = *from
+	}
+
+	reader, err := lookupReader(*from)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "omnist parse: %v\n", err)
+		return ExitUsage
+	}
+	writer, err := lookupWriter(toFormat)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "omnist parse: %v\n", err)
+		return ExitUsage
+	}
+	text, err := readInput(input, stdin)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "omnist parse: %v\n", err)
+		return ExitUsage
+	}
+
+	doc, err := reader(text, omnist.DefaultLimits())
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "omnist parse: %v\n", err)
+		return ExitProblem
+	}
+	outText, err := writer(doc)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "omnist parse: %v\n", err)
+		return ExitProblem
+	}
+	if err := writeOutput(*out, outText, stdout); err != nil {
+		_, _ = fmt.Fprintf(stderr, "omnist parse: %v\n", err)
+		return ExitUsage
+	}
+	return ExitOK
+}

--- a/cmd/omnist/cmd_schema.go
+++ b/cmd/omnist/cmd_schema.go
@@ -1,0 +1,216 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"strings"
+
+	omnist "github.com/omnist-dev/omnist-go"
+)
+
+// cmdSchema dispatches `omnist schema SUBCOMMAND ...` to one of the
+// seven schema-algebra sub-subcommands.
+func cmdSchema(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
+	if len(args) == 0 {
+		printSchemaUsage(stderr)
+		return ExitUsage
+	}
+	switch args[0] {
+	case "-h", "--help":
+		printSchemaUsage(stdout)
+		return ExitOK
+	case "normalize":
+		return schemaTransform(args[1:], stdin, stdout, stderr, "omnist schema normalize", omnist.Normalize)
+	case "prune":
+		return schemaTransform(args[1:], stdin, stdout, stderr, "omnist schema prune", omnist.Prune)
+	case "extract":
+		return cmdSchemaExtract(args[1:], stdin, stdout, stderr)
+	case "compatible-with":
+		return schemaBoolean(args[1:], stdin, stdout, stderr, "omnist schema compatible-with", omnist.CompatibleWith)
+	case "equivalent":
+		return schemaBoolean(args[1:], stdin, stdout, stderr, "omnist schema equivalent", omnist.Equivalent)
+	case "is-empty":
+		return cmdSchemaIsEmpty(args[1:], stdin, stdout, stderr)
+	default:
+		_, _ = fmt.Fprintf(stderr, "omnist schema: unknown subcommand %q\n\n", args[0])
+		printSchemaUsage(stderr)
+		return ExitUsage
+	}
+}
+
+func printSchemaUsage(w io.Writer) {
+	_, _ = fmt.Fprintln(w, `usage:
+  omnist schema normalize [-o FILE] SCHEMA
+  omnist schema prune [-o FILE] SCHEMA
+  omnist schema extract --keep label1,label2,... [-o FILE] SCHEMA
+  omnist schema compatible-with A B
+  omnist schema equivalent A B
+  omnist schema is-empty SCHEMA
+
+(flags must come before the positional SCHEMA argument)`)
+}
+
+// loadSchema reads and parses one OSD schema argument (a file path, or
+// "-"/"" for stdin), matching how parse/validate/materialize distinguish
+// their two failure modes: a file/stdin that couldn't be read is a usage
+// error (ExitUsage, the CLI never got to run OSD's parser), while text
+// that read fine but doesn't parse as OSD is an operation problem
+// (ExitProblem, the same bucket a malformed document parse error falls
+// into). On failure it has already written a "name: message" line to
+// stderr; the caller just returns the exit code.
+func loadSchema(name, path string, stdin io.Reader, stderr io.Writer) (omnist.Schema, int, bool) {
+	text, err := readInput(path, stdin)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "%s: %v\n", name, err)
+		return omnist.Schema{}, ExitUsage, false
+	}
+	schema, err := omnist.ReadOSD(text)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "%s: %v\n", name, err)
+		return omnist.Schema{}, ExitProblem, false
+	}
+	return schema, ExitOK, true
+}
+
+// schemaTransform implements the shared shape of `schema normalize` and
+// `schema prune`: read one SCHEMA, apply a pure Schema -> Schema
+// transform, write the result as OSD.
+func schemaTransform(args []string, stdin io.Reader, stdout, stderr io.Writer, name string, transform func(omnist.Schema) omnist.Schema) int {
+	fs := flag.NewFlagSet(name, flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	out := fs.String("o", "", "output file (default: stdout)")
+	fs.Usage = func() {
+		_, _ = fmt.Fprintf(stderr, "usage: %s [-o FILE] SCHEMA\n", name)
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		return ExitUsage
+	}
+	if fs.NArg() != 1 {
+		_, _ = fmt.Fprintf(stderr, "%s: expected exactly one SCHEMA argument\n", name)
+		fs.Usage()
+		return ExitUsage
+	}
+
+	schema, code, ok := loadSchema(name, fs.Arg(0), stdin, stderr)
+	if !ok {
+		return code
+	}
+	result := transform(schema)
+	if err := writeOutput(*out, omnist.WriteOSD(result, false), stdout); err != nil {
+		_, _ = fmt.Fprintf(stderr, "%s: %v\n", name, err)
+		return ExitUsage
+	}
+	return ExitOK
+}
+
+// cmdSchemaExtract implements `omnist schema extract`.
+func cmdSchemaExtract(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
+	const name = "omnist schema extract"
+	fs := flag.NewFlagSet(name, flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	keep := fs.String("keep", "", "comma-separated record names to keep (required)")
+	out := fs.String("o", "", "output file (default: stdout)")
+	fs.Usage = func() {
+		_, _ = fmt.Fprintf(stderr, "usage: %s --keep label1,label2,... [-o FILE] SCHEMA\n", name)
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		return ExitUsage
+	}
+	if fs.NArg() != 1 {
+		_, _ = fmt.Fprintf(stderr, "%s: expected exactly one SCHEMA argument\n", name)
+		fs.Usage()
+		return ExitUsage
+	}
+	if *keep == "" {
+		_, _ = fmt.Fprintf(stderr, "%s: --keep is required\n", name)
+		return ExitUsage
+	}
+	keepMap := make(map[string]bool)
+	for _, label := range strings.Split(*keep, ",") {
+		label = strings.TrimSpace(label)
+		if label == "" {
+			continue
+		}
+		keepMap[label] = true
+	}
+	if len(keepMap) == 0 {
+		_, _ = fmt.Fprintf(stderr, "%s: --keep must name at least one record\n", name)
+		return ExitUsage
+	}
+
+	schema, code, ok := loadSchema(name, fs.Arg(0), stdin, stderr)
+	if !ok {
+		return code
+	}
+	// Extract rejects a --keep set naming something the schema doesn't
+	// have (or an ill-formed request in general) -- that's the caller's
+	// flag input being wrong, so it's a usage error (ExitUsage), not an
+	// "operation ran and reported a problem" (ExitProblem).
+	result, err := omnist.Extract(schema, keepMap)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "%s: %v\n", name, err)
+		return ExitUsage
+	}
+	if err := writeOutput(*out, omnist.WriteOSD(result, false), stdout); err != nil {
+		_, _ = fmt.Fprintf(stderr, "%s: %v\n", name, err)
+		return ExitUsage
+	}
+	return ExitOK
+}
+
+// schemaBoolean implements the shared shape of `schema compatible-with`
+// and `schema equivalent`: read two SCHEMA arguments, run a
+// (Schema, Schema) -> bool comparison, print "true" or "false", always
+// exit 0 (see exit.go for why).
+func schemaBoolean(args []string, stdin io.Reader, stdout, stderr io.Writer, name string, compare func(a, b omnist.Schema) bool) int {
+	fs := flag.NewFlagSet(name, flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	fs.Usage = func() {
+		_, _ = fmt.Fprintf(stderr, "usage: %s A B\n", name)
+	}
+	if err := fs.Parse(args); err != nil {
+		return ExitUsage
+	}
+	if fs.NArg() != 2 {
+		_, _ = fmt.Fprintf(stderr, "%s: expected exactly two SCHEMA arguments\n", name)
+		fs.Usage()
+		return ExitUsage
+	}
+	a, code, ok := loadSchema(name, fs.Arg(0), stdin, stderr)
+	if !ok {
+		return code
+	}
+	b, code, ok := loadSchema(name, fs.Arg(1), stdin, stderr)
+	if !ok {
+		return code
+	}
+	_, _ = fmt.Fprintln(stdout, compare(a, b))
+	return ExitOK
+}
+
+// cmdSchemaIsEmpty implements `omnist schema is-empty`.
+func cmdSchemaIsEmpty(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
+	const name = "omnist schema is-empty"
+	fs := flag.NewFlagSet(name, flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	fs.Usage = func() {
+		_, _ = fmt.Fprintf(stderr, "usage: %s SCHEMA\n", name)
+	}
+	if err := fs.Parse(args); err != nil {
+		return ExitUsage
+	}
+	if fs.NArg() != 1 {
+		_, _ = fmt.Fprintf(stderr, "%s: expected exactly one SCHEMA argument\n", name)
+		fs.Usage()
+		return ExitUsage
+	}
+	schema, code, ok := loadSchema(name, fs.Arg(0), stdin, stderr)
+	if !ok {
+		return code
+	}
+	_, _ = fmt.Fprintln(stdout, omnist.IsEmpty(schema))
+	return ExitOK
+}

--- a/cmd/omnist/cmd_validate.go
+++ b/cmd/omnist/cmd_validate.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+
+	omnist "github.com/omnist-dev/omnist-go"
+)
+
+// cmdValidate implements `omnist validate`: stage-1 read INPUT, read the
+// OSD --schema, and run Validate, printing each Diagnostic one per line
+// as "path: code: message". Prints nothing when validation finds
+// nothing to report.
+func cmdValidate(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("omnist validate", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	from := fs.String("from", "", "input format: json, yaml, toml, xml, oml (required)")
+	schemaPath := fs.String("schema", "", "OSD schema file (required)")
+	fs.Usage = func() {
+		_, _ = fmt.Fprintln(stderr, "usage: omnist validate --from FORMAT --schema SCHEMA INPUT")
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		return ExitUsage
+	}
+	if fs.NArg() != 1 {
+		_, _ = fmt.Fprintln(stderr, "omnist validate: expected exactly one INPUT argument")
+		fs.Usage()
+		return ExitUsage
+	}
+	input := fs.Arg(0)
+	if *from == "" {
+		_, _ = fmt.Fprintln(stderr, "omnist validate: --from is required")
+		return ExitUsage
+	}
+	if *schemaPath == "" {
+		_, _ = fmt.Fprintln(stderr, "omnist validate: --schema is required")
+		return ExitUsage
+	}
+
+	reader, err := lookupReader(*from)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "omnist validate: %v\n", err)
+		return ExitUsage
+	}
+	text, err := readInput(input, stdin)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "omnist validate: %v\n", err)
+		return ExitUsage
+	}
+	schemaText, err := readInput(*schemaPath, stdin)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "omnist validate: %v\n", err)
+		return ExitUsage
+	}
+
+	doc, err := reader(text, omnist.DefaultLimits())
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "omnist validate: %v\n", err)
+		return ExitProblem
+	}
+	schema, err := omnist.ReadOSD(schemaText)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "omnist validate: %v\n", err)
+		return ExitProblem
+	}
+
+	diags := omnist.Validate(doc, schema)
+	for _, d := range diags {
+		_, _ = fmt.Fprintf(stdout, "%s: %s: %s\n", d.Path, d.Code, d.Message)
+	}
+	if len(diags) > 0 {
+		return ExitProblem
+	}
+	return ExitOK
+}

--- a/cmd/omnist/exit.go
+++ b/cmd/omnist/exit.go
@@ -1,0 +1,40 @@
+package main
+
+// Exit code convention for this CLI. There is no spec mandate for CLI
+// exit codes (omnist-spec documents Python's CLI shape as one worked
+// example, not a binding contract -- see issue #37), so this convention
+// is this port's own deliberate choice, not a copy of Python's.
+//
+//	0  success -- the requested operation ran and found nothing to
+//	   report.
+//	1  usage/tool error -- the CLI itself could not carry out the
+//	   request: bad or missing flags, an unrecognized subcommand, an
+//	   unrecognized --from/--to format name, an input/output file that
+//	   could not be opened, or a --keep set naming a label the schema
+//	   does not have. The underlying library operation never ran.
+//	2  operation problem -- the operation ran to completion but its
+//	   result reports something worth the caller's attention: a parse
+//	   error against malformed input, validate/materialize diagnostics,
+//	   an infer failure (e.g. conflicting scalar kinds across samples),
+//	   or lint findings at error/warning severity. This is distinct
+//	   from a Go panic or an unhandled error escaping to main: it is
+//	   the CLI faithfully reporting a real finding about the input
+//	   data, the same way a linter or type-checker's nonzero exit
+//	   means "ran fine, found problems" rather than "crashed."
+//
+// The three boolean-result schema commands (schema compatible-with,
+// schema equivalent, schema is-empty) are a deliberate exception: they
+// always exit 0 and print "true" or "false" to stdout. Python's CLI
+// instead folds the boolean into the exit code itself (0/1). This port
+// chooses not to: reserving exit codes for the usage-vs-problem
+// distinction above, and letting a boolean result live on stdout where a
+// caller greps for it, was judged less surprising than overloading exit
+// 1 with two unrelated meanings ("you invoked me wrong" and "the
+// schemas are not compatible"). A caller who wants the boolean as an
+// exit code can wrap the command: omnist schema is-empty S.osd | grep
+// -q true.
+const (
+	ExitOK      = 0
+	ExitUsage   = 1
+	ExitProblem = 2
+)

--- a/cmd/omnist/format.go
+++ b/cmd/omnist/format.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	omnist "github.com/omnist-dev/omnist-go"
+)
+
+// formatReaderFunc and formatWriterFunc give every stage-1 reader/writer
+// pair in the library a single shared shape, so the --from/--to dispatch
+// table below can be built once and shared by every subcommand that
+// needs format dispatch (parse, validate, materialize, infer), instead
+// of six separate copies of the same format-name switch statement.
+type formatReaderFunc func(text string, limits omnist.Limits) (omnist.Document, error)
+type formatWriterFunc func(d omnist.Document) (string, error)
+
+var formatReaders = map[string]formatReaderFunc{
+	"json": omnist.ReadJSON,
+	"yaml": omnist.ReadYAML,
+	"toml": omnist.ReadTOML,
+	"xml":  omnist.ReadXML,
+	"oml":  omnist.ReadOML,
+}
+
+var formatWriters = map[string]formatWriterFunc{
+	"json": omnist.WriteJSON,
+	"yaml": omnist.WriteYAML,
+	"toml": omnist.WriteTOML,
+	"xml":  omnist.WriteXML,
+	// WriteOML never returns an error (compact-vs-pretty is the only
+	// knob, and both always succeed), but it's wrapped here so every
+	// entry in this table shares one signature.
+	"oml": func(d omnist.Document) (string, error) { return omnist.WriteOML(d, false), nil },
+}
+
+// knownFormatNames returns the five supported format names, sorted, for
+// use in usage/error text.
+func knownFormatNames() []string {
+	names := make([]string, 0, len(formatReaders))
+	for name := range formatReaders {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func lookupReader(name string) (formatReaderFunc, error) {
+	r, ok := formatReaders[strings.ToLower(name)]
+	if !ok {
+		return nil, fmt.Errorf("unknown format %q (supported: %s)", name, strings.Join(knownFormatNames(), ", "))
+	}
+	return r, nil
+}
+
+func lookupWriter(name string) (formatWriterFunc, error) {
+	w, ok := formatWriters[strings.ToLower(name)]
+	if !ok {
+		return nil, fmt.Errorf("unknown format %q (supported: %s)", name, strings.Join(knownFormatNames(), ", "))
+	}
+	return w, nil
+}

--- a/cmd/omnist/format_test.go
+++ b/cmd/omnist/format_test.go
@@ -1,0 +1,39 @@
+package main
+
+import "testing"
+
+func TestLookupReaderKnown(t *testing.T) {
+	for _, name := range knownFormatNames() {
+		if _, err := lookupReader(name); err != nil {
+			t.Errorf("lookupReader(%q): %v", name, err)
+		}
+		if _, err := lookupWriter(name); err != nil {
+			t.Errorf("lookupWriter(%q): %v", name, err)
+		}
+	}
+}
+
+func TestLookupReaderCaseInsensitive(t *testing.T) {
+	if _, err := lookupReader("JSON"); err != nil {
+		t.Errorf("lookupReader(%q): %v", "JSON", err)
+	}
+}
+
+func TestLookupReaderUnknown(t *testing.T) {
+	if _, err := lookupReader("csv"); err == nil {
+		t.Error("lookupReader(csv): expected error, got nil")
+	}
+}
+
+func TestLookupWriterUnknown(t *testing.T) {
+	if _, err := lookupWriter("csv"); err == nil {
+		t.Error("lookupWriter(csv): expected error, got nil")
+	}
+}
+
+func TestKnownFormatNamesCount(t *testing.T) {
+	names := knownFormatNames()
+	if len(names) != 5 {
+		t.Errorf("knownFormatNames() = %v, want 5 entries", names)
+	}
+}

--- a/cmd/omnist/io.go
+++ b/cmd/omnist/io.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+// readInput reads a document/schema body from path, or from stdin when
+// path is "" or "-", matching common Unix CLI convention.
+func readInput(path string, stdin io.Reader) (string, error) {
+	if path == "" || path == "-" {
+		b, err := io.ReadAll(stdin)
+		if err != nil {
+			return "", fmt.Errorf("reading stdin: %w", err)
+		}
+		return string(b), nil
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("reading %s: %w", path, err)
+	}
+	return string(b), nil
+}
+
+// writeOutput writes content to path, or to stdout when path is "",
+// matching common Unix CLI convention (an omitted -o means stdout).
+func writeOutput(path string, content string, stdout io.Writer) error {
+	if path == "" {
+		_, err := io.WriteString(stdout, content)
+		return err
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		return fmt.Errorf("writing %s: %w", path, err)
+	}
+	return nil
+}

--- a/cmd/omnist/io_test.go
+++ b/cmd/omnist/io_test.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestReadInputStdin(t *testing.T) {
+	for _, path := range []string{"", "-"} {
+		got, err := readInput(path, strings.NewReader("hello"))
+		if err != nil {
+			t.Fatalf("readInput(%q): %v", path, err)
+		}
+		if got != "hello" {
+			t.Errorf("readInput(%q) = %q, want %q", path, got, "hello")
+		}
+	}
+}
+
+func TestReadInputFile(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "in.txt")
+	if err := os.WriteFile(p, []byte("file content"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := readInput(p, nil)
+	if err != nil {
+		t.Fatalf("readInput: %v", err)
+	}
+	if got != "file content" {
+		t.Errorf("readInput() = %q, want %q", got, "file content")
+	}
+}
+
+func TestReadInputMissingFile(t *testing.T) {
+	_, err := readInput(filepath.Join(t.TempDir(), "does-not-exist"), nil)
+	if err == nil {
+		t.Error("readInput: expected error for missing file, got nil")
+	}
+}
+
+func TestWriteOutputStdout(t *testing.T) {
+	var buf bytes.Buffer
+	if err := writeOutput("", "hi", &buf); err != nil {
+		t.Fatalf("writeOutput: %v", err)
+	}
+	if buf.String() != "hi" {
+		t.Errorf("stdout = %q, want %q", buf.String(), "hi")
+	}
+}
+
+func TestWriteOutputFile(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "out.txt")
+	if err := writeOutput(p, "content", nil); err != nil {
+		t.Fatalf("writeOutput: %v", err)
+	}
+	got, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "content" {
+		t.Errorf("file content = %q, want %q", got, "content")
+	}
+}
+
+func TestWriteOutputBadPath(t *testing.T) {
+	err := writeOutput(filepath.Join(t.TempDir(), "nosuchdir", "out.txt"), "x", nil)
+	if err == nil {
+		t.Error("writeOutput: expected error for unwritable path, got nil")
+	}
+}
+
+// failingReader always errors, letting TestReadInputStdinError exercise
+// readInput's io.ReadAll failure branch without needing a real broken
+// stdin.
+type failingReader struct{}
+
+func (failingReader) Read([]byte) (int, error) {
+	return 0, errors.New("simulated read failure")
+}
+
+func TestReadInputStdinError(t *testing.T) {
+	_, err := readInput("-", failingReader{})
+	if err == nil {
+		t.Error("readInput: expected error from a failing stdin reader, got nil")
+	}
+}

--- a/cmd/omnist/run_test.go
+++ b/cmd/omnist/run_test.go
@@ -1,0 +1,792 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// runCLI is a small helper that runs the CLI's internal run() dispatcher
+// (not a subprocess -- see subprocess_test.go for real binary
+// invocations) with the given args and stdin text, and returns the exit
+// code plus captured stdout/stderr.
+func runCLI(t *testing.T, args []string, stdin string) (code int, stdout, stderr string) {
+	t.Helper()
+	var outBuf, errBuf bytes.Buffer
+	code = run(args, strings.NewReader(stdin), &outBuf, &errBuf)
+	return code, outBuf.String(), errBuf.String()
+}
+
+const testSchema = `record Root {
+  "name": string,
+  "age": integer,
+  "nickname" [0,1]: string
+}
+root Root
+`
+
+func writeTemp(t *testing.T, name, content string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func TestRunNoArgs(t *testing.T) {
+	code, _, stderr := runCLI(t, nil, "")
+	if code != ExitUsage {
+		t.Errorf("exit = %d, want %d", code, ExitUsage)
+	}
+	if !strings.Contains(stderr, "Usage:") {
+		t.Errorf("stderr = %q, want usage text", stderr)
+	}
+}
+
+func TestRunHelp(t *testing.T) {
+	code, stdout, _ := runCLI(t, []string{"--help"}, "")
+	if code != ExitOK {
+		t.Errorf("exit = %d, want %d", code, ExitOK)
+	}
+	if !strings.Contains(stdout, "omnist parse") {
+		t.Errorf("stdout missing usage: %q", stdout)
+	}
+}
+
+func TestRunUnknownSubcommand(t *testing.T) {
+	code, _, stderr := runCLI(t, []string{"bogus"}, "")
+	if code != ExitUsage {
+		t.Errorf("exit = %d, want %d", code, ExitUsage)
+	}
+	if !strings.Contains(stderr, "unknown subcommand") {
+		t.Errorf("stderr = %q", stderr)
+	}
+}
+
+func TestCmdParseConvert(t *testing.T) {
+	code, stdout, stderr := runCLI(t, []string{"parse", "--from", "json", "--to", "yaml", "-"}, `{"a": 1}`)
+	if code != ExitOK {
+		t.Fatalf("exit = %d, stderr = %q", code, stderr)
+	}
+	if !strings.Contains(stdout, "\"a\": 1") {
+		t.Errorf("stdout = %q", stdout)
+	}
+}
+
+func TestCmdParseMalformed(t *testing.T) {
+	code, _, stderr := runCLI(t, []string{"parse", "--from", "json", "-"}, `{not json`)
+	if code != ExitProblem {
+		t.Errorf("exit = %d, want %d, stderr=%q", code, ExitProblem, stderr)
+	}
+}
+
+func TestCmdParseMissingFrom(t *testing.T) {
+	code, _, _ := runCLI(t, []string{"parse", "-"}, `{}`)
+	if code != ExitUsage {
+		t.Errorf("exit = %d, want %d", code, ExitUsage)
+	}
+}
+
+func TestCmdParseUnknownFormat(t *testing.T) {
+	code, _, stderr := runCLI(t, []string{"parse", "--from", "csv", "-"}, `{}`)
+	if code != ExitUsage {
+		t.Errorf("exit = %d, want %d", code, ExitUsage)
+	}
+	if !strings.Contains(stderr, "unknown format") {
+		t.Errorf("stderr = %q", stderr)
+	}
+}
+
+func TestCmdParseMissingFile(t *testing.T) {
+	code, _, _ := runCLI(t, []string{"parse", "--from", "json", filepath.Join(t.TempDir(), "nope.json")}, "")
+	if code != ExitUsage {
+		t.Errorf("exit = %d, want %d", code, ExitUsage)
+	}
+}
+
+func TestCmdParseWrongArgCount(t *testing.T) {
+	code, _, _ := runCLI(t, []string{"parse", "--from", "json"}, "")
+	if code != ExitUsage {
+		t.Errorf("exit = %d, want %d", code, ExitUsage)
+	}
+}
+
+func TestCmdParseWriteToFile(t *testing.T) {
+	dir := t.TempDir()
+	out := filepath.Join(dir, "out.yaml")
+	code, _, stderr := runCLI(t, []string{"parse", "--from", "json", "-o", out, "-"}, `{"a": 1}`)
+	if code != ExitOK {
+		t.Fatalf("exit = %d, stderr = %q", code, stderr)
+	}
+	got, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(got), "\"a\": 1") {
+		t.Errorf("file content = %q", got)
+	}
+}
+
+func TestCmdValidateSuccess(t *testing.T) {
+	schemaPath := writeTemp(t, "s.osd", testSchema)
+	code, stdout, _ := runCLI(t, []string{"validate", "--from", "json", "--schema", schemaPath, "-"}, `{"name": "Ada", "age": 12}`)
+	if code != ExitOK {
+		t.Errorf("exit = %d, want %d", code, ExitOK)
+	}
+	if stdout != "" {
+		t.Errorf("stdout = %q, want empty on success", stdout)
+	}
+}
+
+func TestCmdValidateFailure(t *testing.T) {
+	schemaPath := writeTemp(t, "s.osd", testSchema)
+	code, stdout, _ := runCLI(t, []string{"validate", "--from", "json", "--schema", schemaPath, "-"}, `{"name": "Ada"}`)
+	if code != ExitProblem {
+		t.Errorf("exit = %d, want %d", code, ExitProblem)
+	}
+	if !strings.Contains(stdout, "validate.cardinality") {
+		t.Errorf("stdout = %q, want a validate.cardinality diagnostic", stdout)
+	}
+}
+
+func TestCmdValidateMissingFlags(t *testing.T) {
+	code, _, _ := runCLI(t, []string{"validate", "-"}, `{}`)
+	if code != ExitUsage {
+		t.Errorf("exit = %d, want %d", code, ExitUsage)
+	}
+	code, _, _ = runCLI(t, []string{"validate", "--from", "json", "-"}, `{}`)
+	if code != ExitUsage {
+		t.Errorf("exit = %d, want %d (missing --schema)", code, ExitUsage)
+	}
+}
+
+func TestCmdValidateBadSchema(t *testing.T) {
+	schemaPath := writeTemp(t, "s.osd", "not a valid schema {{{")
+	code, _, stderr := runCLI(t, []string{"validate", "--from", "json", "--schema", schemaPath, "-"}, `{}`)
+	if code != ExitProblem {
+		t.Errorf("exit = %d, want %d, stderr=%q", code, ExitProblem, stderr)
+	}
+}
+
+func TestCmdValidateMissingSchemaFile(t *testing.T) {
+	code, _, _ := runCLI(t, []string{"validate", "--from", "json", "--schema", filepath.Join(t.TempDir(), "nope.osd"), "-"}, `{}`)
+	if code != ExitUsage {
+		t.Errorf("exit = %d, want %d", code, ExitUsage)
+	}
+}
+
+func TestCmdMaterializeSuccessNoOutput(t *testing.T) {
+	schemaPath := writeTemp(t, "s.osd", testSchema)
+	code, stdout, _ := runCLI(t, []string{"materialize", "--from", "json", "--schema", schemaPath, "-"}, `{"name": "Ada", "age": 12}`)
+	if code != ExitOK {
+		t.Errorf("exit = %d, want %d", code, ExitOK)
+	}
+	if stdout != "" {
+		t.Errorf("stdout = %q, want empty (no --to/-o requested)", stdout)
+	}
+}
+
+func TestCmdMaterializeWithOutput(t *testing.T) {
+	schemaPath := writeTemp(t, "s.osd", testSchema)
+	code, stdout, stderr := runCLI(t, []string{"materialize", "--from", "json", "--schema", schemaPath, "--to", "json", "-"}, `{"name": "Ada", "age": 12}`)
+	if code != ExitOK {
+		t.Fatalf("exit = %d, stderr = %q", code, stderr)
+	}
+	if !strings.Contains(stdout, "Ada") {
+		t.Errorf("stdout = %q", stdout)
+	}
+}
+
+func TestCmdMaterializeDiagnostics(t *testing.T) {
+	schemaPath := writeTemp(t, "s.osd", testSchema)
+	code, stdout, _ := runCLI(t, []string{"materialize", "--from", "json", "--schema", schemaPath, "-"}, `{"name": "Ada"}`)
+	if code != ExitProblem {
+		t.Errorf("exit = %d, want %d", code, ExitProblem)
+	}
+	if !strings.Contains(stdout, "validate.cardinality") {
+		t.Errorf("stdout = %q", stdout)
+	}
+}
+
+func TestCmdMaterializeMissingFlags(t *testing.T) {
+	code, _, _ := runCLI(t, []string{"materialize", "-"}, `{}`)
+	if code != ExitUsage {
+		t.Errorf("exit = %d, want %d", code, ExitUsage)
+	}
+	schemaPath := writeTemp(t, "s.osd", testSchema)
+	code, _, _ = runCLI(t, []string{"materialize", "--schema", schemaPath, "-"}, `{}`)
+	if code != ExitUsage {
+		t.Errorf("exit = %d, want %d (missing --from)", code, ExitUsage)
+	}
+}
+
+func TestCmdMaterializeWrongArgCount(t *testing.T) {
+	schemaPath := writeTemp(t, "s.osd", testSchema)
+	code, _, _ := runCLI(t, []string{"materialize", "--from", "json", "--schema", schemaPath}, "")
+	if code != ExitUsage {
+		t.Errorf("exit = %d, want %d", code, ExitUsage)
+	}
+}
+
+func TestCmdMaterializeBadToFormat(t *testing.T) {
+	schemaPath := writeTemp(t, "s.osd", testSchema)
+	code, _, _ := runCLI(t, []string{"materialize", "--from", "json", "--schema", schemaPath, "--to", "csv", "-"}, `{"name":"Ada","age":1}`)
+	if code != ExitUsage {
+		t.Errorf("exit = %d, want %d", code, ExitUsage)
+	}
+}
+
+func TestCmdSchemaNormalize(t *testing.T) {
+	schemaPath := writeTemp(t, "s.osd", testSchema)
+	code, stdout, stderr := runCLI(t, []string{"schema", "normalize", schemaPath}, "")
+	if code != ExitOK {
+		t.Fatalf("exit = %d, stderr = %q", code, stderr)
+	}
+	if !strings.Contains(stdout, "record Root") {
+		t.Errorf("stdout = %q", stdout)
+	}
+}
+
+func TestCmdSchemaPrune(t *testing.T) {
+	schemaPath := writeTemp(t, "s.osd", testSchema)
+	code, stdout, stderr := runCLI(t, []string{"schema", "prune", schemaPath}, "")
+	if code != ExitOK {
+		t.Fatalf("exit = %d, stderr = %q", code, stderr)
+	}
+	if !strings.Contains(stdout, "record Root") {
+		t.Errorf("stdout = %q", stdout)
+	}
+}
+
+func TestCmdSchemaExtract(t *testing.T) {
+	schemaPath := writeTemp(t, "s.osd", testSchema)
+	code, stdout, stderr := runCLI(t, []string{"schema", "extract", "--keep", "name,age", schemaPath}, "")
+	if code != ExitOK {
+		t.Fatalf("exit = %d, stderr = %q", code, stderr)
+	}
+	if !strings.Contains(stdout, "record Root") || strings.Contains(stdout, "nickname") {
+		t.Errorf("stdout = %q, want Root without the dropped nickname field", stdout)
+	}
+}
+
+func TestCmdSchemaExtractMissingKeep(t *testing.T) {
+	schemaPath := writeTemp(t, "s.osd", testSchema)
+	code, _, _ := runCLI(t, []string{"schema", "extract", schemaPath}, "")
+	if code != ExitUsage {
+		t.Errorf("exit = %d, want %d", code, ExitUsage)
+	}
+}
+
+func TestCmdSchemaExtractUnknownLabel(t *testing.T) {
+	schemaPath := writeTemp(t, "s.osd", testSchema)
+	code, _, stderr := runCLI(t, []string{"schema", "extract", "--keep", "DoesNotExist", schemaPath}, "")
+	if code != ExitUsage {
+		t.Errorf("exit = %d, want %d, stderr=%q", code, ExitUsage, stderr)
+	}
+}
+
+func TestCmdSchemaCompatibleWith(t *testing.T) {
+	schemaPath := writeTemp(t, "s.osd", testSchema)
+	code, stdout, stderr := runCLI(t, []string{"schema", "compatible-with", schemaPath, schemaPath}, "")
+	if code != ExitOK {
+		t.Fatalf("exit = %d, stderr = %q", code, stderr)
+	}
+	if strings.TrimSpace(stdout) != "true" {
+		t.Errorf("stdout = %q, want true", stdout)
+	}
+}
+
+func TestCmdSchemaEquivalent(t *testing.T) {
+	schemaPath := writeTemp(t, "s.osd", testSchema)
+	code, stdout, stderr := runCLI(t, []string{"schema", "equivalent", schemaPath, schemaPath}, "")
+	if code != ExitOK {
+		t.Fatalf("exit = %d, stderr = %q", code, stderr)
+	}
+	if strings.TrimSpace(stdout) != "true" {
+		t.Errorf("stdout = %q, want true", stdout)
+	}
+}
+
+func TestCmdSchemaCompareWrongArgCount(t *testing.T) {
+	schemaPath := writeTemp(t, "s.osd", testSchema)
+	code, _, _ := runCLI(t, []string{"schema", "compatible-with", schemaPath}, "")
+	if code != ExitUsage {
+		t.Errorf("exit = %d, want %d", code, ExitUsage)
+	}
+}
+
+func TestCmdSchemaIsEmpty(t *testing.T) {
+	schemaPath := writeTemp(t, "s.osd", testSchema)
+	code, stdout, stderr := runCLI(t, []string{"schema", "is-empty", schemaPath}, "")
+	if code != ExitOK {
+		t.Fatalf("exit = %d, stderr = %q", code, stderr)
+	}
+	if strings.TrimSpace(stdout) != "false" {
+		t.Errorf("stdout = %q, want false", stdout)
+	}
+}
+
+func TestCmdSchemaIsEmptyWrongArgCount(t *testing.T) {
+	code, _, _ := runCLI(t, []string{"schema", "is-empty"}, "")
+	if code != ExitUsage {
+		t.Errorf("exit = %d, want %d", code, ExitUsage)
+	}
+}
+
+func TestCmdSchemaNoArgs(t *testing.T) {
+	code, _, _ := runCLI(t, []string{"schema"}, "")
+	if code != ExitUsage {
+		t.Errorf("exit = %d, want %d", code, ExitUsage)
+	}
+}
+
+func TestCmdSchemaHelp(t *testing.T) {
+	code, stdout, _ := runCLI(t, []string{"schema", "--help"}, "")
+	if code != ExitOK {
+		t.Errorf("exit = %d, want %d", code, ExitOK)
+	}
+	if !strings.Contains(stdout, "schema normalize") {
+		t.Errorf("stdout = %q", stdout)
+	}
+}
+
+func TestCmdSchemaUnknownSubcommand(t *testing.T) {
+	code, _, stderr := runCLI(t, []string{"schema", "bogus"}, "")
+	if code != ExitUsage {
+		t.Errorf("exit = %d, want %d", code, ExitUsage)
+	}
+	if !strings.Contains(stderr, "unknown subcommand") {
+		t.Errorf("stderr = %q", stderr)
+	}
+}
+
+func TestCmdSchemaBadSchemaFile(t *testing.T) {
+	schemaPath := writeTemp(t, "bad.osd", "{{{ garbage")
+	code, _, _ := runCLI(t, []string{"schema", "normalize", schemaPath}, "")
+	if code != ExitProblem {
+		t.Errorf("exit = %d, want %d", code, ExitProblem)
+	}
+}
+
+func TestCmdSchemaWrongArgCountNormalize(t *testing.T) {
+	code, _, _ := runCLI(t, []string{"schema", "normalize"}, "")
+	if code != ExitUsage {
+		t.Errorf("exit = %d, want %d", code, ExitUsage)
+	}
+}
+
+func TestCmdInfer(t *testing.T) {
+	f1 := writeTemp(t, "a.json", `{"name": "Ada", "age": 12}`)
+	code, stdout, stderr := runCLI(t, []string{"infer", "--from", "json", f1}, "")
+	if code != ExitOK {
+		t.Fatalf("exit = %d, stderr = %q", code, stderr)
+	}
+	if !strings.Contains(stdout, "record Root") {
+		t.Errorf("stdout = %q", stdout)
+	}
+}
+
+func TestCmdInferAllowAnyFallback(t *testing.T) {
+	f1 := writeTemp(t, "a.json", `{"v": 1}`)
+	f2 := writeTemp(t, "b.json", `{"v": "s"}`)
+	code, stdout, stderr := runCLI(t, []string{"infer", "--from", "json", "--allow-any", f1, f2}, "")
+	if code != ExitOK {
+		t.Fatalf("exit = %d, stderr = %q", code, stderr)
+	}
+	if !strings.Contains(stderr, "opened to any") {
+		t.Errorf("stderr = %q, want an any-fallback note", stderr)
+	}
+	if !strings.Contains(stdout, "any") {
+		t.Errorf("stdout = %q, want any-typed field", stdout)
+	}
+}
+
+func TestCmdInferConflict(t *testing.T) {
+	f1 := writeTemp(t, "a.json", `{"v": 1}`)
+	f2 := writeTemp(t, "b.json", `{"v": "s"}`)
+	code, _, stderr := runCLI(t, []string{"infer", "--from", "json", f1, f2}, "")
+	if code != ExitProblem {
+		t.Errorf("exit = %d, want %d, stderr=%q", code, ExitProblem, stderr)
+	}
+}
+
+func TestCmdInferNoFiles(t *testing.T) {
+	code, _, _ := runCLI(t, []string{"infer", "--from", "json"}, "")
+	if code != ExitUsage {
+		t.Errorf("exit = %d, want %d", code, ExitUsage)
+	}
+}
+
+func TestCmdInferMissingFrom(t *testing.T) {
+	f1 := writeTemp(t, "a.json", `{"v": 1}`)
+	code, _, _ := runCLI(t, []string{"infer", f1}, "")
+	if code != ExitUsage {
+		t.Errorf("exit = %d, want %d", code, ExitUsage)
+	}
+}
+
+func TestCmdInferBadFile(t *testing.T) {
+	code, _, _ := runCLI(t, []string{"infer", "--from", "json", filepath.Join(t.TempDir(), "nope.json")}, "")
+	if code != ExitUsage {
+		t.Errorf("exit = %d, want %d", code, ExitUsage)
+	}
+}
+
+func TestCmdInferMalformedFile(t *testing.T) {
+	f1 := writeTemp(t, "bad.json", `{not json`)
+	code, _, _ := runCLI(t, []string{"infer", "--from", "json", f1}, "")
+	if code != ExitProblem {
+		t.Errorf("exit = %d, want %d", code, ExitProblem)
+	}
+}
+
+func TestCmdLintClean(t *testing.T) {
+	schemaPath := writeTemp(t, "s.osd", testSchema)
+	code, stdout, stderr := runCLI(t, []string{"lint", schemaPath}, "")
+	if code != ExitOK {
+		t.Fatalf("exit = %d, stderr = %q", code, stderr)
+	}
+	if stdout != "" {
+		t.Errorf("stdout = %q, want empty", stdout)
+	}
+}
+
+func TestCmdLintFinding(t *testing.T) {
+	// A record unreachable from root should trigger a lint finding.
+	schema := `record Root {
+  "name": string
+}
+record Unused {
+  "x": string
+}
+root Root
+`
+	schemaPath := writeTemp(t, "s.osd", schema)
+	code, stdout, _ := runCLI(t, []string{"lint", schemaPath}, "")
+	if code != ExitProblem {
+		t.Errorf("exit = %d, want %d, stdout=%q", code, ExitProblem, stdout)
+	}
+	if stdout == "" {
+		t.Error("stdout empty, want at least one finding line")
+	}
+}
+
+func TestCmdLintWrongArgCount(t *testing.T) {
+	code, _, _ := runCLI(t, []string{"lint"}, "")
+	if code != ExitUsage {
+		t.Errorf("exit = %d, want %d", code, ExitUsage)
+	}
+}
+
+func TestCmdLintMissingFile(t *testing.T) {
+	code, _, _ := runCLI(t, []string{"lint", filepath.Join(t.TempDir(), "nope.osd")}, "")
+	if code != ExitUsage {
+		t.Errorf("exit = %d, want %d", code, ExitUsage)
+	}
+}
+
+func TestFlagParseErrorIsUsage(t *testing.T) {
+	code, _, _ := runCLI(t, []string{"parse", "--not-a-flag"}, "")
+	if code != ExitUsage {
+		t.Errorf("exit = %d, want %d", code, ExitUsage)
+	}
+}
+
+func badOutputPath(t *testing.T) string {
+	t.Helper()
+	return filepath.Join(t.TempDir(), "no-such-dir", "out.txt")
+}
+
+func TestCmdParseWriteError(t *testing.T) {
+	code, _, stderr := runCLI(t, []string{"parse", "--from", "json", "-o", badOutputPath(t), "-"}, `{"a": 1}`)
+	if code != ExitUsage {
+		t.Errorf("exit = %d, want %d, stderr=%q", code, ExitUsage, stderr)
+	}
+}
+
+func TestCmdValidateMissingInputFile(t *testing.T) {
+	schemaPath := writeTemp(t, "s.osd", testSchema)
+	code, _, _ := runCLI(t, []string{"validate", "--from", "json", "--schema", schemaPath, filepath.Join(t.TempDir(), "nope.json")}, "")
+	if code != ExitUsage {
+		t.Errorf("exit = %d, want %d", code, ExitUsage)
+	}
+}
+
+func TestCmdValidateBadFromFormat(t *testing.T) {
+	schemaPath := writeTemp(t, "s.osd", testSchema)
+	code, _, _ := runCLI(t, []string{"validate", "--from", "csv", "--schema", schemaPath, "-"}, `{}`)
+	if code != ExitUsage {
+		t.Errorf("exit = %d, want %d", code, ExitUsage)
+	}
+}
+
+func TestCmdValidateWrongArgCount(t *testing.T) {
+	schemaPath := writeTemp(t, "s.osd", testSchema)
+	code, _, _ := runCLI(t, []string{"validate", "--from", "json", "--schema", schemaPath}, "")
+	if code != ExitUsage {
+		t.Errorf("exit = %d, want %d", code, ExitUsage)
+	}
+}
+
+func TestCmdMaterializeMissingInputFile(t *testing.T) {
+	schemaPath := writeTemp(t, "s.osd", testSchema)
+	code, _, _ := runCLI(t, []string{"materialize", "--from", "json", "--schema", schemaPath, filepath.Join(t.TempDir(), "nope.json")}, "")
+	if code != ExitUsage {
+		t.Errorf("exit = %d, want %d", code, ExitUsage)
+	}
+}
+
+func TestCmdMaterializeMissingSchemaFile(t *testing.T) {
+	code, _, _ := runCLI(t, []string{"materialize", "--from", "json", "--schema", filepath.Join(t.TempDir(), "nope.osd"), "-"}, `{}`)
+	if code != ExitUsage {
+		t.Errorf("exit = %d, want %d", code, ExitUsage)
+	}
+}
+
+func TestCmdMaterializeBadSchema(t *testing.T) {
+	schemaPath := writeTemp(t, "bad.osd", "{{{ garbage")
+	code, _, _ := runCLI(t, []string{"materialize", "--from", "json", "--schema", schemaPath, "-"}, `{}`)
+	if code != ExitProblem {
+		t.Errorf("exit = %d, want %d", code, ExitProblem)
+	}
+}
+
+func TestCmdMaterializeWriteError(t *testing.T) {
+	schemaPath := writeTemp(t, "s.osd", testSchema)
+	code, _, _ := runCLI(t, []string{"materialize", "--from", "json", "--schema", schemaPath, "--to", "json", "-o", badOutputPath(t), "-"}, `{"name":"Ada","age":1}`)
+	if code != ExitUsage {
+		t.Errorf("exit = %d, want %d", code, ExitUsage)
+	}
+}
+
+func TestCmdSchemaTransformWriteError(t *testing.T) {
+	schemaPath := writeTemp(t, "s.osd", testSchema)
+	code, _, _ := runCLI(t, []string{"schema", "normalize", "-o", badOutputPath(t), schemaPath}, "")
+	if code != ExitUsage {
+		t.Errorf("exit = %d, want %d", code, ExitUsage)
+	}
+}
+
+func TestCmdSchemaExtractWriteError(t *testing.T) {
+	schemaPath := writeTemp(t, "s.osd", testSchema)
+	code, _, _ := runCLI(t, []string{"schema", "extract", "--keep", "name,age", "-o", badOutputPath(t), schemaPath}, "")
+	if code != ExitUsage {
+		t.Errorf("exit = %d, want %d", code, ExitUsage)
+	}
+}
+
+func TestCmdSchemaExtractKeepAllWhitespace(t *testing.T) {
+	schemaPath := writeTemp(t, "s.osd", testSchema)
+	code, _, stderr := runCLI(t, []string{"schema", "extract", "--keep", " , ,", schemaPath}, "")
+	if code != ExitUsage {
+		t.Errorf("exit = %d, want %d, stderr=%q", code, ExitUsage, stderr)
+	}
+}
+
+func TestCmdSchemaExtractBadSchema(t *testing.T) {
+	schemaPath := writeTemp(t, "bad.osd", "{{{ garbage")
+	code, _, _ := runCLI(t, []string{"schema", "extract", "--keep", "name", schemaPath}, "")
+	if code != ExitProblem {
+		t.Errorf("exit = %d, want %d", code, ExitProblem)
+	}
+}
+
+func TestCmdSchemaCompareSecondArgBad(t *testing.T) {
+	good := writeTemp(t, "good.osd", testSchema)
+	bad := writeTemp(t, "bad.osd", "{{{ garbage")
+	code, _, _ := runCLI(t, []string{"schema", "compatible-with", good, bad}, "")
+	if code != ExitProblem {
+		t.Errorf("exit = %d, want %d", code, ExitProblem)
+	}
+}
+
+func TestCmdSchemaCompareFirstArgBad(t *testing.T) {
+	bad := writeTemp(t, "bad.osd", "{{{ garbage")
+	good := writeTemp(t, "good.osd", testSchema)
+	code, _, _ := runCLI(t, []string{"schema", "compatible-with", bad, good}, "")
+	if code != ExitProblem {
+		t.Errorf("exit = %d, want %d", code, ExitProblem)
+	}
+}
+
+func TestCmdInferWriteError(t *testing.T) {
+	f1 := writeTemp(t, "a.json", `{"name": "Ada"}`)
+	code, _, _ := runCLI(t, []string{"infer", "--from", "json", "-o", badOutputPath(t), f1}, "")
+	if code != ExitUsage {
+		t.Errorf("exit = %d, want %d", code, ExitUsage)
+	}
+}
+
+func TestCmdInferBadFromFormat(t *testing.T) {
+	f1 := writeTemp(t, "a.json", `{"name": "Ada"}`)
+	code, _, _ := runCLI(t, []string{"infer", "--from", "csv", f1}, "")
+	if code != ExitUsage {
+		t.Errorf("exit = %d, want %d", code, ExitUsage)
+	}
+}
+
+func TestCmdLintFlagParseError(t *testing.T) {
+	code, _, _ := runCLI(t, []string{"lint", "--not-a-flag"}, "")
+	if code != ExitUsage {
+		t.Errorf("exit = %d, want %d", code, ExitUsage)
+	}
+}
+
+func TestCmdSchemaTransformFlagParseError(t *testing.T) {
+	code, _, _ := runCLI(t, []string{"schema", "normalize", "--not-a-flag"}, "")
+	if code != ExitUsage {
+		t.Errorf("exit = %d, want %d", code, ExitUsage)
+	}
+}
+
+func TestCmdSchemaExtractFlagParseError(t *testing.T) {
+	code, _, _ := runCLI(t, []string{"schema", "extract", "--not-a-flag"}, "")
+	if code != ExitUsage {
+		t.Errorf("exit = %d, want %d", code, ExitUsage)
+	}
+}
+
+func TestCmdSchemaCompareFlagParseError(t *testing.T) {
+	code, _, _ := runCLI(t, []string{"schema", "compatible-with", "--not-a-flag"}, "")
+	if code != ExitUsage {
+		t.Errorf("exit = %d, want %d", code, ExitUsage)
+	}
+}
+
+func TestCmdSchemaIsEmptyFlagParseError(t *testing.T) {
+	code, _, _ := runCLI(t, []string{"schema", "is-empty", "--not-a-flag"}, "")
+	if code != ExitUsage {
+		t.Errorf("exit = %d, want %d", code, ExitUsage)
+	}
+}
+
+func TestCmdInferFlagParseError(t *testing.T) {
+	code, _, _ := runCLI(t, []string{"infer", "--not-a-flag"}, "")
+	if code != ExitUsage {
+		t.Errorf("exit = %d, want %d", code, ExitUsage)
+	}
+}
+
+func TestCmdValidateFlagParseError(t *testing.T) {
+	code, _, _ := runCLI(t, []string{"validate", "--not-a-flag"}, "")
+	if code != ExitUsage {
+		t.Errorf("exit = %d, want %d", code, ExitUsage)
+	}
+}
+
+func TestCmdMaterializeFlagParseError(t *testing.T) {
+	code, _, _ := runCLI(t, []string{"materialize", "--not-a-flag"}, "")
+	if code != ExitUsage {
+		t.Errorf("exit = %d, want %d", code, ExitUsage)
+	}
+}
+
+func TestCmdParseBadToFormat(t *testing.T) {
+	code, _, stderr := runCLI(t, []string{"parse", "--from", "json", "--to", "csv", "-"}, `{}`)
+	if code != ExitUsage {
+		t.Errorf("exit = %d, want %d, stderr=%q", code, ExitUsage, stderr)
+	}
+}
+
+func TestCmdParseWriterError(t *testing.T) {
+	// A bare scalar-rooted document has no XML spelling (XML requires a
+	// single top-level element) -- WriteXML reports
+	// write.unsupported-value, exercising the writer(doc) error branch
+	// distinct from the reader(text) error branch above it.
+	code, _, stderr := runCLI(t, []string{"parse", "--from", "json", "--to", "xml", "-"}, `42`)
+	if code != ExitProblem {
+		t.Errorf("exit = %d, want %d, stderr=%q", code, ExitProblem, stderr)
+	}
+}
+
+func TestCmdMaterializeMissingSchemaFlag(t *testing.T) {
+	code, _, _ := runCLI(t, []string{"materialize", "--from", "json", "-"}, `{}`)
+	if code != ExitUsage {
+		t.Errorf("exit = %d, want %d", code, ExitUsage)
+	}
+}
+
+func TestCmdMaterializeBadFromFormat(t *testing.T) {
+	schemaPath := writeTemp(t, "s.osd", testSchema)
+	code, _, _ := runCLI(t, []string{"materialize", "--from", "csv", "--schema", schemaPath, "-"}, `{}`)
+	if code != ExitUsage {
+		t.Errorf("exit = %d, want %d", code, ExitUsage)
+	}
+}
+
+func TestCmdMaterializeOutputFileNoToFlag(t *testing.T) {
+	// -o without --to should still work, defaulting the output format
+	// to --from.
+	schemaPath := writeTemp(t, "s.osd", testSchema)
+	dir := t.TempDir()
+	out := filepath.Join(dir, "out.json")
+	code, _, stderr := runCLI(t, []string{"materialize", "--from", "json", "--schema", schemaPath, "-o", out, "-"}, `{"name":"Ada","age":1}`)
+	if code != ExitOK {
+		t.Fatalf("exit = %d, stderr = %q", code, stderr)
+	}
+	got, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(got), "Ada") {
+		t.Errorf("file content = %q", got)
+	}
+}
+
+func TestCmdMaterializeMalformedInput(t *testing.T) {
+	schemaPath := writeTemp(t, "s.osd", testSchema)
+	code, _, _ := runCLI(t, []string{"materialize", "--from", "json", "--schema", schemaPath, "-"}, `{not json`)
+	if code != ExitProblem {
+		t.Errorf("exit = %d, want %d", code, ExitProblem)
+	}
+}
+
+func TestCmdSchemaExtractWrongArgCount(t *testing.T) {
+	code, _, _ := runCLI(t, []string{"schema", "extract", "--keep", "name"}, "")
+	if code != ExitUsage {
+		t.Errorf("exit = %d, want %d", code, ExitUsage)
+	}
+}
+
+func TestCmdSchemaIsEmptyMissingFile(t *testing.T) {
+	code, _, _ := runCLI(t, []string{"schema", "is-empty", filepath.Join(t.TempDir(), "nope.osd")}, "")
+	if code != ExitUsage {
+		t.Errorf("exit = %d, want %d", code, ExitUsage)
+	}
+}
+
+func TestCmdValidateMalformedInput(t *testing.T) {
+	schemaPath := writeTemp(t, "s.osd", testSchema)
+	code, _, _ := runCLI(t, []string{"validate", "--from", "json", "--schema", schemaPath, "-"}, `{not json`)
+	if code != ExitProblem {
+		t.Errorf("exit = %d, want %d", code, ExitProblem)
+	}
+}
+
+func TestCmdMaterializeWriterErrorMultipleRoots(t *testing.T) {
+	// testSchema's Root record has more than one top-level field, so
+	// materializing it and writing the result as XML hits
+	// CodeFormatMultipleRoots -- exercising the writer(result) error
+	// branch in cmdMaterialize distinct from the earlier reader/schema
+	// parse-error branches.
+	schemaPath := writeTemp(t, "s.osd", testSchema)
+	code, _, stderr := runCLI(t, []string{"materialize", "--from", "json", "--schema", schemaPath, "--to", "xml", "-"}, `{"name":"Ada","age":1}`)
+	if code != ExitProblem {
+		t.Errorf("exit = %d, want %d, stderr=%q", code, ExitProblem, stderr)
+	}
+}
+
+func TestCmdParseToOML(t *testing.T) {
+	// Exercises the oml entry in formatWriters' shared table (format.go),
+	// whose closure wrapping WriteOML otherwise never runs.
+	code, stdout, stderr := runCLI(t, []string{"parse", "--from", "json", "--to", "oml", "-"}, `{"a": 1}`)
+	if code != ExitOK {
+		t.Fatalf("exit = %d, stderr = %q", code, stderr)
+	}
+	if !strings.Contains(stdout, "a") {
+		t.Errorf("stdout = %q", stdout)
+	}
+}

--- a/cmd/omnist/subprocess_test.go
+++ b/cmd/omnist/subprocess_test.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// buildOmnistBinary compiles the actual cmd/omnist binary once per test
+// run into a temp dir, proving `go build` on this package succeeds and
+// giving the subprocess tests below a real executable to invoke -- as
+// opposed to the run_test.go tests, which call run() in-process.
+func buildOmnistBinary(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	name := "omnist"
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+	bin := filepath.Join(dir, name)
+	cmd := exec.Command("go", "build", "-o", bin, ".")
+	cmd.Env = append(os.Environ(), "GOFLAGS=-mod=mod")
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("go build cmd/omnist: %v\n%s", err, stderr.String())
+	}
+	return bin
+}
+
+func runBinary(t *testing.T, bin string, stdin string, args ...string) (code int, stdout, stderr string) {
+	t.Helper()
+	cmd := exec.Command(bin, args...)
+	cmd.Stdin = strings.NewReader(stdin)
+	var outBuf, errBuf bytes.Buffer
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	if err == nil {
+		return 0, outBuf.String(), errBuf.String()
+	}
+	if exitErr, ok := err.(*exec.ExitError); ok {
+		return exitErr.ExitCode(), outBuf.String(), errBuf.String()
+	}
+	t.Fatalf("running %s %v: %v", bin, args, err)
+	return -1, "", ""
+}
+
+// TestSubprocessParseGoldenPath proves the real compiled binary converts
+// JSON to YAML end to end via stdin/stdout, not just the internal run()
+// function.
+func TestSubprocessParseGoldenPath(t *testing.T) {
+	bin := buildOmnistBinary(t)
+	code, stdout, stderr := runBinary(t, bin, `{"greeting": "hi"}`, "parse", "--from", "json", "--to", "yaml", "-")
+	if code != ExitOK {
+		t.Fatalf("exit = %d, stderr = %q", code, stderr)
+	}
+	if !strings.Contains(stdout, "\"greeting\": \"hi\"") {
+		t.Errorf("stdout = %q", stdout)
+	}
+}
+
+// TestSubprocessValidateGoldenPath proves the real binary validates a
+// document against a schema file on disk and reports real diagnostics
+// with a nonzero exit code, via a real subprocess invocation.
+func TestSubprocessValidateGoldenPath(t *testing.T) {
+	bin := buildOmnistBinary(t)
+	dir := t.TempDir()
+	schemaPath := filepath.Join(dir, "s.osd")
+	if err := os.WriteFile(schemaPath, []byte(testSchema), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	code, stdout, _ := runBinary(t, bin, `{"name": "Ada"}`, "validate", "--from", "json", "--schema", schemaPath, "-")
+	if code != ExitProblem {
+		t.Fatalf("exit = %d, want %d", code, ExitProblem)
+	}
+	if !strings.Contains(stdout, "validate.cardinality") {
+		t.Errorf("stdout = %q", stdout)
+	}
+}
+
+// TestSubprocessSchemaNormalizeGoldenPath proves the real binary runs a
+// schema-algebra subcommand (normalize) end to end and prints valid OSD.
+func TestSubprocessSchemaNormalizeGoldenPath(t *testing.T) {
+	bin := buildOmnistBinary(t)
+	dir := t.TempDir()
+	schemaPath := filepath.Join(dir, "s.osd")
+	if err := os.WriteFile(schemaPath, []byte(testSchema), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	code, stdout, stderr := runBinary(t, bin, "", "schema", "normalize", schemaPath)
+	if code != ExitOK {
+		t.Fatalf("exit = %d, stderr = %q", code, stderr)
+	}
+	if !strings.Contains(stdout, "record Root") {
+		t.Errorf("stdout = %q", stdout)
+	}
+}
+
+// TestSubprocessMissingFileExitsCleanly proves a real invocation with a
+// nonexistent input file produces the documented usage-error exit code
+// and a sensible message, not a panic or Go stack trace.
+func TestSubprocessMissingFileExitsCleanly(t *testing.T) {
+	bin := buildOmnistBinary(t)
+	code, _, stderr := runBinary(t, bin, "", "parse", "--from", "json", filepath.Join(t.TempDir(), "does-not-exist.json"))
+	if code != ExitUsage {
+		t.Fatalf("exit = %d, want %d", code, ExitUsage)
+	}
+	if strings.Contains(stderr, "panic") || strings.Contains(stderr, "goroutine") {
+		t.Errorf("stderr looks like a panic, not a clean error: %q", stderr)
+	}
+}
+
+// TestSubprocessMalformedInputExitsCleanly proves a real invocation with
+// malformed input produces the documented operation-problem exit code
+// rather than a panic.
+func TestSubprocessMalformedInputExitsCleanly(t *testing.T) {
+	bin := buildOmnistBinary(t)
+	code, _, stderr := runBinary(t, bin, `{not valid json`, "parse", "--from", "json", "-")
+	if code != ExitProblem {
+		t.Fatalf("exit = %d, want %d", code, ExitProblem)
+	}
+	if strings.Contains(stderr, "panic") || strings.Contains(stderr, "goroutine") {
+		t.Errorf("stderr looks like a panic, not a clean error: %q", stderr)
+	}
+}
+
+// TestSubprocessBadFormatNameExitsCleanly proves an unknown --from
+// format name is a usage error, not a panic, via a real invocation.
+func TestSubprocessBadFormatNameExitsCleanly(t *testing.T) {
+	bin := buildOmnistBinary(t)
+	code, _, stderr := runBinary(t, bin, "{}", "parse", "--from", "yeehaw", "-")
+	if code != ExitUsage {
+		t.Fatalf("exit = %d, want %d", code, ExitUsage)
+	}
+	if !strings.Contains(stderr, "unknown format") {
+		t.Errorf("stderr = %q", stderr)
+	}
+}


### PR DESCRIPTION
Closes #37.

Adds cmd/omnist: a thin CLI wrapper over the existing library. Subcommands: parse, validate, materialize, schema {normalize,prune,extract,compatible-with,equivalent,is-empty}, infer, lint.

No spec mandates a CLI contract (conformance-harness.md explicitly documents Python's shape as one worked example, not a mandate) -- this issue had genuine design freedom, exercised and documented rather than guessed at: stdlib flag package only (shallow subcommand tree doesn't need a framework), an explicit exit-code convention (0 success, 1 usage/tool error, 2 operation-reported-a-problem, with the three boolean schema commands deliberately always exiting 0 rather than copying Python's exit-code-carries-the-boolean convention), --json output deliberately deferred as a scope decision.

Independently verified with a real build of the binary, not just unit tests -- driven with real commands covering format conversion, validate pass/fail with real diagnostic output, all three boolean schema commands in both directions, bad-invocation error handling, and the flag-ordering limitation the CLI's own usage text documents. First review attempt was discarded: it claimed to have run every gate and driven the binary but showed only 1 tool call total, which cannot support those claims -- redispatched fresh, and the second pass produced real, reproducible output for everything.

One review finding acted on: the original CI coverage exclusion covered the whole cmd/omnist package, broader than justified (only main(), which calls os.Exit and can't run under `go test`, and one documented-dead error branch in cmdMaterialize actually needed it -- the other 19 functions were already at 100%). Narrowed to those two exact functions in a follow-up commit on this branch, so a regression anywhere else in the package still fails the gate.

One judgment call surfaced with a genuine second opinion, not resolved either way as a correctness issue: whether schema extract's root-invalidation failure should exit 1 (usage error, current behavior) or exit 2 (operation problem) -- the reviewer leans slightly toward exit 2 since the failure depends on schema content, not --keep's syntax, but calls the current choice defensible and consistently applied. Left as-is; worth a second look if it ever comes up again.

100% coverage on 19 of 21 cmd/omnist functions per the narrowed exclusion above, 100% on the rest of the repo. 0 lint issues (7 errcheck findings on stdout/stderr write failures fixed and independently confirmed legitimate -- a CLI has no meaningful recovery action for those).