### PR TITLE
Package restructuring stage 1: extract shared temporal helpers

### DIFF
--- a/json_reader.go
+++ b/json_reader.go
@@ -347,8 +347,8 @@ func (r *jsonReader) readArrayElements(key string) ([]Target, error) {
 // function), so the type switch's only remaining possibilities from
 // json.Decoder.UseNumber()'s token set are nil, bool, string, and
 // json.Number — an exhaustive set with no default case needed, matching
-// the no-dead-branch convention oml_lexer.go's temporal decoders already
-// use (see the comment above parseDateValue).
+// the no-dead-branch convention temporal.go's temporal decoders already
+// use (see the comment above ParseISODate).
 func (r *jsonReader) scalarToValue(tok json.Token, path Path) (Value, error) {
 	switch v := tok.(type) {
 	case nil:
@@ -392,10 +392,9 @@ func (r *jsonReader) numberToValue(n json.Number, path Path) (Value, error) {
 	// s is a JSON-grammar-valid integer literal (the only kind
 	// json.Decoder.UseNumber() ever hands back for a no-'.'/'e'/'E' token):
 	// -?(0|[1-9]\d*). SetString with base 10 cannot fail on such a string,
-	// so — mirroring oml_lexer.go's parseDateValue/parseTimeValue
+	// so — mirroring temporal.go's ParseISODate/ParseISOTime
 	// convention for a regex-pinned precondition — this does not carry a
 	// permanently-dead "malformed" branch for a case no input can reach.
 	bi, _ := new(big.Int).SetString(s, 10)
 	return ScalarValue(NewIntegerScalar(bi)), nil
 }
-

--- a/json_writer.go
+++ b/json_writer.go
@@ -242,7 +242,7 @@ func formatISOTime(t TimeValue) string {
 // formatISOFraction converts a Nanosecond field to the shortest 1-6 digit
 // fraction string that reproduces it, mirroring oml_writer.go's
 // formatOMLFraction. Nanosecond is always a product of a source fraction
-// decoder that right-pads to 9 digits (oml_lexer.go's fracToNanos is the
+// decoder that right-pads to 9 digits (temporal.go's fracToNanos is the
 // only producer of TimeValue.Nanosecond in this repo), so it is always an
 // exact multiple of 1000, and trimming trailing zeros from its 6-digit
 // microsecond form can never trim down to nothing given the caller's

--- a/materialize.go
+++ b/materialize.go
@@ -3,7 +3,6 @@ package omnist
 import (
 	"math"
 	"math/big"
-	"regexp"
 )
 
 // This file implements materialize(document, schema) per spec §7.1 (the
@@ -147,8 +146,8 @@ func materializeScalar(target Target, r resolved, path Path, result *[]Diagnosti
 //     source integer "looks whole" — §7.2's easy-to-miss detail that the
 //     table's "Yes" does not itself spell out the target representation.
 //   - date/time/datetime targets: accepted only if the source is a string
-//     matching that exact kind's spelling per matchesTemporalKind (reused
-//     from oml_lexer.go's own lexical regexes — see that function's doc
+//     matching that exact kind's spelling per MatchesISOKind (reused
+//     from temporal.go's own lexical regexes — see that function's doc
 //     comment for why reuse rather than a new parser is correct here).
 //   - anything else: undefined (rejected).
 func tryUpgrade(s Scalar, targetKind ScalarKind) (Scalar, bool) {
@@ -168,20 +167,20 @@ func tryUpgrade(s Scalar, targetKind ScalarKind) (Scalar, bool) {
 		f, _ := new(big.Float).SetInt(s.Int).Float64()
 		return NewNumberScalar(f), true
 	case KindDate:
-		if s.Kind != KindString || !matchesTemporalKind(s.Str, temporalDate) {
+		if s.Kind != KindString || !MatchesISOKind(s.Str, TemporalDate) {
 			return Scalar{}, false
 		}
-		return NewDateScalar(parseDateValue(s.Str)), true
+		return NewDateScalar(ParseISODate(s.Str)), true
 	case KindTime:
-		if s.Kind != KindString || !matchesTemporalKind(s.Str, temporalTime) {
+		if s.Kind != KindString || !MatchesISOKind(s.Str, TemporalTime) {
 			return Scalar{}, false
 		}
-		return NewTimeScalar(parseTimeValue(s.Str)), true
+		return NewTimeScalar(ParseISOTime(s.Str)), true
 	case KindDateTime:
-		if s.Kind != KindString || !matchesTemporalKind(s.Str, temporalDateTime) {
+		if s.Kind != KindString || !MatchesISOKind(s.Str, TemporalDateTime) {
 			return Scalar{}, false
 		}
-		return NewDateTimeScalar(parseDateTimeValue(s.Str)), true
+		return NewDateTimeScalar(ParseISODateTime(s.Str)), true
 	default:
 		// KindString, KindBoolean: no cross-kind upgrade path exists for
 		// either (boolean per the rule above; string is never produced by
@@ -207,50 +206,4 @@ func integerFromExactFloat(f float64) (Scalar, bool) {
 	}
 	bi, _ := bf.Int(nil)
 	return NewIntegerScalar(bi), true
-}
-
-// temporalKind selects which of oml_lexer.go's three fully-anchored
-// temporal regexes matchesTemporalKind checks against.
-type temporalKind int
-
-const (
-	temporalDate temporalKind = iota
-	temporalTime
-	temporalDateTime
-)
-
-// matchesTemporalKind reports whether s is *exactly* (start to end) the
-// spelling reDate/reTime/reDateTime (oml_lexer.go) accept for kind — the
-// "exact spelling matches_kind() accepts for that specific kind, not
-// merely parseable by a looser library function" rule from §7.2's
-// try_upgrade notes. oml_lexer.go's own use of these regexes is via
-// FindString on a remaining-input tail (correct for a lexer scanning
-// forward through a longer document), which only pins the *start* of a
-// match, not the end — reusing them here needs a full-string check, so
-// this wraps FindString with an explicit "the match is the whole string"
-// comparison rather than introducing new regexes with different anchoring
-// (which is exactly the kind of drift the issue warns against: "reuse the
-// EXACT same format-matching logic rather than writing a new, possibly
-// looser or stricter parser").
-//
-// This is deliberately the OML lexer's spelling (§4's grammar), not
-// toml_reader.go's parseTOMLDateTime (which documents itself as *wider*
-// than oml_lexer.go's format: TOML allows a lowercase or space date/time
-// separator and a bare 'Z'/'z' offset). materialize's source strings
-// arrive from JSON/YAML/arbitrary Document construction, not specifically
-// from a TOML read, and §7.2's rule is a single canonical spelling per
-// kind — the OML lexer's spelling is that spelling, since OML is the
-// format whose native literal syntax the temporal scalar kinds were
-// designed around (§2.2.1/§4).
-func matchesTemporalKind(s string, kind temporalKind) bool {
-	var re *regexp.Regexp
-	switch kind {
-	case temporalDate:
-		re = reDate
-	case temporalTime:
-		re = reTime
-	case temporalDateTime:
-		re = reDateTime
-	}
-	return re.FindString(s) == s
 }

--- a/oml_lexer.go
+++ b/oml_lexer.go
@@ -167,12 +167,9 @@ func (l *lexer) skipTrivia() (sawSep bool, sepLine, sepCol int) {
 }
 
 var (
-	reDateTime = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2}(\.\d{1,6})?)?([+-]\d{2}:\d{2})?`)
-	reDate     = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}`)
-	reTime     = regexp.MustCompile(`^\d{2}:\d{2}(:\d{2}(\.\d{1,6})?)?([+-]\d{2}:\d{2})?`)
-	reNumber   = regexp.MustCompile(`^-?\d+(\.\d+([eE][+-]?\d+)?|[eE][+-]?\d+)`)
-	reInteger  = regexp.MustCompile(`^-?\d+`)
-	reIdent    = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_-]*`)
+	reNumber  = regexp.MustCompile(`^-?\d+(\.\d+([eE][+-]?\d+)?|[eE][+-]?\d+)`)
+	reInteger = regexp.MustCompile(`^-?\d+`)
+	reIdent   = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_-]*`)
 )
 
 // remainingString returns the source from the current position onward, as
@@ -213,21 +210,21 @@ func (l *lexer) next() (token, *ParseError) {
 	rest := l.remainingString()
 
 	// Rule 3: DATETIME.
-	if m := reDateTime.FindString(rest); m != "" {
+	if m := ISODateTimeRegexp.FindString(rest); m != "" {
 		l.consumeRunes(len([]rune(m)))
-		return token{kind: tokDateTime, text: m, dateTimeVal: parseDateTimeValue(m), line: startLine, col: startCol, sepBefore: sawSep, sepLine: sepLine, sepCol: sepCol}, nil
+		return token{kind: tokDateTime, text: m, dateTimeVal: ParseISODateTime(m), line: startLine, col: startCol, sepBefore: sawSep, sepLine: sepLine, sepCol: sepCol}, nil
 	}
 
 	// Rule 4: DATE (not followed by a valid DATETIME, already excluded above).
-	if m := reDate.FindString(rest); m != "" {
+	if m := ISODateRegexp.FindString(rest); m != "" {
 		l.consumeRunes(len([]rune(m)))
-		return token{kind: tokDate, text: m, dateVal: parseDateValue(m), line: startLine, col: startCol, sepBefore: sawSep, sepLine: sepLine, sepCol: sepCol}, nil
+		return token{kind: tokDate, text: m, dateVal: ParseISODate(m), line: startLine, col: startCol, sepBefore: sawSep, sepLine: sepLine, sepCol: sepCol}, nil
 	}
 
 	// Rule 5: TIME.
-	if m := reTime.FindString(rest); m != "" {
+	if m := ISOTimeRegexp.FindString(rest); m != "" {
 		l.consumeRunes(len([]rune(m)))
-		return token{kind: tokTime, text: m, timeVal: parseTimeValue(m), line: startLine, col: startCol, sepBefore: sawSep, sepLine: sepLine, sepCol: sepCol}, nil
+		return token{kind: tokTime, text: m, timeVal: ParseISOTime(m), line: startLine, col: startCol, sepBefore: sawSep, sepLine: sepLine, sepCol: sepCol}, nil
 	}
 
 	// Rule 6: NUMBER (decimal or exponent form).
@@ -318,70 +315,6 @@ func matchReservedFloat(rest string) (matched string, val float64, ok bool) {
 		return "inf", math.Inf(1), true
 	}
 	return "", 0, false
-}
-
-// --- temporal value construction ---
-//
-// parseDateValue/parseTimeValue/parseDateTimeValue are only ever called on
-// text already matched by reDate/reTime/reDateTime, which fully pin the
-// digit layout these functions assume (down to field widths). Given that
-// precondition the Sscanf/index calls below cannot fail, so — unlike the
-// lexer's other decoders — these deliberately have no error return: an
-// error-returning version would carry a permanently-dead "malformed"
-// branch that no input could ever reach (regex guarantees the format),
-// which is worse for coverage and for readability than asserting the
-// precondition in this comment once, here.
-
-func parseDateValue(s string) DateValue {
-	var y, mo, d int
-	_, _ = fmt.Sscanf(s, "%4d-%2d-%2d", &y, &mo, &d)
-	return DateValue{Year: y, Month: mo, Day: d}
-}
-
-func parseTimeValue(s string) TimeValue {
-	rest := s
-	var hh, mm int
-	_, _ = fmt.Sscanf(rest, "%2d:%2d", &hh, &mm)
-	rest = rest[5:]
-	tv := TimeValue{Hour: hh, Minute: mm}
-	if strings.HasPrefix(rest, ":") {
-		var ss int
-		_, _ = fmt.Sscanf(rest[1:], "%2d", &ss)
-		tv.Second = ss
-		rest = rest[3:]
-		if strings.HasPrefix(rest, ".") {
-			end := 1
-			for end < len(rest) && rest[end] >= '0' && rest[end] <= '9' {
-				end++
-			}
-			tv.Nanosecond = fracToNanos(rest[1:end])
-			rest = rest[end:]
-		}
-	}
-	if len(rest) == 6 && (rest[0] == '+' || rest[0] == '-') {
-		var oh, om int
-		_, _ = fmt.Sscanf(rest[1:], "%2d:%2d", &oh, &om)
-		sign := 1
-		if rest[0] == '-' {
-			sign = -1
-		}
-		tv.HasOffset = true
-		tv.OffsetSeconds = sign * (oh*3600 + om*60)
-	}
-	return tv
-}
-
-func parseDateTimeValue(s string) DateTimeValue {
-	idx := strings.IndexByte(s, 'T')
-	return DateTimeValue{Date: parseDateValue(s[:idx]), Time: parseTimeValue(s[idx+1:])}
-}
-
-// fracToNanos converts a fractional-second digit string (1-6 digits, as
-// matched by the grammar) to nanoseconds, right-padding to 9 digits.
-func fracToNanos(digits string) int {
-	padded := (digits + "000000000")[:9]
-	n, _ := strconv.Atoi(padded)
-	return n
 }
 
 // --- string scanning ---

--- a/oml_writer.go
+++ b/oml_writer.go
@@ -149,7 +149,7 @@ func writeOMLValue(b *strings.Builder, v Value) {
 // either built by NewIntegerScalar (which always copies a non-nil
 // *big.Int) or produced by ReadOML/ReadOSD, neither of which ever leaves
 // Int nil for KindInteger. This mirrors the same trusted-precondition
-// convention oml_lexer.go's temporal decoders already use.
+// convention temporal.go's temporal decoders already use.
 func writeOMLScalar(b *strings.Builder, s Scalar) {
 	switch s.Kind {
 	case KindString:
@@ -205,7 +205,7 @@ func formatOMLDate(d DateValue) string {
 }
 
 // formatOMLTime renders a TimeValue per the TIME production (spec §4.2's
-// reTime). Seconds are emitted only when Second or Nanosecond is nonzero,
+// ISOTimeRegexp). Seconds are emitted only when Second or Nanosecond is nonzero,
 // and the fractional part only when Nanosecond is nonzero — the Document
 // model does not distinguish "seconds explicitly written as :00" from
 // "seconds omitted", so omitting a zero seconds/fraction component is a
@@ -242,7 +242,7 @@ func formatOMLTime(t TimeValue) string {
 
 // formatOMLFraction converts a Nanosecond field back to the shortest 1-6
 // digit fraction string that reproduces it. Nanosecond is always a
-// product of fracToNanos (oml_lexer.go), which right-pads a 1-6 digit
+// product of fracToNanos (temporal.go), which right-pads a 1-6 digit
 // source fraction to 9 digits with zeros — so Nanosecond is always an
 // exact multiple of 1000, and trimming trailing zeros from its 6-digit
 // microsecond form can never trim down to nothing given the caller's

--- a/temporal.go
+++ b/temporal.go
@@ -1,0 +1,148 @@
+package omnist
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// ISODateTimeRegexp, ISODateRegexp, and ISOTimeRegexp are the exact,
+// start-anchored regexes the OML lexer uses (spec §4.2's DATETIME/DATE/
+// TIME productions) to recognize the three temporal token kinds. They are
+// exported because multiple packages beyond the OML lexer itself need the
+// identical spelling: a codec reader deciding whether a source string is
+// "exactly" a date/time/datetime (see MatchesISOKind), or any future
+// package that needs to recognize this exact literal shape without
+// duplicating — and risking drifting from — the OML grammar's own regex.
+//
+// Each regex is anchored only at the start ('^'), not the end: that is
+// correct for the OML lexer's own use (FindString on a remaining-input
+// tail, consuming a prefix while scanning forward through a longer
+// document) but means a caller that needs a *whole-string* match — is
+// this entire string exactly a DATE, not just prefixed by one — must
+// check that explicitly, e.g. via MatchesISOKind, rather than trusting a
+// non-empty FindString result on its own.
+var (
+	ISODateTimeRegexp = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2}(\.\d{1,6})?)?([+-]\d{2}:\d{2})?`)
+	ISODateRegexp     = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}`)
+	ISOTimeRegexp     = regexp.MustCompile(`^\d{2}:\d{2}(:\d{2}(\.\d{1,6})?)?([+-]\d{2}:\d{2})?`)
+)
+
+// TemporalKind selects which of ISODateRegexp/ISOTimeRegexp/
+// ISODateTimeRegexp MatchesISOKind checks a string against.
+type TemporalKind int
+
+const (
+	TemporalDate TemporalKind = iota
+	TemporalTime
+	TemporalDateTime
+)
+
+// MatchesISOKind reports whether s is *exactly* (start to end) the
+// spelling ISODateRegexp/ISOTimeRegexp/ISODateTimeRegexp accepts for
+// kind — the "exact spelling matches_kind() accepts for that specific
+// kind, not merely parseable by a looser library function" rule from
+// spec §7.2's try_upgrade notes. The underlying regexes are only
+// start-anchored (correct for a lexer scanning forward through a longer
+// document via FindString on a remaining-input tail, which pins the
+// *start* of a match but not the end), so this wraps FindString with an
+// explicit "the match is the whole string" comparison rather than
+// introducing new regexes with different anchoring — that would be
+// exactly the kind of drift spec §7.2 warns against: reuse the same
+// format-matching logic rather than a new, possibly looser or stricter
+// parser.
+//
+// This is deliberately the OML lexer's spelling (§4's grammar), not, for
+// example, a TOML/YAML reader's own wider temporal parsing (TOML and YAML
+// both allow separators/offsets OML's grammar does not). Callers reading
+// from an arbitrary Document (JSON, YAML, or direct construction) should
+// use this canonical spelling per §7.2's rule of a single canonical
+// spelling per kind — the OML lexer's spelling is that spelling, since
+// OML is the format whose native literal syntax the temporal scalar kinds
+// were designed around (§2.2.1/§4).
+func MatchesISOKind(s string, kind TemporalKind) bool {
+	var re *regexp.Regexp
+	switch kind {
+	case TemporalDate:
+		re = ISODateRegexp
+	case TemporalTime:
+		re = ISOTimeRegexp
+	case TemporalDateTime:
+		re = ISODateTimeRegexp
+	}
+	return re.FindString(s) == s
+}
+
+// --- temporal value construction ---
+//
+// ParseISODate/ParseISOTime/ParseISODateTime are only ever meant to be
+// called on text already matched by ISODateRegexp/ISOTimeRegexp/
+// ISODateTimeRegexp (or a superset grammar that pins the same digit
+// layout, e.g. a TOML/YAML reader's own wider temporal regex reusing
+// these for the date/time portions), which fully pin the digit layout
+// these functions assume (down to field widths). Given that precondition
+// the Sscanf/index calls below cannot fail, so — unlike other decoders in
+// this package — these deliberately have no error return: an
+// error-returning version would carry a permanently-dead "malformed"
+// branch that no input could ever reach (the regex guarantees the
+// format), which is worse for coverage and for readability than asserting
+// the precondition in this comment once, here.
+
+// ParseISODate parses s, which must already match ISODateRegexp, into a
+// DateValue.
+func ParseISODate(s string) DateValue {
+	var y, mo, d int
+	_, _ = fmt.Sscanf(s, "%4d-%2d-%2d", &y, &mo, &d)
+	return DateValue{Year: y, Month: mo, Day: d}
+}
+
+// ParseISOTime parses s, which must already match ISOTimeRegexp, into a
+// TimeValue.
+func ParseISOTime(s string) TimeValue {
+	rest := s
+	var hh, mm int
+	_, _ = fmt.Sscanf(rest, "%2d:%2d", &hh, &mm)
+	rest = rest[5:]
+	tv := TimeValue{Hour: hh, Minute: mm}
+	if strings.HasPrefix(rest, ":") {
+		var ss int
+		_, _ = fmt.Sscanf(rest[1:], "%2d", &ss)
+		tv.Second = ss
+		rest = rest[3:]
+		if strings.HasPrefix(rest, ".") {
+			end := 1
+			for end < len(rest) && rest[end] >= '0' && rest[end] <= '9' {
+				end++
+			}
+			tv.Nanosecond = fracToNanos(rest[1:end])
+			rest = rest[end:]
+		}
+	}
+	if len(rest) == 6 && (rest[0] == '+' || rest[0] == '-') {
+		var oh, om int
+		_, _ = fmt.Sscanf(rest[1:], "%2d:%2d", &oh, &om)
+		sign := 1
+		if rest[0] == '-' {
+			sign = -1
+		}
+		tv.HasOffset = true
+		tv.OffsetSeconds = sign * (oh*3600 + om*60)
+	}
+	return tv
+}
+
+// ParseISODateTime parses s, which must already match ISODateTimeRegexp,
+// into a DateTimeValue.
+func ParseISODateTime(s string) DateTimeValue {
+	idx := strings.IndexByte(s, 'T')
+	return DateTimeValue{Date: ParseISODate(s[:idx]), Time: ParseISOTime(s[idx+1:])}
+}
+
+// fracToNanos converts a fractional-second digit string (1-6 digits, as
+// matched by the grammar) to nanoseconds, right-padding to 9 digits.
+func fracToNanos(digits string) int {
+	padded := (digits + "000000000")[:9]
+	n, _ := strconv.Atoi(padded)
+	return n
+}

--- a/toml_reader.go
+++ b/toml_reader.go
@@ -452,9 +452,9 @@ func itoa(n int) string { return strconv.Itoa(n) }
 // constructs a *unstable.ParserError with a genuine, non-nil Highlight —
 // a real subslice of the input — so the type assertion below is
 // unchecked and Highlight is trusted to be non-nil, the same precondition
-// -trusting convention oml_lexer.go's parseDateValue/parseTimeValue
+// -trusting convention temporal.go's ParseISODate/ParseISOTime
 // already use in this package (see that file's comment above
-// parseDateValue) rather than carrying a defensive fallback branch no
+// ParseISODate) rather than carrying a defensive fallback branch no
 // input can reach.
 func (r *tomlReader) wrapParserError(err error) error {
 	pe := err.(*unstable.ParserError) //nolint:errorlint // see doc comment: the library's own error is always this concrete type
@@ -483,9 +483,9 @@ func (r *tomlReader) readScalar(v *unstable.Node) (Value, error) {
 	case unstable.Float:
 		return ScalarValue(NewNumberScalar(parseTOMLFloat(string(v.Data)))), nil
 	case unstable.LocalDate:
-		return ScalarValue(NewDateScalar(parseDateValue(string(v.Data)))), nil
+		return ScalarValue(NewDateScalar(ParseISODate(string(v.Data)))), nil
 	case unstable.LocalTime:
-		return ScalarValue(NewTimeScalar(parseTimeValue(string(v.Data)))), nil
+		return ScalarValue(NewTimeScalar(ParseISOTime(string(v.Data)))), nil
 	default: // unstable.LocalDateTime, unstable.DateTime
 		return ScalarValue(NewDateTimeScalar(parseTOMLDateTime(string(v.Data)))), nil
 	}
@@ -503,7 +503,7 @@ func (r *tomlReader) readScalar(v *unstable.Node) (Value, error) {
 // see ReadTOML's doc comment on the sign/radix-prefix combination the
 // parser itself rejects before this function ever sees the text), so
 // SetString cannot fail on well-formed input, so — mirroring
-// oml_lexer.go's parseDateValue/parseTimeValue convention of trusting a
+// temporal.go's ParseISODate/ParseISOTime convention of trusting a
 // checked precondition rather than carrying a permanently-dead error
 // branch (see that file's comment for the same reasoning applied to a
 // different precondition) — this has no error return at all.
@@ -547,22 +547,22 @@ func parseTOMLFloat(raw string) float64 {
 // text into a DateTimeValue. TOML's grammar allows 'T', 't', or a literal
 // space as the date/time separator (all three confirmed empirically to
 // reach Kind=LocalDateTime/DateTime, not rejected), and either 'Z'/'z' or
-// a +HH:MM/-HH:MM suffix for an offset — wider than oml_lexer.go's own
-// parseDateTimeValue (OML's grammar only allows 'T', matching reDateTime),
+// a +HH:MM/-HH:MM suffix for an offset — wider than temporal.go's own
+// ParseISODateTime (OML's grammar only allows 'T', matching ISODateTimeRegexp),
 // so this does not reuse it directly, though it does reuse
-// parseDateValue/parseTimeValue (document-model-neutral, format-agnostic
-// field parsers oml_lexer.go already defines) for the date and
+// ParseISODate/ParseISOTime (document-model-neutral, format-agnostic
+// field parsers temporal.go already defines) for the date and
 // (offset-less) time portions.
 func parseTOMLDateTime(s string) DateTimeValue {
 	datePart := s[:10]
 	timePart := s[11:]
 	var tv TimeValue
 	if n := len(timePart); n > 0 && (timePart[n-1] == 'Z' || timePart[n-1] == 'z') {
-		tv = parseTimeValue(timePart[:n-1])
+		tv = ParseISOTime(timePart[:n-1])
 		tv.HasOffset = true
 		tv.OffsetSeconds = 0
 	} else {
-		tv = parseTimeValue(timePart)
+		tv = ParseISOTime(timePart)
 	}
-	return DateTimeValue{Date: parseDateValue(datePart), Time: tv}
+	return DateTimeValue{Date: ParseISODate(datePart), Time: tv}
 }

--- a/yaml_reader.go
+++ b/yaml_reader.go
@@ -481,7 +481,7 @@ func resolveYAMLScalar(n *yaml.Node) Value {
 		return ScalarValue(NewDateTimeScalar(parseYAMLDateTime(s)))
 	}
 	if reYAMLDate.MatchString(s) {
-		return ScalarValue(NewDateScalar(parseDateValue(s)))
+		return ScalarValue(NewDateScalar(ParseISODate(s)))
 	}
 	return ScalarValue(NewStringScalar(s))
 }
@@ -530,15 +530,15 @@ func parseYAMLInt(s string) (*big.Int, bool) {
 // parseYAMLDateTime converts a scalar's text into a DateTimeValue. Its
 // only caller (resolveYAMLScalar) checks reYAMLDateTime.MatchString(s)
 // first and only calls this on success, so FindStringSubmatch here is
-// guaranteed non-nil — mirroring oml_lexer.go's parseDateValue/
-// parseTimeValue precondition convention (see that file's comment above
-// parseDateValue), this does not carry a permanently-dead "no match"
+// guaranteed non-nil — mirroring temporal.go's ParseISODate/
+// ParseISOTime precondition convention (see that file's comment above
+// ParseISODate), this does not carry a permanently-dead "no match"
 // branch for a case the precondition already excludes.
 //
-// Unlike OML's reDateTime (which oml_lexer.go's parseDateTimeValue
+// Unlike OML's ISODateTimeRegexp (which temporal.go's ParseISODateTime
 // assumes), YAML's timestamp type additionally allows a lowercase 't' or a
 // literal space as the date/time separator and a bare 'Z' for UTC, so this
-// does not reuse oml_lexer.go's parseDateTimeValue directly (its
+// does not reuse temporal.go's ParseISODateTime directly (its
 // Sscanf-based implementation is pinned to the OML lexer's own narrower
 // regex) and instead extracts fields from reYAMLDateTime's own capture
 // groups.
@@ -578,4 +578,3 @@ func parseYAMLDateTime(s string) DateTimeValue {
 		Time: tv,
 	}
 }
-


### PR DESCRIPTION
Closes #39.

Stage 1 of a 6-stage package-restructuring project (repo currently one flat 28-file package, moving to a subpackage layout: root kernel + /oml + /osd + /formats/{json,yaml,toml,xml} + /algebra). This stage extracts and exports the temporal parsing helpers previously private in oml_lexer.go (ISODateRegexp/ISOTimeRegexp/ISODateTimeRegexp, ParseISODate/ParseISOTime/ParseISODateTime, TemporalKind/MatchesISOKind promoted from materialize.go) into a new temporal.go -- these were secretly reused by 5 other files (materialize.go, json_reader.go, toml_reader.go, yaml_reader.go, oml_writer.go), a cross-cutting dependency that would have silently broken later stages if not resolved before any file moves to a different package.

Pure, behavior-preserving refactor -- no logic changed anywhere, only symbol names/locations. Verified as a genuine no-op, not just claimed as one: independently reproduced via two separate git worktrees at the before/after commits, running the conformance harness at each and diffing the full output byte-for-byte (140/6/3, identical failure/skip lists at both). Full test suite pass count identical at both commits (725/725, 0 fail both times) -- not just the aggregate, since a masked behavior change could preserve pass/fail counts while changing what's actually being asserted; spot-checked temporal-parsing test assertions directly to confirm the underlying values are unchanged, not just their pass/fail status.

100% coverage maintained on the root package; cmd/omnist's documented 99.2% exception confirmed unchanged, not accidentally widened by this change. 0 lint issues. gofmt claim about two pre-existing unrelated files verified against the parent commit.