### PR TITLE
Add ok:true+diagnostics channel to codec writers

### DIFF
--- a/cmd/omnist/cmd_materialize.go
+++ b/cmd/omnist/cmd_materialize.go
@@ -95,19 +95,26 @@ func cmdMaterialize(args []string, stdin io.Reader, stdout, stderr io.Writer) in
 		return ExitProblem
 	}
 
+	writeDiagCount := 0
 	if wantsOutput {
-		outText, werr := writer(result)
+		outText, writeDiags, werr := writer(result)
 		if werr != nil {
 			_, _ = fmt.Fprintf(stderr, "omnist materialize: %v\n", werr)
 			return ExitProblem
 		}
+		// Same non-fatal-adjustment channel as cmdParse -- a writer can
+		// succeed while reporting one (issue #49, spec §8.5.3).
+		for _, d := range writeDiags {
+			_, _ = fmt.Fprintf(stderr, "omnist materialize: %s: %s: %s\n", d.Path, d.Code, d.Message)
+		}
+		writeDiagCount = len(writeDiags)
 		if werr := writeOutput(*out, outText, stdout); werr != nil {
 			_, _ = fmt.Fprintf(stderr, "omnist materialize: %v\n", werr)
 			return ExitUsage
 		}
 	}
 
-	if len(diags) > 0 {
+	if len(diags) > 0 || writeDiagCount > 0 {
 		return ExitProblem
 	}
 	return ExitOK

--- a/cmd/omnist/cmd_parse.go
+++ b/cmd/omnist/cmd_parse.go
@@ -61,14 +61,25 @@ func cmdParse(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		_, _ = fmt.Fprintf(stderr, "omnist parse: %v\n", err)
 		return ExitProblem
 	}
-	outText, err := writer(doc)
+	outText, diags, err := writer(doc)
 	if err != nil {
 		_, _ = fmt.Fprintf(stderr, "omnist parse: %v\n", err)
 		return ExitProblem
 	}
+	// A writer can succeed while still reporting a non-fatal adjustment
+	// (issue #49, spec §8.5.3's write-only ok:true+diagnostics
+	// coexistence) -- print each one to stderr, mirroring cmdMaterialize's
+	// established diagnostic-printing convention, without treating it as
+	// a failure: the output was still produced and is still written below.
+	for _, d := range diags {
+		_, _ = fmt.Fprintf(stderr, "omnist parse: %s: %s: %s\n", d.Path, d.Code, d.Message)
+	}
 	if err := writeOutput(*out, outText, stdout); err != nil {
 		_, _ = fmt.Fprintf(stderr, "omnist parse: %v\n", err)
 		return ExitUsage
+	}
+	if len(diags) > 0 {
+		return ExitProblem
 	}
 	return ExitOK
 }

--- a/cmd/omnist/format.go
+++ b/cmd/omnist/format.go
@@ -19,7 +19,13 @@ import (
 // needs format dispatch (parse, validate, materialize, infer), instead
 // of six separate copies of the same format-name switch statement.
 type formatReaderFunc func(text string, limits omnist.Limits) (omnist.Document, error)
-type formatWriterFunc func(d omnist.Document) (string, error)
+
+// formatWriterFunc's diagnostics return is the ok:true+diagnostics
+// channel added in issue #49: a writer can succeed (err == nil) while
+// still reporting a non-fatal adjustment (a dropped null, a stringified
+// temporal, a substituted NaN/Infinity) via the returned
+// []omnist.Diagnostic, per spec §8.5.3.
+type formatWriterFunc func(d omnist.Document) (string, []omnist.Diagnostic, error)
 
 var formatReaders = map[string]formatReaderFunc{
 	"json": json.Read,
@@ -35,9 +41,14 @@ var formatWriters = map[string]formatWriterFunc{
 	"toml": toml.Write,
 	"xml":  xml.Write,
 	// oml.Write never returns an error (compact-vs-pretty is the only
-	// knob, and both always succeed), but it's wrapped here so every
-	// entry in this table shares one signature.
-	"oml": func(d omnist.Document) (string, error) { return oml.Write(d, false), nil },
+	// knob, and both always succeed, and every omnist.Kind has a native
+	// OML spelling so there's never an adjustment to report either), but
+	// it's wrapped here so every entry in this table shares one
+	// signature.
+	"oml": func(d omnist.Document) (string, []omnist.Diagnostic, error) {
+		text, diags := oml.Write(d, false)
+		return text, diags, nil
+	},
 }
 
 // knownFormatNames returns the five supported format names, sorted, for

--- a/cmd/omnist/run_test.go
+++ b/cmd/omnist/run_test.go
@@ -702,6 +702,24 @@ func TestCmdParseWriterError(t *testing.T) {
 	}
 }
 
+func TestCmdParseWriterSucceedsWithDiagnostics(t *testing.T) {
+	// Writing a date leaf as JSON succeeds but reports
+	// format.temporal-stringified (issue #49's ok:true+diagnostics
+	// channel) -- exercises cmdParse's new diags-printing branch and its
+	// ExitProblem-on-nonempty-diagnostics behavior, distinct from
+	// TestCmdParseWriterError's hard-failure branch.
+	code, stdout, stderr := runCLI(t, []string{"parse", "--from", "oml", "--to", "json", "-"}, `d: 2024-01-01`)
+	if code != ExitProblem {
+		t.Errorf("exit = %d, want %d, stderr=%q", code, ExitProblem, stderr)
+	}
+	if !strings.Contains(stderr, "format.temporal-stringified") {
+		t.Errorf("stderr = %q, want it to mention format.temporal-stringified", stderr)
+	}
+	if !strings.Contains(stdout, `"d": "2024-01-01"`) {
+		t.Errorf("stdout = %q, want the written text despite the diagnostic", stdout)
+	}
+}
+
 func TestCmdMaterializeMissingSchemaFlag(t *testing.T) {
 	code, _, _ := runCLI(t, []string{"materialize", "--from", "json", "-"}, `{}`)
 	if code != ExitUsage {
@@ -776,6 +794,26 @@ func TestCmdMaterializeWriterErrorMultipleRoots(t *testing.T) {
 	code, _, stderr := runCLI(t, []string{"materialize", "--from", "json", "--schema", schemaPath, "--to", "xml", "-"}, `{"name":"Ada","age":1}`)
 	if code != ExitProblem {
 		t.Errorf("exit = %d, want %d, stderr=%q", code, ExitProblem, stderr)
+	}
+}
+
+func TestCmdMaterializeWriterSucceedsWithDiagnostics(t *testing.T) {
+	// Mirrors TestCmdParseWriterSucceedsWithDiagnostics for cmdMaterialize's
+	// own writer(result) call: materializing a date field then writing it
+	// as JSON succeeds but reports format.temporal-stringified, exercising
+	// cmdMaterialize's writeDiags branch (distinct from
+	// TestCmdMaterializeWriterErrorMultipleRoots's hard-failure branch and
+	// from a materialize-diagnostics-only run).
+	schemaPath := writeTemp(t, "dateschema.osd", "record Root {\n  \"d\": date\n}\nroot Root\n")
+	code, stdout, stderr := runCLI(t, []string{"materialize", "--from", "json", "--schema", schemaPath, "--to", "json", "-"}, `{"d": "2024-01-01"}`)
+	if code != ExitProblem {
+		t.Errorf("exit = %d, want %d, stderr=%q", code, ExitProblem, stderr)
+	}
+	if !strings.Contains(stderr, "format.temporal-stringified") {
+		t.Errorf("stderr = %q, want it to mention format.temporal-stringified", stderr)
+	}
+	if !strings.Contains(stdout, `"d": "2024-01-01"`) {
+		t.Errorf("stdout = %q, want the written text despite the diagnostic", stdout)
 	}
 }
 

--- a/formats/json/json_reader_test.go
+++ b/formats/json/json_reader_test.go
@@ -58,7 +58,7 @@ func TestJSONCountOneAsymmetry(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadJSON failed: %v", err)
 	}
-	got, err := Write(doc)
+	got, _, err := Write(doc)
 	if err != nil {
 		t.Fatalf("WriteJSON failed: %v", err)
 	}
@@ -280,7 +280,7 @@ func TestJSONRoundTripProperty(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			text, err := Write(tc.doc)
+			text, _, err := Write(tc.doc)
 			if err != nil {
 				t.Fatalf("WriteJSON failed: %v", err)
 			}
@@ -304,7 +304,7 @@ func TestJSONNaNInfinityWriteThenReadBecomesNull(t *testing.T) {
 	doc := omnist.NodeDocument(omnist.NewNode().
 		AddValue("n", omnist.ScalarValue(omnist.NewNumberScalar(math.NaN()))).
 		AddValue("ok", omnist.ScalarValue(omnist.NewStringScalar("still here"))))
-	text, err := Write(doc)
+	text, _, err := Write(doc)
 	if err != nil {
 		t.Fatalf("WriteJSON failed: %v", err)
 	}

--- a/formats/json/json_writer.go
+++ b/formats/json/json_writer.go
@@ -17,22 +17,22 @@ import (
 // ISO-8601, and NaN/Infinity — not valid JSON tokens — are substituted
 // with `null` at the leaf (docs/formats/json.md's default lenient mode).
 //
-// The signature returns an error because a NaN/Infinity substitution is a
-// reportable adjustment, not always a silent one (spec §7.4: "a reader or
+// The signature returns diagnostics alongside text and error because both
+// of JSON's leaf adjustments are reportable per spec §7.4 ("a reader or
 // writer SHOULD be able to report the adjustments... this is what makes
-// lossiness auditable"). In lenient mode (this function) the write itself
-// never fails — substitution always succeeds — so the error return is
-// currently always nil; it exists so the signature doesn't have to change
-// later when full format-report plumbing lands, and so a caller reading
-// only the signature sees, correctly, that writing JSON can have something
-// to report. Full diagnostic-collection wiring is a TODO (spec §7.4 says
-// only SHOULD, and no `format.*` adjustment-reporting mechanism exists
-// elsewhere in this repo yet to hook into) — this is called out explicitly
-// per the issue's instruction not to silently drop the requirement.
+// lossiness auditable") and spec §8.5.3, which documents write as the one
+// operation where a successful `{ok: true, ...}` result and a non-empty
+// diagnostics list are not mutually exclusive: every temporal leaf
+// stringified to ISO-8601 (format.temporal-stringified) and every
+// NaN/Infinity substituted with `null` (format.float-special) is now
+// reported this way. text is non-empty and err is nil whenever the write
+// succeeds, with diagnostics non-empty exactly when an adjustment
+// happened; text is empty and err is non-nil only on WriteStrict's hard
+// NaN/Infinity failure below.
 //
 // See WriteStrict for the spec's optional MAY: failing instead of
 // substituting.
-func Write(d omnist.Document) (string, error) {
+func Write(d omnist.Document) (string, []omnist.Diagnostic, error) {
 	return writeJSONDocument(d, false)
 }
 
@@ -42,22 +42,26 @@ func Write(d omnist.Document) (string, error) {
 // describes as a spec MAY ("A strict mode MAY instead fail"). The
 // returned error is a omnist.Diagnostic (code write.unsupported-value, spec
 // §8.3.9), positioned by the omnist.Document path to the offending leaf.
-func WriteStrict(d omnist.Document) (string, error) {
+// A temporal leaf can still be stringified and reported even in strict
+// mode (the two adjustments are independent), so a strict write can
+// succeed with non-empty diagnostics just like Write's.
+func WriteStrict(d omnist.Document) (string, []omnist.Diagnostic, error) {
 	return writeJSONDocument(d, true)
 }
 
-func writeJSONDocument(d omnist.Document, strict bool) (string, error) {
+func writeJSONDocument(d omnist.Document, strict bool) (string, []omnist.Diagnostic, error) {
 	var b strings.Builder
+	var diags []omnist.Diagnostic
 	if d.IsNode {
-		if err := writeJSONNode(&b, d.Node, "$", strict); err != nil {
-			return "", err
+		if err := writeJSONNode(&b, d.Node, "$", strict, &diags); err != nil {
+			return "", nil, err
 		}
-		return b.String(), nil
+		return b.String(), diags, nil
 	}
-	if err := writeJSONValue(&b, d.Value, "$", strict); err != nil {
-		return "", err
+	if err := writeJSONValue(&b, d.Value, "$", strict, &diags); err != nil {
+		return "", nil, err
 	}
-	return b.String(), nil
+	return b.String(), diags, nil
 }
 
 // jsonGroup is one label's worth of grouped edges, in the order
@@ -73,7 +77,7 @@ type jsonGroup struct {
 // format: group edges sharing a label (grouping rule), then render each
 // group as a bare value when it has exactly one child or as a list
 // otherwise (count-1 rule).
-func writeJSONNode(b *strings.Builder, n *omnist.Node, path string, strict bool) error {
+func writeJSONNode(b *strings.Builder, n *omnist.Node, path string, strict bool, diags *[]omnist.Diagnostic) error {
 	groups := groupJSONEdges(n)
 
 	b.WriteByte('{')
@@ -86,7 +90,7 @@ func writeJSONNode(b *strings.Builder, n *omnist.Node, path string, strict bool)
 		childPath := path + "." + g.label
 
 		if len(g.children) == 1 {
-			if err := writeJSONTarget(b, g.children[0], childPath, strict); err != nil {
+			if err := writeJSONTarget(b, g.children[0], childPath, strict, diags); err != nil {
 				return err
 			}
 			continue
@@ -96,7 +100,7 @@ func writeJSONNode(b *strings.Builder, n *omnist.Node, path string, strict bool)
 			if j > 0 {
 				b.WriteString(", ")
 			}
-			if err := writeJSONTarget(b, t, fmt.Sprintf("%s[%d]", childPath, j), strict); err != nil {
+			if err := writeJSONTarget(b, t, fmt.Sprintf("%s[%d]", childPath, j), strict, diags); err != nil {
 				return err
 			}
 		}
@@ -125,20 +129,20 @@ func groupJSONEdges(n *omnist.Node) []jsonGroup {
 	return groups
 }
 
-func writeJSONTarget(b *strings.Builder, t omnist.Target, path string, strict bool) error {
+func writeJSONTarget(b *strings.Builder, t omnist.Target, path string, strict bool, diags *[]omnist.Diagnostic) error {
 	if node, ok := t.Node(); ok {
-		return writeJSONNode(b, node, path, strict)
+		return writeJSONNode(b, node, path, strict, diags)
 	}
 	v, _ := t.Value()
-	return writeJSONValue(b, v, path, strict)
+	return writeJSONValue(b, v, path, strict, diags)
 }
 
-func writeJSONValue(b *strings.Builder, v omnist.Value, path string, strict bool) error {
+func writeJSONValue(b *strings.Builder, v omnist.Value, path string, strict bool, diags *[]omnist.Diagnostic) error {
 	if v.IsNull {
 		b.WriteString("null")
 		return nil
 	}
-	return writeJSONScalar(b, v.Scalar, path, strict)
+	return writeJSONScalar(b, v.Scalar, path, strict, diags)
 }
 
 // writeJSONScalar renders one leaf. Per docs/formats/json.md: "a writer
@@ -150,14 +154,14 @@ func writeJSONValue(b *strings.Builder, v omnist.Value, path string, strict bool
 // reaching this function was built by omnist.NewIntegerScalar (which always
 // copies a non-nil *big.Int) or produced by ReadJSON, neither of which
 // ever leaves Int nil for KindInteger.
-func writeJSONScalar(b *strings.Builder, s omnist.Scalar, path string, strict bool) error {
+func writeJSONScalar(b *strings.Builder, s omnist.Scalar, path string, strict bool, diags *[]omnist.Diagnostic) error {
 	switch s.Kind {
 	case omnist.KindString:
 		writeJSONString(b, s.Str)
 	case omnist.KindInteger:
 		b.WriteString(s.Int.String())
 	case omnist.KindNumber:
-		return writeJSONNumber(b, s.Num, path, strict)
+		return writeJSONNumber(b, s.Num, path, strict, diags)
 	case omnist.KindBoolean:
 		if s.Bool {
 			b.WriteString("true")
@@ -166,10 +170,28 @@ func writeJSONScalar(b *strings.Builder, s omnist.Scalar, path string, strict bo
 		}
 	case omnist.KindDate:
 		writeJSONString(b, omnist.FormatISODate(s.Date))
+		*diags = append(*diags, omnist.Diagnostic{
+			Path:     path,
+			Code:     omnist.CodeFormatTemporalStringified,
+			Message:  "a date leaf has no native JSON representation, so it is stringified to ISO-8601",
+			Severity: omnist.SeverityWarning,
+		})
 	case omnist.KindTime:
 		writeJSONString(b, omnist.FormatISOTime(s.Time))
+		*diags = append(*diags, omnist.Diagnostic{
+			Path:     path,
+			Code:     omnist.CodeFormatTemporalStringified,
+			Message:  "a time leaf has no native JSON representation, so it is stringified to ISO-8601",
+			Severity: omnist.SeverityWarning,
+		})
 	case omnist.KindDateTime:
 		writeJSONString(b, omnist.FormatISODate(s.DateTime.Date)+"T"+omnist.FormatISOTime(s.DateTime.Time))
+		*diags = append(*diags, omnist.Diagnostic{
+			Path:     path,
+			Code:     omnist.CodeFormatTemporalStringified,
+			Message:  "a datetime leaf has no native JSON representation, so it is stringified to ISO-8601",
+			Severity: omnist.SeverityWarning,
+		})
 	}
 	return nil
 }
@@ -182,7 +204,7 @@ func writeJSONScalar(b *strings.Builder, s omnist.Scalar, path string, strict bo
 // round-trip. NaN/Infinity have no valid JSON spelling at all (spec: "not
 // valid JSON... a writer MUST NOT emit them"); the default lenient mode
 // substitutes `null`, strict mode fails with write.unsupported-value.
-func writeJSONNumber(b *strings.Builder, f float64, path string, strict bool) error {
+func writeJSONNumber(b *strings.Builder, f float64, path string, strict bool, diags *[]omnist.Diagnostic) error {
 	if math.IsNaN(f) || math.IsInf(f, 0) {
 		if strict {
 			return omnist.Diagnostic{
@@ -193,6 +215,12 @@ func writeJSONNumber(b *strings.Builder, f float64, path string, strict bool) er
 			}
 		}
 		b.WriteString("null")
+		*diags = append(*diags, omnist.Diagnostic{
+			Path:     path,
+			Code:     omnist.CodeFormatFloatSpecial,
+			Message:  "NaN/Infinity has no JSON representation, so it is substituted with null",
+			Severity: omnist.SeverityError,
+		})
 		return nil
 	}
 	s := strconv.FormatFloat(f, 'g', -1, 64)

--- a/formats/json/json_writer_test.go
+++ b/formats/json/json_writer_test.go
@@ -16,7 +16,7 @@ func TestWriteJSONGroupingAndCountOne(t *testing.T) {
 		AddValue("m", omnist.ScalarValue(omnist.NewStringScalar("A"))).
 		AddValue("x", omnist.ScalarValue(omnist.NewStringScalar("X"))).
 		AddValue("m", omnist.ScalarValue(omnist.NewStringScalar("B"))))
-	got, err := Write(doc)
+	got, _, err := Write(doc)
 	if err != nil {
 		t.Fatalf("WriteJSON failed: %v", err)
 	}
@@ -30,7 +30,7 @@ func TestWriteJSONGroupingAndCountOne(t *testing.T) {
 
 func TestWriteJSONSingleLabelIsBareValueNotList(t *testing.T) {
 	doc := omnist.NodeDocument(omnist.NewNode().AddValue("tag", omnist.ScalarValue(omnist.NewStringScalar("x"))))
-	got, err := Write(doc)
+	got, _, err := Write(doc)
 	if err != nil {
 		t.Fatalf("WriteJSON failed: %v", err)
 	}
@@ -49,13 +49,33 @@ func TestWriteJSONTemporalStringified(t *testing.T) {
 			Date: omnist.DateValue{Year: 2024, Month: 1, Day: 2},
 			Time: omnist.TimeValue{Hour: 10, Minute: 30, Second: 5, Nanosecond: 250000000},
 		}))))
-	got, err := Write(doc)
+	got, diags, err := Write(doc)
 	if err != nil {
 		t.Fatalf("WriteJSON failed: %v", err)
 	}
 	want := `{"d": "2024-01-02", "t": "10:30", "dt": "2024-01-02T10:30:05.25"}`
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
+	}
+
+	// Issue #49: each of the three stringified temporal leaves is now
+	// reported as a format.temporal-stringified adjustment alongside the
+	// successful write (spec §8.5.3).
+	wantPaths := map[string]bool{"$.d": true, "$.t": true, "$.dt": true}
+	if len(diags) != len(wantPaths) {
+		t.Fatalf("diags = %v, want exactly one per temporal leaf (%v)", diags, wantPaths)
+	}
+	for _, d := range diags {
+		if d.Code != omnist.CodeFormatTemporalStringified {
+			t.Errorf("diagnostic code = %s, want %s", d.Code, omnist.CodeFormatTemporalStringified)
+		}
+		if !wantPaths[d.Path] {
+			t.Errorf("unexpected diagnostic path %q", d.Path)
+		}
+		delete(wantPaths, d.Path)
+	}
+	if len(wantPaths) != 0 {
+		t.Errorf("missing diagnostics for paths %v", wantPaths)
 	}
 
 	// A writer MUST stringify; the result is plain omnist.KindString on read back
@@ -92,7 +112,7 @@ func TestWriteJSONTimeVariants(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			doc := omnist.ValueDocument(omnist.ScalarValue(omnist.NewTimeScalar(tc.tv)))
-			got, err := Write(doc)
+			got, _, err := Write(doc)
 			if err != nil {
 				t.Fatalf("WriteJSON failed: %v", err)
 			}
@@ -121,13 +141,24 @@ func TestWriteJSONNaNInfinitySubstitutesNull(t *testing.T) {
 				AddValue("before", omnist.ScalarValue(omnist.NewStringScalar("kept"))).
 				AddValue("n", omnist.ScalarValue(omnist.NewNumberScalar(tc.num))).
 				AddValue("after", omnist.ScalarValue(omnist.NewIntegerScalar(big.NewInt(7)))))
-			got, err := Write(doc)
+			got, diags, err := Write(doc)
 			if err != nil {
 				t.Fatalf("WriteJSON failed: %v", err)
 			}
 			want := `{"before": "kept", "n": null, "after": 7}`
 			if got != want {
 				t.Errorf("got %q, want %q (rest of the document must be otherwise unaffected)", got, want)
+			}
+			// Issue #49: the substitution is now reported alongside the
+			// successful write (spec §8.5.3).
+			if len(diags) != 1 {
+				t.Fatalf("diags = %v, want exactly one diagnostic", diags)
+			}
+			if diags[0].Code != omnist.CodeFormatFloatSpecial {
+				t.Errorf("diagnostic code = %s, want %s", diags[0].Code, omnist.CodeFormatFloatSpecial)
+			}
+			if diags[0].Path != "$.n" {
+				t.Errorf("diagnostic path = %s, want $.n", diags[0].Path)
 			}
 		})
 	}
@@ -139,7 +170,7 @@ func TestWriteJSONStrictFailsOnNaNInfinity(t *testing.T) {
 	cases := []float64{math.NaN(), math.Inf(1), math.Inf(-1)}
 	for _, num := range cases {
 		doc := omnist.NodeDocument(omnist.NewNode().AddValue("n", omnist.ScalarValue(omnist.NewNumberScalar(num))))
-		_, err := WriteStrict(doc)
+		_, _, err := WriteStrict(doc)
 		if err == nil {
 			t.Fatalf("WriteStrict(%v) succeeded, want an error", num)
 		}
@@ -163,7 +194,7 @@ func TestWriteJSONStrictFailsOnNaNInfinityInsideList(t *testing.T) {
 	doc := omnist.NodeDocument(omnist.NewNode().
 		AddValue("n", omnist.ScalarValue(omnist.NewNumberScalar(1))).
 		AddValue("n", omnist.ScalarValue(omnist.NewNumberScalar(math.NaN()))))
-	_, err := WriteStrict(doc)
+	_, _, err := WriteStrict(doc)
 	if err == nil {
 		t.Fatal("expected an error")
 	}
@@ -178,7 +209,7 @@ func TestWriteJSONStrictFailsOnNaNInfinityInsideList(t *testing.T) {
 
 func TestWriteJSONStrictSucceedsOnFiniteValues(t *testing.T) {
 	doc := omnist.NodeDocument(omnist.NewNode().AddValue("n", omnist.ScalarValue(omnist.NewNumberScalar(3.5))))
-	got, err := WriteStrict(doc)
+	got, _, err := WriteStrict(doc)
 	if err != nil {
 		t.Fatalf("WriteJSONStrict failed: %v", err)
 	}
@@ -188,7 +219,7 @@ func TestWriteJSONStrictSucceedsOnFiniteValues(t *testing.T) {
 }
 
 func TestWriteJSONStrictFailsOnBareValueDocument(t *testing.T) {
-	_, err := WriteStrict(omnist.ValueDocument(omnist.ScalarValue(omnist.NewNumberScalar(math.NaN()))))
+	_, _, err := WriteStrict(omnist.ValueDocument(omnist.ScalarValue(omnist.NewNumberScalar(math.NaN()))))
 	if err == nil {
 		t.Fatal("expected an error")
 	}
@@ -202,7 +233,7 @@ func TestWriteJSONStrictFailsOnBareValueDocument(t *testing.T) {
 
 func TestWriteJSONNumberAlwaysDistinctFromInteger(t *testing.T) {
 	doc := omnist.ValueDocument(omnist.ScalarValue(omnist.NewNumberScalar(5)))
-	got, err := Write(doc)
+	got, _, err := Write(doc)
 	if err != nil {
 		t.Fatalf("WriteJSON failed: %v", err)
 	}
@@ -223,7 +254,7 @@ func TestWriteJSONNumberAlwaysDistinctFromInteger(t *testing.T) {
 func TestWriteJSONStringEscaping(t *testing.T) {
 	s := "\"\\\n\r\t\x00\x01\x1f\bg\fh世"
 	doc := omnist.ValueDocument(omnist.ScalarValue(omnist.NewStringScalar(s)))
-	text, err := Write(doc)
+	text, _, err := Write(doc)
 	if err != nil {
 		t.Fatalf("WriteJSON failed: %v", err)
 	}
@@ -260,7 +291,7 @@ func TestWriteJSONBareValueDocument(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := Write(tc.doc)
+			got, _, err := Write(tc.doc)
 			if err != nil {
 				t.Fatalf("WriteJSON failed: %v", err)
 			}
@@ -272,7 +303,7 @@ func TestWriteJSONBareValueDocument(t *testing.T) {
 }
 
 func TestWriteJSONEmptyNode(t *testing.T) {
-	got, err := Write(omnist.NodeDocument(omnist.NewNode()))
+	got, _, err := Write(omnist.NodeDocument(omnist.NewNode()))
 	if err != nil {
 		t.Fatalf("WriteJSON failed: %v", err)
 	}
@@ -283,7 +314,7 @@ func TestWriteJSONEmptyNode(t *testing.T) {
 
 func TestWriteJSONNestedNode(t *testing.T) {
 	doc := omnist.NodeDocument(omnist.NewNode().AddNode("a", omnist.NewNode().AddValue("b", omnist.ScalarValue(omnist.NewIntegerScalar(big.NewInt(1))))))
-	got, err := Write(doc)
+	got, _, err := Write(doc)
 	if err != nil {
 		t.Fatalf("WriteJSON failed: %v", err)
 	}

--- a/formats/toml/toml_writer.go
+++ b/formats/toml/toml_writer.go
@@ -55,15 +55,27 @@ import (
 // adjustment rather than inventing a representation." Unlike WriteJSON's
 // NaN/Infinity substitution (which has a lenient default and a strict
 // opt-in that fails instead), TOML has no lenient option to fall back to
-// here — there is no spelling of any kind, not even a lossy one, so this
-// writer's only choice is to fail. It does so by returning a omnist.Diagnostic
-// (omnist.CodeFormatNullUnrepresentable, spec §8.3.8, the code's own defined
-// warning severity, carrying the omnist.Document path to the offending leaf) the
-// first time it encounters a null anywhere in the tree — this is the
-// same "return the omnist.Diagnostic itself as the error" mechanism
-// WriteJSONStrict already uses for its own hard-failure case
-// (write.unsupported-value), applied here to the one case TOML's writer
-// has no lenient mode for at all.
+// here — there is no spelling of any kind, not even a lossy one. But
+// per spec §8.5.3, write is the one operation where a successful
+// `{ok: true, ...}` result and a non-empty diagnostics list coexist: the
+// rest of the document can still be written faithfully around a null
+// leaf, so this writer drops the null leaf (per docs/formats/toml.md's
+// own wording, "cannot be written... and is omitted") and reports it as
+// a omnist.Diagnostic (omnist.CodeFormatNullUnrepresentable, spec §8.3.8,
+// warning severity, carrying the omnist.Document path to the offending
+// leaf) rather than failing the whole write. A single-child group whose
+// one value is null omits the entire `key = value` line (there is
+// nothing left to assign the key to); a null inside a multi-child group
+// (an array) instead just omits that one element, keeping the rest of
+// the array intact — see writeTOMLGroupValue.
+//
+// This is different from strict mode's behavior (spec: "Implementations
+// MAY offer a strict mode that fails outright instead"): this repository
+// has no strict-mode parameter on Write today (tracked separately, see
+// tools/conformance/drivers.go's runWrite skip for
+// formats-toml/nulls/strict-mode-refuses-to-write-instead-of-omitting) —
+// out of scope for this change, which is about the diagnostics channel,
+// not adding a new write mode.
 //
 // # Bare-scalar-root: a real error, not malformed output
 //
@@ -73,9 +85,9 @@ import (
 // table header. Write checks d.IsNode before writing anything and
 // fails immediately (omnist.CodeWriteUnsupportedValue) if the root is a scalar
 // omnist.Value rather than a omnist.Node, rather than producing any output at all.
-func Write(d omnist.Document) (string, error) {
+func Write(d omnist.Document) (string, []omnist.Diagnostic, error) {
 	if !d.IsNode {
-		return "", omnist.Diagnostic{
+		return "", nil, omnist.Diagnostic{
 			Path:     "$",
 			Code:     omnist.CodeWriteUnsupportedValue,
 			Message:  "a TOML document's top level must be a table; a bare scalar omnist.Document has no TOML spelling",
@@ -83,10 +95,9 @@ func Write(d omnist.Document) (string, error) {
 		}
 	}
 	var b strings.Builder
-	if err := writeTOMLTopLevel(&b, d.Node); err != nil {
-		return "", err
-	}
-	return b.String(), nil
+	var diags []omnist.Diagnostic
+	writeTOMLTopLevel(&b, d.Node, &diags)
+	return b.String(), diags, nil
 }
 
 // tomlGroup mirrors jsonGroup/yamlGroup (json_writer.go/yaml_writer.go):
@@ -115,77 +126,111 @@ func groupTOMLEdges(n *omnist.Node) []tomlGroup {
 // document root: one `key = value` (or `key = [values]`) line per group,
 // per the grouping and count-1 rules — see Write's doc comment for
 // why nested tables are written as inline-table values here rather than
-// `[section]` headers.
-func writeTOMLTopLevel(b *strings.Builder, n *omnist.Node) error {
+// `[section]` headers, and for the null-drop reasoning below.
+func writeTOMLTopLevel(b *strings.Builder, n *omnist.Node, diags *[]omnist.Diagnostic) {
 	groups := groupTOMLEdges(n)
 	for _, g := range groups {
+		var vb strings.Builder
+		if !writeTOMLGroupValue(&vb, g, "$."+g.label, diags) {
+			// The group's one child was a null leaf with no TOML
+			// spelling at all — see Write's doc comment. There is
+			// nothing to assign the key to, so the whole `key = value`
+			// line is omitted (the diagnostic was already recorded by
+			// writeTOMLGroupValue/writeTOMLTargetOptional).
+			continue
+		}
 		writeTOMLKey(b, g.label)
 		b.WriteString(" = ")
-		if err := writeTOMLGroupValue(b, g, "$."+g.label); err != nil {
-			return err
-		}
+		b.WriteString(vb.String())
 		b.WriteByte('\n')
 	}
-	return nil
 }
 
 // writeTOMLGroupValue renders one group's value per §7.3.1's count-1
 // rule: a bare rendering of the single target when the group has exactly
-// one child, an inline array of renderings otherwise.
-func writeTOMLGroupValue(b *strings.Builder, g tomlGroup, path string) error {
+// one child, an inline array of renderings otherwise. The returned bool
+// reports whether anything was written at all — false only for a
+// single-child group whose one child is a dropped null leaf (see Write's
+// doc comment); a multi-child group always writes an array (possibly
+// missing some of its null elements, never entirely omitted, since a
+// `key = []` is a valid, faithful rendering of "some elements dropped").
+//
+// This (and writeTOMLTargetOptional/writeTOMLInlineTable below) carries
+// no error return: since the null-drop case became a diagnostic rather
+// than a hard failure, nothing below the root can fail at all — TOML's
+// only failure mode (a bare-scalar document root) is checked once, in
+// Write, before any of this is ever called.
+func writeTOMLGroupValue(b *strings.Builder, g tomlGroup, path string, diags *[]omnist.Diagnostic) bool {
 	if len(g.children) == 1 {
-		return writeTOMLTarget(b, g.children[0], path)
+		return writeTOMLTargetOptional(b, g.children[0], path, diags)
 	}
 	b.WriteByte('[')
+	first := true
 	for i, t := range g.children {
-		if i > 0 {
+		var eb strings.Builder
+		if !writeTOMLTargetOptional(&eb, t, fmt.Sprintf("%s[%d]", path, i), diags) {
+			continue
+		}
+		if !first {
 			b.WriteString(", ")
 		}
-		if err := writeTOMLTarget(b, t, fmt.Sprintf("%s[%d]", path, i)); err != nil {
-			return err
-		}
+		b.WriteString(eb.String())
+		first = false
 	}
 	b.WriteByte(']')
-	return nil
+	return true
 }
 
-// writeTOMLTarget renders one Target: an inline table for a omnist.Node, a
-// scalar literal (or the null failure) for a omnist.Value.
-func writeTOMLTarget(b *strings.Builder, t omnist.Target, path string) error {
+// writeTOMLTargetOptional renders one Target: an inline table for a
+// omnist.Node, a scalar literal for a non-null omnist.Value. A null
+// omnist.Value has no TOML spelling at all (see Write's doc comment); it
+// writes nothing, records the format.null-unrepresentable diagnostic, and
+// reports false so the caller (writeTOMLGroupValue/writeTOMLTopLevel)
+// knows to drop the key or the array element rather than emit an empty
+// placeholder.
+func writeTOMLTargetOptional(b *strings.Builder, t omnist.Target, path string, diags *[]omnist.Diagnostic) bool {
 	if node, ok := t.Node(); ok {
-		return writeTOMLInlineTable(b, node, path)
+		writeTOMLInlineTable(b, node, path, diags)
+		return true
 	}
 	v, _ := t.Value()
 	if v.IsNull {
-		return omnist.Diagnostic{
+		*diags = append(*diags, omnist.Diagnostic{
 			Path:     path,
 			Code:     omnist.CodeFormatNullUnrepresentable,
 			Message:  "a null leaf cannot be written in TOML, so it is dropped",
 			Severity: omnist.SeverityWarning,
-		}
+		})
+		return false
 	}
 	writeTOMLScalar(b, v.Scalar)
-	return nil
+	return true
 }
 
 // writeTOMLInlineTable renders n as a TOML inline table (`{k = v, ...}`),
 // applying the same grouping/count-1 rules writeTOMLTopLevel applies at
 // the root — an inline table is exactly a nested write(node, format).
-func writeTOMLInlineTable(b *strings.Builder, n *omnist.Node, path string) error {
+// Mirroring writeTOMLTopLevel, a group whose value is entirely dropped
+// (a single null child) omits its `k = v` entry from the table rather
+// than leaving a dangling key.
+func writeTOMLInlineTable(b *strings.Builder, n *omnist.Node, path string, diags *[]omnist.Diagnostic) {
 	groups := groupTOMLEdges(n)
 	b.WriteByte('{')
-	for i, g := range groups {
-		if i > 0 {
+	first := true
+	for _, g := range groups {
+		var vb strings.Builder
+		if !writeTOMLGroupValue(&vb, g, path+"."+g.label, diags) {
+			continue
+		}
+		if !first {
 			b.WriteString(", ")
 		}
 		writeTOMLKey(b, g.label)
 		b.WriteString(" = ")
-		if err := writeTOMLGroupValue(b, g, path+"."+g.label); err != nil {
-			return err
-		}
+		b.WriteString(vb.String())
+		first = false
 	}
 	b.WriteByte('}')
-	return nil
 }
 
 // writeTOMLKey renders a label as a TOML quoted (basic string) key,

--- a/formats/toml/toml_writer_test.go
+++ b/formats/toml/toml_writer_test.go
@@ -14,7 +14,7 @@ func TestWriteTOMLGroupingAndCountOne(t *testing.T) {
 		AddValue("a", omnist.ScalarValue(omnist.NewIntegerScalar(big.NewInt(1)))).
 		AddValue("m", omnist.ScalarValue(omnist.NewStringScalar("A"))).
 		AddValue("m", omnist.ScalarValue(omnist.NewStringScalar("B"))))
-	out, err := Write(d)
+	out, _, err := Write(d)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -32,7 +32,7 @@ func TestWriteTOMLGroupingAndCountOne(t *testing.T) {
 
 func TestWriteTOMLSingleLabelIsBareValueNotList(t *testing.T) {
 	d := omnist.NodeDocument(omnist.NewNode().AddValue("a", omnist.ScalarValue(omnist.NewIntegerScalar(big.NewInt(1)))))
-	out, err := Write(d)
+	out, _, err := Write(d)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -61,7 +61,7 @@ func TestWriteTOMLRoundTripsWorkedExample(t *testing.T) {
 		AddNode("items", item2)
 	d := omnist.NodeDocument(omnist.NewNode().AddNode("order", order))
 
-	out, err := Write(d)
+	out, _, err := Write(d)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -84,7 +84,7 @@ func TestWriteTOMLTemporalRoundTripAllThreeKinds(t *testing.T) {
 			Date: omnist.DateValue{Year: 2024, Month: 1, Day: 1},
 			Time: omnist.TimeValue{Hour: 12},
 		}))))
-	out, err := Write(d)
+	out, _, err := Write(d)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -120,7 +120,7 @@ func TestWriteTOMLOffsetDateTimeRoundTrips(t *testing.T) {
 		Date: omnist.DateValue{Year: 2024, Month: 1, Day: 1},
 		Time: omnist.TimeValue{Hour: 12, Minute: 0, Second: 0, HasOffset: true, OffsetSeconds: 5*3600 + 30*60},
 	}))))
-	out, err := Write(d)
+	out, _, err := Write(d)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -135,16 +135,24 @@ func TestWriteTOMLOffsetDateTimeRoundTrips(t *testing.T) {
 
 // --- null: write-time adjustment, reported not invented ---
 
+// Since issue #49, a null leaf is a non-fatal write-time adjustment: the
+// write still succeeds (err == nil), the null is dropped from the
+// output, and the drop is reported via the returned []omnist.Diagnostic
+// rather than aborting the whole write (spec §8.5.3's write-only
+// ok:true+diagnostics coexistence).
 func TestWriteTOMLNullReportsAdjustment(t *testing.T) {
 	d := omnist.NodeDocument(omnist.NewNode().AddValue("coupon", omnist.NullValue()))
-	_, err := Write(d)
-	if err == nil {
-		t.Fatal("expected an error: TOML has no null spelling")
+	out, diags, err := Write(d)
+	if err != nil {
+		t.Fatalf("Write: unexpected error: %v", err)
 	}
-	diag, ok := err.(omnist.Diagnostic)
-	if !ok {
-		t.Fatalf("error is %T, want omnist.Diagnostic", err)
+	if out != "" {
+		t.Errorf("out = %q, want empty (the only key was a dropped null)", out)
 	}
+	if len(diags) != 1 {
+		t.Fatalf("diags = %v, want exactly one diagnostic", diags)
+	}
+	diag := diags[0]
 	if diag.Code != omnist.CodeFormatNullUnrepresentable {
 		t.Errorf("omnist.Diagnostic.Code = %s, want %s", diag.Code, omnist.CodeFormatNullUnrepresentable)
 	}
@@ -158,13 +166,18 @@ func TestWriteTOMLNullReportsAdjustment(t *testing.T) {
 
 func TestWriteTOMLNullInsideNestedNodeReportsAdjustment(t *testing.T) {
 	d := omnist.NodeDocument(omnist.NewNode().AddNode("order", omnist.NewNode().AddValue("coupon", omnist.NullValue())))
-	_, err := Write(d)
-	diag, ok := err.(omnist.Diagnostic)
-	if !ok {
-		t.Fatalf("error is %T, want omnist.Diagnostic", err)
+	out, diags, err := Write(d)
+	if err != nil {
+		t.Fatalf("Write: unexpected error: %v", err)
 	}
-	if diag.Path != "$.order.coupon" {
-		t.Errorf("omnist.Diagnostic.Path = %s, want $.order.coupon", diag.Path)
+	if out != `"order" = {}`+"\n" {
+		t.Errorf("out = %q, want the order table with its only key (the dropped null) omitted", out)
+	}
+	if len(diags) != 1 {
+		t.Fatalf("diags = %v, want exactly one diagnostic", diags)
+	}
+	if diags[0].Path != "$.order.coupon" {
+		t.Errorf("omnist.Diagnostic.Path = %s, want $.order.coupon", diags[0].Path)
 	}
 }
 
@@ -172,16 +185,21 @@ func TestWriteTOMLNullInsideListReportsAdjustment(t *testing.T) {
 	d := omnist.NodeDocument(omnist.NewNode().
 		AddValue("m", omnist.ScalarValue(omnist.NewStringScalar("A"))).
 		AddValue("m", omnist.NullValue()))
-	_, err := Write(d)
-	diag, ok := err.(omnist.Diagnostic)
-	if !ok {
-		t.Fatalf("error is %T, want omnist.Diagnostic", err)
+	out, diags, err := Write(d)
+	if err != nil {
+		t.Fatalf("Write: unexpected error: %v", err)
 	}
-	if diag.Code != omnist.CodeFormatNullUnrepresentable {
-		t.Errorf("omnist.Diagnostic.Code = %s, want %s", diag.Code, omnist.CodeFormatNullUnrepresentable)
+	if out != `"m" = ["A"]`+"\n" {
+		t.Errorf("out = %q, want the array with its dropped null element omitted", out)
 	}
-	if diag.Path != "$.m[1]" {
-		t.Errorf("omnist.Diagnostic.Path = %s, want $.m[1]", diag.Path)
+	if len(diags) != 1 {
+		t.Fatalf("diags = %v, want exactly one diagnostic", diags)
+	}
+	if diags[0].Code != omnist.CodeFormatNullUnrepresentable {
+		t.Errorf("omnist.Diagnostic.Code = %s, want %s", diags[0].Code, omnist.CodeFormatNullUnrepresentable)
+	}
+	if diags[0].Path != "$.m[1]" {
+		t.Errorf("omnist.Diagnostic.Path = %s, want $.m[1]", diags[0].Path)
 	}
 }
 
@@ -189,7 +207,7 @@ func TestWriteTOMLNullInsideListReportsAdjustment(t *testing.T) {
 
 func TestWriteTOMLBareScalarRootFails(t *testing.T) {
 	d := omnist.ValueDocument(omnist.ScalarValue(omnist.NewStringScalar("x")))
-	_, err := Write(d)
+	_, _, err := Write(d)
 	if err == nil {
 		t.Fatal("expected an error: TOML has no bare-scalar-root spelling")
 	}
@@ -208,7 +226,7 @@ func TestWriteTOMLNumberAlwaysDistinctFromInteger(t *testing.T) {
 	d := omnist.NodeDocument(omnist.NewNode().
 		AddValue("i", omnist.ScalarValue(omnist.NewIntegerScalar(big.NewInt(2)))).
 		AddValue("f", omnist.ScalarValue(omnist.NewNumberScalar(2.0))))
-	out, err := Write(d)
+	out, _, err := Write(d)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -226,7 +244,7 @@ func TestWriteTOMLNaNInfinityNativeSpellings(t *testing.T) {
 		AddValue("a", omnist.ScalarValue(omnist.NewNumberScalar(math.NaN()))).
 		AddValue("b", omnist.ScalarValue(omnist.NewNumberScalar(math.Inf(1)))).
 		AddValue("c", omnist.ScalarValue(omnist.NewNumberScalar(math.Inf(-1)))))
-	out, err := Write(d)
+	out, _, err := Write(d)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -245,7 +263,7 @@ func TestWriteTOMLBareTimeWithOffsetDropsOffset(t *testing.T) {
 	d := omnist.NodeDocument(omnist.NewNode().AddValue("t", omnist.ScalarValue(omnist.NewTimeScalar(omnist.TimeValue{
 		Hour: 12, Minute: 0, Second: 0, HasOffset: true, OffsetSeconds: 3600,
 	}))))
-	out, err := Write(d)
+	out, _, err := Write(d)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -263,7 +281,7 @@ func TestWriteTOMLBareTimeWithOffsetDropsOffset(t *testing.T) {
 
 func TestWriteTOMLStringEscaping(t *testing.T) {
 	d := omnist.NodeDocument(omnist.NewNode().AddValue("s", omnist.ScalarValue(omnist.NewStringScalar("a\nb\tc\"d\\e\bf\rg\fh\x01i"))))
-	out, err := Write(d)
+	out, _, err := Write(d)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -280,7 +298,7 @@ func TestWriteTOMLStringEscaping(t *testing.T) {
 
 func TestWriteTOMLQuotesEveryKey(t *testing.T) {
 	d := omnist.NodeDocument(omnist.NewNode().AddValue("has space", omnist.ScalarValue(omnist.NewIntegerScalar(big.NewInt(1)))))
-	out, err := Write(d)
+	out, _, err := Write(d)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -299,7 +317,7 @@ func TestWriteTOMLBooleans(t *testing.T) {
 	d := omnist.NodeDocument(omnist.NewNode().
 		AddValue("t", omnist.ScalarValue(omnist.NewBooleanScalar(true))).
 		AddValue("f", omnist.ScalarValue(omnist.NewBooleanScalar(false))))
-	out, err := Write(d)
+	out, _, err := Write(d)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -316,7 +334,7 @@ func TestWriteTOMLBooleans(t *testing.T) {
 
 func TestWriteTOMLEmptyNode(t *testing.T) {
 	d := omnist.NodeDocument(omnist.NewNode())
-	out, err := Write(d)
+	out, _, err := Write(d)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -329,7 +347,7 @@ func TestWriteTOMLEmptyNode(t *testing.T) {
 
 func TestWriteTOMLNestedNode(t *testing.T) {
 	d := omnist.NodeDocument(omnist.NewNode().AddNode("a", omnist.NewNode().AddValue("b", omnist.ScalarValue(omnist.NewIntegerScalar(big.NewInt(1))))))
-	out, err := Write(d)
+	out, _, err := Write(d)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/formats/xml/xml_writer.go
+++ b/formats/xml/xml_writer.go
@@ -60,9 +60,9 @@ import (
 // writing anything and fails immediately (omnist.CodeWriteUnsupportedValue,
 // staying consistent with WriteTOML's identical call) if the root is a
 // scalar omnist.Value rather than a omnist.Node.
-func Write(d omnist.Document) (string, error) {
+func Write(d omnist.Document) (string, []omnist.Diagnostic, error) {
 	if !d.IsNode {
-		return "", omnist.Diagnostic{
+		return "", nil, omnist.Diagnostic{
 			Path:     "$",
 			Code:     omnist.CodeWriteUnsupportedValue,
 			Message:  "an XML document's top level must be a single element; a bare scalar omnist.Document has no XML spelling",
@@ -71,7 +71,7 @@ func Write(d omnist.Document) (string, error) {
 	}
 	switch len(d.Node.Edges) {
 	case 0:
-		return "", omnist.Diagnostic{
+		return "", nil, omnist.Diagnostic{
 			Path:     "$",
 			Code:     omnist.CodeWriteUnsupportedValue,
 			Message:  "an XML document needs exactly one top-level element; this omnist.Document has none",
@@ -80,7 +80,7 @@ func Write(d omnist.Document) (string, error) {
 	case 1:
 		// fall through
 	default:
-		return "", omnist.Diagnostic{
+		return "", nil, omnist.Diagnostic{
 			Path:     "$",
 			Code:     omnist.CodeFormatMultipleRoots,
 			Message:  "an XML document needs exactly one top-level element; this omnist.Document has more than one top-level edge",
@@ -90,10 +90,11 @@ func Write(d omnist.Document) (string, error) {
 
 	root := d.Node.Edges[0]
 	var b strings.Builder
-	if err := writeXMLElement(&b, root.Label, root.Target, "$."+root.Label); err != nil {
-		return "", err
+	var diags []omnist.Diagnostic
+	if err := writeXMLElement(&b, root.Label, root.Target, "$."+root.Label, &diags); err != nil {
+		return "", nil, err
 	}
-	return b.String(), nil
+	return b.String(), diags, nil
 }
 
 // writeXMLElement renders one omnist.Edge as a `<label>...</label>` element (or
@@ -103,7 +104,7 @@ func Write(d omnist.Document) (string, error) {
 // empty-string omnist.KindString leaf, and encxml.EscapeText writes nothing for an
 // empty byte slice, so the element naturally comes out as `<label></label>`
 // either way; nothing here special-cases self-closing form specifically).
-func writeXMLElement(b *strings.Builder, label string, t omnist.Target, path string) error {
+func writeXMLElement(b *strings.Builder, label string, t omnist.Target, path string, diags *[]omnist.Diagnostic) error {
 	if !isValidXMLName(label) {
 		return omnist.Diagnostic{
 			Path:     path,
@@ -118,7 +119,7 @@ func writeXMLElement(b *strings.Builder, label string, t omnist.Target, path str
 		b.WriteString(label)
 		b.WriteByte('>')
 		for _, e := range node.Edges {
-			if err := writeXMLElement(b, e.Label, e.Target, path+"."+e.Label); err != nil {
+			if err := writeXMLElement(b, e.Label, e.Target, path+"."+e.Label, diags); err != nil {
 				return err
 			}
 		}
@@ -141,17 +142,22 @@ func writeXMLElement(b *strings.Builder, label string, t omnist.Target, path str
 		// same warning-severity adjustment code TOML's writer already
 		// uses for "this leaf has no representation in this format, so it
 		// is written as empty/dropped", applied to XML's own empty-element
-		// spelling instead of TOML's outright omission.
-		diag := omnist.Diagnostic{
+		// spelling instead of TOML's outright omission. Unlike TOML
+		// (which has no spelling at all and must drop the leaf), XML's
+		// empty-element spelling is a real, if lossy, representation, so
+		// per spec §8.5.3 (write's ok:true + diagnostics coexistence) this
+		// is now a non-fatal diagnostic rather than a hard failure that
+		// discards the rest of the document.
+		*diags = append(*diags, omnist.Diagnostic{
 			Path:     path,
 			Code:     omnist.CodeFormatNullUnrepresentable,
 			Message:  "a null leaf cannot be written in XML, so it is written as an empty element",
 			Severity: omnist.SeverityWarning,
-		}
+		})
 		b.WriteString("</")
 		b.WriteString(label)
 		b.WriteByte('>')
-		return diag
+		return nil
 	}
 	// encxml.EscapeText's only failure mode is its io.Writer returning an
 	// error; xmlTextWriter wraps a *strings.Builder, whose Write never

--- a/formats/xml/xml_writer_test.go
+++ b/formats/xml/xml_writer_test.go
@@ -18,7 +18,7 @@ func TestWriteXMLPreservesInterleaving(t *testing.T) {
 		AddValue("m", omnist.ScalarValue(omnist.NewStringScalar("B")))
 	d := omnist.NodeDocument(omnist.NewNode().AddNode("root", root))
 
-	out, err := Write(d)
+	out, _, err := Write(d)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -46,7 +46,7 @@ func TestWriteXMLRepeatedElementsNoWrapper(t *testing.T) {
 		AddValue("items", omnist.ScalarValue(omnist.NewStringScalar("b"))).
 		AddValue("items", omnist.ScalarValue(omnist.NewStringScalar("c")))
 	d := omnist.NodeDocument(omnist.NewNode().AddNode("root", root))
-	out, err := Write(d)
+	out, _, err := Write(d)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -62,7 +62,7 @@ func TestWriteXMLRejectsMultipleTopLevelEdges(t *testing.T) {
 	d := omnist.NodeDocument(omnist.NewNode().
 		AddValue("a", omnist.ScalarValue(omnist.NewStringScalar("1"))).
 		AddValue("b", omnist.ScalarValue(omnist.NewStringScalar("2"))))
-	_, err := Write(d)
+	_, _, err := Write(d)
 	if err == nil {
 		t.Fatal("expected an error for multiple top-level edges")
 	}
@@ -77,7 +77,7 @@ func TestWriteXMLRejectsMultipleTopLevelEdges(t *testing.T) {
 
 func TestWriteXMLRejectsEmptyTopLevel(t *testing.T) {
 	d := omnist.NodeDocument(omnist.NewNode())
-	_, err := Write(d)
+	_, _, err := Write(d)
 	if err == nil {
 		t.Fatal("expected an error for a omnist.Document with no top-level edges")
 	}
@@ -91,7 +91,7 @@ func TestWriteXMLRejectsEmptyTopLevel(t *testing.T) {
 
 func TestWriteXMLRejectsBareScalarRoot(t *testing.T) {
 	d := omnist.ValueDocument(omnist.ScalarValue(omnist.NewStringScalar("hi")))
-	_, err := Write(d)
+	_, _, err := Write(d)
 	if err == nil {
 		t.Fatal("expected an error for a bare scalar root")
 	}
@@ -109,7 +109,7 @@ func TestWriteXMLRoundTripsWorkedExample(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	out, err := Write(d)
+	out, _, err := Write(d)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -127,7 +127,7 @@ func TestWriteXMLRoundTripsSelfClosingLeaf(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	out, err := Write(d)
+	out, _, err := Write(d)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -150,7 +150,7 @@ func TestWriteXMLScalarKinds(t *testing.T) {
 		AddValue("bool", omnist.ScalarValue(omnist.NewBooleanScalar(true))).
 		AddValue("date", omnist.ScalarValue(omnist.NewDateScalar(omnist.DateValue{Year: 2024, Month: 1, Day: 15})))
 	d := omnist.NodeDocument(omnist.NewNode().AddNode("root", root))
-	out, err := Write(d)
+	out, _, err := Write(d)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -180,7 +180,7 @@ func TestWriteXMLBooleanFalseAndTemporalKinds(t *testing.T) {
 			Time: omnist.TimeValue{Hour: 9, Minute: 0},
 		})))
 	d := omnist.NodeDocument(omnist.NewNode().AddNode("root", root))
-	out, err := Write(d)
+	out, _, err := Write(d)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -201,7 +201,7 @@ func TestWriteXMLNaNInfinity(t *testing.T) {
 		AddValue("inf", omnist.ScalarValue(omnist.NewNumberScalar(math.Inf(1)))).
 		AddValue("ninf", omnist.ScalarValue(omnist.NewNumberScalar(math.Inf(-1))))
 	d := omnist.NodeDocument(omnist.NewNode().AddNode("root", root))
-	out, err := Write(d)
+	out, _, err := Write(d)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -217,13 +217,19 @@ func TestWriteXMLNaNInfinity(t *testing.T) {
 
 func TestWriteXMLNullLeafReportsAdjustment(t *testing.T) {
 	d := omnist.NodeDocument(omnist.NewNode().AddValue("a", omnist.NullValue()))
-	_, err := Write(d)
-	if err == nil {
-		t.Fatal("expected a omnist.Diagnostic reporting the null adjustment")
+	out, diags, err := Write(d)
+	if err != nil {
+		t.Fatalf("Write: unexpected error: %v", err)
 	}
-	diag, ok := err.(omnist.Diagnostic)
-	if !ok || diag.Code != omnist.CodeFormatNullUnrepresentable {
-		t.Fatalf("got %v (%T), want omnist.CodeFormatNullUnrepresentable", err, err)
+	if out != "<a></a>" {
+		t.Errorf("out = %q, want the null leaf written as an empty element", out)
+	}
+	if len(diags) != 1 {
+		t.Fatalf("diags = %v, want exactly one diagnostic", diags)
+	}
+	diag := diags[0]
+	if diag.Code != omnist.CodeFormatNullUnrepresentable {
+		t.Fatalf("got code %v, want omnist.CodeFormatNullUnrepresentable", diag.Code)
 	}
 	if diag.Severity != omnist.SeverityWarning {
 		t.Errorf("got severity %v, want omnist.SeverityWarning", diag.Severity)
@@ -237,7 +243,7 @@ func TestWriteXMLNullLeafReportsAdjustment(t *testing.T) {
 
 func TestWriteXMLRejectsInvalidLabel(t *testing.T) {
 	d := omnist.NodeDocument(omnist.NewNode().AddValue("1bad", omnist.ScalarValue(omnist.NewStringScalar("x"))))
-	_, err := Write(d)
+	_, _, err := Write(d)
 	if err == nil {
 		t.Fatal("expected an error for an invalid XML element name")
 	}
@@ -249,7 +255,7 @@ func TestWriteXMLRejectsInvalidLabel(t *testing.T) {
 
 func TestWriteXMLRejectsColonInLabel(t *testing.T) {
 	d := omnist.NodeDocument(omnist.NewNode().AddValue("ns:b", omnist.ScalarValue(omnist.NewStringScalar("x"))))
-	_, err := Write(d)
+	_, _, err := Write(d)
 	if err == nil {
 		t.Fatal("expected an error for a colon in a label")
 	}
@@ -259,7 +265,7 @@ func TestWriteXMLAcceptsNestedInvalidLabel(t *testing.T) {
 	// A nested (non-root) label must be validated too, not just the root.
 	inner := omnist.NewNode().AddValue("bad label", omnist.ScalarValue(omnist.NewStringScalar("x")))
 	d := omnist.NodeDocument(omnist.NewNode().AddNode("root", inner))
-	_, err := Write(d)
+	_, _, err := Write(d)
 	if err == nil {
 		t.Fatal("expected an error for an invalid nested label")
 	}

--- a/formats/yaml/yaml_reader_test.go
+++ b/formats/yaml/yaml_reader_test.go
@@ -661,7 +661,7 @@ func TestYAMLRoundTripProperty(t *testing.T) {
 		omnist.ValueDocument(omnist.NullValue()),
 	}
 	for i, d := range cases {
-		out, err := Write(d)
+		out, _, err := Write(d)
 		if err != nil {
 			t.Fatalf("case %d: WriteYAML: %v", i, err)
 		}

--- a/formats/yaml/yaml_writer.go
+++ b/formats/yaml/yaml_writer.go
@@ -1,6 +1,7 @@
 package yaml
 
 import (
+	"fmt"
 	"math"
 	"strconv"
 	"strings"
@@ -64,20 +65,22 @@ import (
 //     today — see the TODO below on why the collection itself isn't wired
 //     up yet, mirroring json_writer.go's identical TODO.
 //
-// The signature returns an error for the same reason WriteJSON's does: a
-// stringification is a reportable adjustment (spec §7.4), not always a
-// silent one, even though nothing below can currently fail (there is no
-// strict/lenient toggle for YAML's time sharp edge — it isn't optional the
-// way JSON's NaN/Infinity substitution is, so there is only one mode).
-// Full diagnostic-collection plumbing is a TODO, exactly as noted on
-// WriteJSON: spec §7.4 says only SHOULD, and no format.* adjustment-
-// reporting mechanism exists elsewhere in this repo yet to hook into.
-func Write(d omnist.Document) (string, error) {
+// The signature returns diagnostics alongside text and error, matching
+// every other writer in this package: a omnist.KindTime stringification is a
+// reportable adjustment (spec §7.4, §8.5.3 — write is the one operation
+// where ok:true and diagnostics coexist), collected here via
+// buildYAMLNode/buildYAMLTarget's diags accumulator and reported with
+// omnist.CodeFormatTemporalStringified. There is no strict/lenient toggle
+// for YAML's time sharp edge — it isn't optional the way JSON's
+// NaN/Infinity substitution is, so there is only one mode and the write
+// itself never fails because of it.
+func Write(d omnist.Document) (string, []omnist.Diagnostic, error) {
 	var root *yamllib.Node
+	var diags []omnist.Diagnostic
 	if d.IsNode {
-		root = buildYAMLNode(d.Node)
+		root = buildYAMLNode(d.Node, "$", &diags)
 	} else {
-		root = buildYAMLTargetScalar(d.Value)
+		root = buildYAMLTargetScalar(d.Value, "$", &diags)
 	}
 	out, err := yamllib.Marshal(root)
 	if err != nil {
@@ -97,9 +100,9 @@ func Write(d omnist.Document) (string, error) {
 		// library's own error is surfaced as-is rather than wrapped in
 		// a omnist.Diagnostic that would overstate precision this package
 		// doesn't actually have here.
-		return "", err
+		return "", nil, err
 	}
-	return string(out), nil
+	return string(out), diags, nil
 }
 
 // yamlGroup mirrors jsonGroup (json_writer.go): one label's worth of
@@ -129,7 +132,7 @@ func groupYAMLEdges(n *omnist.Node) []yamlGroup {
 // group as a bare value when it has exactly one child or as a sequence
 // otherwise (count-1 rule) — the same two rules writeJSONNode applies, on
 // yamllib.Node values instead of directly-written text.
-func buildYAMLNode(n *omnist.Node) *yamllib.Node {
+func buildYAMLNode(n *omnist.Node, path string, diags *[]omnist.Diagnostic) *yamllib.Node {
 	groups := groupYAMLEdges(n)
 	m := &yamllib.Node{Kind: yamllib.MappingNode}
 	for _, g := range groups {
@@ -146,32 +149,33 @@ func buildYAMLNode(n *omnist.Node) *yamllib.Node {
 		// "safe" to leave bare — every label is safe when quoted, with
 		// no exceptions to enumerate or get wrong.
 		m.Content = append(m.Content, &yamllib.Node{Kind: yamllib.ScalarNode, Tag: "!!str", Style: yamllib.DoubleQuotedStyle, Value: g.label})
+		childPath := path + "." + g.label
 		if len(g.children) == 1 {
-			m.Content = append(m.Content, buildYAMLTarget(g.children[0]))
+			m.Content = append(m.Content, buildYAMLTarget(g.children[0], childPath, diags))
 			continue
 		}
 		seq := &yamllib.Node{Kind: yamllib.SequenceNode}
-		for _, t := range g.children {
-			seq.Content = append(seq.Content, buildYAMLTarget(t))
+		for i, t := range g.children {
+			seq.Content = append(seq.Content, buildYAMLTarget(t, fmt.Sprintf("%s[%d]", childPath, i), diags))
 		}
 		m.Content = append(m.Content, seq)
 	}
 	return m
 }
 
-func buildYAMLTarget(t omnist.Target) *yamllib.Node {
+func buildYAMLTarget(t omnist.Target, path string, diags *[]omnist.Diagnostic) *yamllib.Node {
 	if node, ok := t.Node(); ok {
-		return buildYAMLNode(node)
+		return buildYAMLNode(node, path, diags)
 	}
 	v, _ := t.Value()
-	return buildYAMLTargetScalar(v)
+	return buildYAMLTargetScalar(v, path, diags)
 }
 
-func buildYAMLTargetScalar(v omnist.Value) *yamllib.Node {
+func buildYAMLTargetScalar(v omnist.Value, path string, diags *[]omnist.Diagnostic) *yamllib.Node {
 	if v.IsNull {
 		return &yamllib.Node{Kind: yamllib.ScalarNode, Tag: "!!null", Value: "null"}
 	}
-	return buildYAMLScalar(v.Scalar)
+	return buildYAMLScalar(v.Scalar, path, diags)
 }
 
 // buildYAMLScalar renders one leaf as a yamllib.Node, deciding bare-vs-quoted
@@ -198,7 +202,7 @@ func buildYAMLTargetScalar(v omnist.Value) *yamllib.Node {
 //     Write's doc comment).
 //   - omnist.KindTime is double-quoted (forced to string on read-back — see
 //     Write's doc comment for why this is the one unavoidable case).
-func buildYAMLScalar(s omnist.Scalar) *yamllib.Node {
+func buildYAMLScalar(s omnist.Scalar, path string, diags *[]omnist.Diagnostic) *yamllib.Node {
 	switch s.Kind {
 	case omnist.KindString:
 		return &yamllib.Node{Kind: yamllib.ScalarNode, Tag: "!!str", Style: yamllib.DoubleQuotedStyle, Value: s.Str}
@@ -215,6 +219,12 @@ func buildYAMLScalar(s omnist.Scalar) *yamllib.Node {
 	case omnist.KindDate:
 		return &yamllib.Node{Kind: yamllib.ScalarNode, Tag: "!!timestamp", Value: omnist.FormatISODate(s.Date)}
 	case omnist.KindTime:
+		*diags = append(*diags, omnist.Diagnostic{
+			Path:     path,
+			Code:     omnist.CodeFormatTemporalStringified,
+			Message:  "YAML's core schema has no standalone time type, so a bare time-of-day leaf is quoted (forced to string on read-back) instead",
+			Severity: omnist.SeverityWarning,
+		})
 		return &yamllib.Node{Kind: yamllib.ScalarNode, Tag: "!!str", Style: yamllib.DoubleQuotedStyle, Value: omnist.FormatISOTime(s.Time)}
 	default: // omnist.KindDateTime
 		return &yamllib.Node{Kind: yamllib.ScalarNode, Tag: "!!timestamp", Value: omnist.FormatISODate(s.DateTime.Date) + "T" + omnist.FormatISOTime(s.DateTime.Time)}

--- a/formats/yaml/yaml_writer_test.go
+++ b/formats/yaml/yaml_writer_test.go
@@ -16,7 +16,7 @@ func TestWriteYAMLGroupingAndCountOne(t *testing.T) {
 		omnist.Edge{Label: "x", Target: omnist.ValueTarget(omnist.ScalarValue(omnist.NewStringScalar("X")))},
 		omnist.Edge{Label: "m", Target: omnist.ValueTarget(omnist.ScalarValue(omnist.NewStringScalar("B")))},
 	)
-	out, err := Write(omnist.NodeDocument(n))
+	out, _, err := Write(omnist.NodeDocument(n))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -35,7 +35,7 @@ func TestWriteYAMLGroupingAndCountOne(t *testing.T) {
 
 func TestWriteYAMLSingleLabelIsBareValueNotList(t *testing.T) {
 	n := omnist.NewNode().AddValue("tag", omnist.ScalarValue(omnist.NewStringScalar("x")))
-	out, err := Write(omnist.NodeDocument(n))
+	out, _, err := Write(omnist.NodeDocument(n))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -60,7 +60,7 @@ func TestWriteYAMLSingleLabelIsBareValueNotList(t *testing.T) {
 
 func TestWriteYAMLDateWrittenBareAndRoundTripsAsDate(t *testing.T) {
 	d := omnist.NodeDocument(omnist.NewNode().AddValue("d", omnist.ScalarValue(omnist.NewDateScalar(omnist.DateValue{Year: 2024, Month: 1, Day: 1}))))
-	out, err := Write(d)
+	out, _, err := Write(d)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -79,7 +79,7 @@ func TestWriteYAMLDateWrittenBareAndRoundTripsAsDate(t *testing.T) {
 func TestWriteYAMLDateTimeWrittenBareAndRoundTripsAsDateTime(t *testing.T) {
 	dt := omnist.DateTimeValue{Date: omnist.DateValue{Year: 2024, Month: 1, Day: 1}, Time: omnist.TimeValue{Hour: 12, Minute: 30}}
 	d := omnist.NodeDocument(omnist.NewNode().AddValue("dt", omnist.ScalarValue(omnist.NewDateTimeScalar(dt))))
-	out, err := Write(d)
+	out, _, err := Write(d)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -104,12 +104,23 @@ func TestWriteYAMLDateTimeWrittenBareAndRoundTripsAsDateTime(t *testing.T) {
 func TestWriteYAMLTimeForcedToQuotedStringOnWrite(t *testing.T) {
 	tv := omnist.TimeValue{Hour: 12, Minute: 0, Second: 0}
 	d := omnist.NodeDocument(omnist.NewNode().AddValue("t", omnist.ScalarValue(omnist.NewTimeScalar(tv))))
-	out, err := Write(d)
+	out, diags, err := Write(d)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if !strings.Contains(out, `"12:00"`) {
 		t.Errorf("expected the time to be written quoted as \"12:00\", got %q", out)
+	}
+	// Issue #49: the forced-to-string adjustment is now reported alongside
+	// the successful write (spec §8.5.3).
+	if len(diags) != 1 {
+		t.Fatalf("diags = %v, want exactly one diagnostic", diags)
+	}
+	if diags[0].Code != omnist.CodeFormatTemporalStringified {
+		t.Errorf("diagnostic code = %s, want %s", diags[0].Code, omnist.CodeFormatTemporalStringified)
+	}
+	if diags[0].Path != "$.t" {
+		t.Errorf("diagnostic path = %s, want $.t", diags[0].Path)
 	}
 	back, err := Read(out, omnist.DefaultLimits())
 	if err != nil {
@@ -134,7 +145,7 @@ func TestWriteYAMLTimeVariants(t *testing.T) {
 	}
 	for _, c := range cases {
 		d := omnist.NodeDocument(omnist.NewNode().AddValue("t", omnist.ScalarValue(omnist.NewTimeScalar(c.t))))
-		out, err := Write(d)
+		out, _, err := Write(d)
 		if err != nil {
 			t.Fatalf("%s: %v", c.name, err)
 		}
@@ -151,7 +162,7 @@ func TestWriteYAMLNaNInfinityRoundTrip(t *testing.T) {
 	cases := []float64{math.NaN(), math.Inf(1), math.Inf(-1)}
 	for _, f := range cases {
 		d := omnist.NodeDocument(omnist.NewNode().AddValue("v", omnist.ScalarValue(omnist.NewNumberScalar(f))))
-		out, err := Write(d)
+		out, _, err := Write(d)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -178,7 +189,7 @@ func TestWriteYAMLNaNInfinityRoundTrip(t *testing.T) {
 
 func TestWriteYAMLNumberAlwaysDistinctFromInteger(t *testing.T) {
 	d := omnist.NodeDocument(omnist.NewNode().AddValue("v", omnist.ScalarValue(omnist.NewNumberScalar(5.0))))
-	out, err := Write(d)
+	out, _, err := Write(d)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -199,7 +210,7 @@ func TestWriteYAMLStringThatWouldCollideWithResolutionStaysAString(t *testing.T)
 	cases := []string{"on", "yes", "no", "null", "true", "2024-01-01", "12:00:00", "5"}
 	for _, s := range cases {
 		d := omnist.NodeDocument(omnist.NewNode().AddValue("v", omnist.ScalarValue(omnist.NewStringScalar(s))))
-		out, err := Write(d)
+		out, _, err := Write(d)
 		if err != nil {
 			t.Fatalf("%q: %v", s, err)
 		}
@@ -216,7 +227,7 @@ func TestWriteYAMLStringThatWouldCollideWithResolutionStaysAString(t *testing.T)
 
 func TestWriteYAMLLabelThatWouldCollideWithResolutionStaysAString(t *testing.T) {
 	d := omnist.NodeDocument(omnist.NewNode().AddValue("on", omnist.ScalarValue(omnist.NewStringScalar("v"))))
-	out, err := Write(d)
+	out, _, err := Write(d)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -233,7 +244,7 @@ func TestWriteYAMLLabelThatWouldCollideWithResolutionStaysAString(t *testing.T) 
 
 func TestWriteYAMLNull(t *testing.T) {
 	d := omnist.NodeDocument(omnist.NewNode().AddValue("v", omnist.NullValue()))
-	out, err := Write(d)
+	out, _, err := Write(d)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -249,7 +260,7 @@ func TestWriteYAMLNull(t *testing.T) {
 func TestWriteYAMLBoolean(t *testing.T) {
 	for _, b := range []bool{true, false} {
 		d := omnist.NodeDocument(omnist.NewNode().AddValue("v", omnist.ScalarValue(omnist.NewBooleanScalar(b))))
-		out, err := Write(d)
+		out, _, err := Write(d)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -269,7 +280,7 @@ func TestWriteYAMLHugeInteger(t *testing.T) {
 		t.Fatal("test setup failed")
 	}
 	d := omnist.NodeDocument(omnist.NewNode().AddValue("v", omnist.ScalarValue(omnist.NewIntegerScalar(huge))))
-	out, err := Write(d)
+	out, _, err := Write(d)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -284,7 +295,7 @@ func TestWriteYAMLHugeInteger(t *testing.T) {
 
 func TestWriteYAMLBareValueDocument(t *testing.T) {
 	d := omnist.ValueDocument(omnist.ScalarValue(omnist.NewStringScalar("bare")))
-	out, err := Write(d)
+	out, _, err := Write(d)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -298,7 +309,7 @@ func TestWriteYAMLBareValueDocument(t *testing.T) {
 }
 
 func TestWriteYAMLEmptyNode(t *testing.T) {
-	out, err := Write(omnist.NodeDocument(omnist.NewNode()))
+	out, _, err := Write(omnist.NodeDocument(omnist.NewNode()))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -322,7 +333,7 @@ func TestWriteYAMLEmptyNode(t *testing.T) {
 func TestWriteYAMLInvalidUTF8StringFails(t *testing.T) {
 	invalid := string([]byte{0xff, 0xfe})
 	d := omnist.NodeDocument(omnist.NewNode().AddValue("v", omnist.ScalarValue(omnist.NewStringScalar(invalid))))
-	_, err := Write(d)
+	_, _, err := Write(d)
 	if err == nil {
 		t.Fatal("expected an error writing a string with invalid UTF-8 bytes")
 	}
@@ -331,7 +342,7 @@ func TestWriteYAMLInvalidUTF8StringFails(t *testing.T) {
 func TestWriteYAMLNestedNode(t *testing.T) {
 	child := omnist.NewNode().AddValue("x", omnist.ScalarValue(omnist.NewIntegerScalar(big.NewInt(1))))
 	d := omnist.NodeDocument(omnist.NewNode().AddNode("child", child))
-	out, err := Write(d)
+	out, _, err := Write(d)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/oml/oml_writer.go
+++ b/oml/oml_writer.go
@@ -43,7 +43,27 @@ var omlQuotedLabelWords = map[string]bool{
 // reasonable, deterministic, self-consistent choice, documented here per
 // the issue's instruction to flag this as a judgment call rather than a
 // spec requirement.
-func Write(d omnist.Document, compact bool) string {
+// Write's return also carries a []omnist.Diagnostic, matching every other
+// codec's writer in this package after issue #49's ok:true+diagnostics
+// channel — but not an error. Every other writer added an error return
+// (or, for JSON/YAML, kept one already present) because at least one
+// leaf shape or document shape genuinely has no spelling in that format
+// (TOML's null, XML's multi-root, JSON's strict-mode NaN/Infinity). OML
+// has no such case: every omnist.Kind has a native, lossless OML
+// spelling (§4.2's grammar covers every scalar kind directly, including
+// null, NaN, and Infinity), so nothing here can ever fail and nothing
+// here ever needs to report an adjustment — the diagnostics slice is
+// always nil today. Adding an always-nil error return anyway, purely for
+// uniformity with the other five signatures, would be exactly the
+// "unused signature element" the issue calls out as a judgment call to
+// avoid: a caller (or a future maintainer) reading `(string, error)`
+// reasonably infers there's a failure mode to check for, and OML has
+// none. `(string, []omnist.Diagnostic)` is the honest middle ground:
+// callers that already loop over every writer's diagnostics (the CLI,
+// the conformance driver) can treat OML uniformly with the rest, without
+// this package claiming a failure mode or an adjustment mode it doesn't
+// have.
+func Write(d omnist.Document, compact bool) (string, []omnist.Diagnostic) {
 	var b strings.Builder
 	if d.IsNode {
 		if compact {
@@ -60,14 +80,14 @@ func Write(d omnist.Document, compact bool) string {
 				b.WriteByte('\n')
 			}
 		}
-		return b.String()
+		return b.String(), nil
 	}
 	writeOMLValue(&b, d.Value)
-	return b.String()
+	return b.String(), nil
 }
 
 // WriteCompact is a convenience wrapper for Write(d, true).
-func WriteCompact(d omnist.Document) string { return Write(d, true) }
+func WriteCompact(d omnist.Document) (string, []omnist.Diagnostic) { return Write(d, true) }
 
 const omlIndentUnit = "  "
 

--- a/oml/oml_writer_test.go
+++ b/oml/oml_writer_test.go
@@ -101,7 +101,7 @@ func TestOMLRoundTripProperty(t *testing.T) {
 	for _, tc := range cases {
 		for _, compact := range []bool{false, true} {
 			t.Run(tc.name, func(t *testing.T) {
-				text := Write(tc.doc, compact)
+				text, _ := Write(tc.doc, compact)
 				got, err := Read(text, omnist.DefaultLimits())
 				if err != nil {
 					t.Fatalf("compact=%v Read(Write(doc)) failed: %v\ntext:\n%s", compact, err, text)
@@ -116,7 +116,9 @@ func TestOMLRoundTripProperty(t *testing.T) {
 
 func TestWriteOMLCompactWrapper(t *testing.T) {
 	doc := omnist.NodeDocument(omnist.NewNode().AddValue("a", omnist.ScalarValue(omnist.NewStringScalar("b"))))
-	if got, want := WriteCompact(doc), Write(doc, true); got != want {
+	got, _ := WriteCompact(doc)
+	want, _ := Write(doc, true)
+	if got != want {
 		t.Errorf("WriteCompact = %q, want %q", got, want)
 	}
 }
@@ -143,7 +145,7 @@ func TestOMLLabelQuoting(t *testing.T) {
 	}
 	for _, tc := range cases {
 		doc := omnist.NodeDocument(omnist.NewNode().AddValue(tc.label, omnist.ScalarValue(omnist.NewStringScalar("v"))))
-		text := Write(doc, true)
+		text, _ := Write(doc, true)
 		wantPrefix := tc.label + ":"
 		if tc.bare {
 			if !strings.HasPrefix(text, wantPrefix) {
@@ -173,7 +175,7 @@ func TestOMLStringEscapingSanctionedFormsOnly(t *testing.T) {
 	// characters, so every branch of escapeOMLString is exercised.
 	s := "\"\\\n\r\t\x00\x01\x1f/\bg\fh世"
 	doc := omnist.ValueDocument(omnist.ScalarValue(omnist.NewStringScalar(s)))
-	text := Write(doc, true)
+	text, _ := Write(doc, true)
 
 	for _, forbidden := range []string{`\/`, `\b`, `\f`} {
 		if strings.Contains(text, forbidden) {
@@ -210,12 +212,12 @@ func TestOMLPrettyLayoutMatchesSpecExample(t *testing.T) {
 		AddValue("tag", omnist.ScalarValue(omnist.NewStringScalar("y"))))
 
 	want := "name: \"Ann\"\naddress: {\n  city: \"Zurich\"\n  postcode: \"8001\"\n}\ntag: \"x\"\ntag: \"y\"\n"
-	if got := Write(doc, false); got != want {
+	if got, _ := Write(doc, false); got != want {
 		t.Errorf("pretty form mismatch:\ngot:  %q\nwant: %q", got, want)
 	}
 
 	wantCompact := `name: "Ann"; address: { city: "Zurich"; postcode: "8001" }; tag: "x"; tag: "y"`
-	if got := Write(doc, true); got != wantCompact {
+	if got, _ := Write(doc, true); got != wantCompact {
 		t.Errorf("compact form mismatch:\ngot:  %q\nwant: %q", got, wantCompact)
 	}
 }
@@ -228,7 +230,7 @@ func TestOMLPrettyLayoutMatchesSpecExample(t *testing.T) {
 func TestOMLTimeAlwaysEmitsSeconds(t *testing.T) {
 	doc := omnist.NodeDocument(omnist.NewNode().AddValue("t", omnist.ScalarValue(omnist.NewTimeScalar(omnist.TimeValue{Hour: 12, Minute: 0}))))
 	want := "t: 12:00:00\n"
-	if got := Write(doc, false); got != want {
+	if got, _ := Write(doc, false); got != want {
 		t.Errorf("got %q, want %q", got, want)
 	}
 }
@@ -237,7 +239,7 @@ func TestOMLTimeAlwaysEmitsSeconds(t *testing.T) {
 
 func TestOMLPrettyOutputEndsWithNewline(t *testing.T) {
 	doc := omnist.NodeDocument(omnist.NewNode().AddValue("a", omnist.ScalarValue(omnist.NewIntegerScalar(big.NewInt(1)))))
-	got := Write(doc, false)
+	got, _ := Write(doc, false)
 	if len(got) == 0 || got[len(got)-1] != '\n' {
 		t.Errorf("got %q, want a trailing newline", got)
 	}
@@ -245,7 +247,7 @@ func TestOMLPrettyOutputEndsWithNewline(t *testing.T) {
 
 func TestOMLEmptyDocumentRoundTrips(t *testing.T) {
 	doc := omnist.NodeDocument(omnist.NewNode())
-	if got := Write(doc, false); got != "" {
+	if got, _ := Write(doc, false); got != "" {
 		t.Errorf("empty document should render as empty string, got %q", got)
 	}
 	reparsed, err := Read("", omnist.DefaultLimits())

--- a/tools/conformance/drivers.go
+++ b/tools/conformance/drivers.go
@@ -267,25 +267,26 @@ func runWrite(v Vector) Result {
 	}
 
 	var text string
+	var gotDiags []omnist.Diagnostic
 	var werr error
 	switch in.Format {
 	case "json":
 		if in.Strict {
-			text, werr = json.WriteStrict(doc)
+			text, gotDiags, werr = json.WriteStrict(doc)
 		} else {
-			text, werr = json.Write(doc)
+			text, gotDiags, werr = json.Write(doc)
 		}
 	case "oml":
-		text = oml.Write(doc, false)
+		text, gotDiags = oml.Write(doc, false)
 	case "yaml":
-		text, werr = yaml.Write(doc)
+		text, gotDiags, werr = yaml.Write(doc)
 	case "toml":
 		if in.Strict {
-			return Result{Vector: v, Status: StatusSkip, Reason: "not yet implemented: WriteTOML has no strict-mode parameter in this repository (toml.Write(d Document) (string, error) only) -- flagged for a follow-up issue, not fixed here per issue #31's scope"}
+			return Result{Vector: v, Status: StatusSkip, Reason: "not yet implemented: WriteTOML has no strict-mode parameter in this repository (toml.Write(d Document) (string, []omnist.Diagnostic, error) only) -- flagged for a follow-up issue, not fixed here per issue #31's/#49's scope"}
 		}
-		text, werr = toml.Write(doc)
+		text, gotDiags, werr = toml.Write(doc)
 	case "xml":
-		text, werr = xml.Write(doc)
+		text, gotDiags, werr = xml.Write(doc)
 	default:
 		return fail(v, "unrecognized format %q", in.Format)
 	}
@@ -310,14 +311,19 @@ func runWrite(v Vector) Result {
 		return fail(v, "expected error, got ok write")
 	}
 	// write is the one operation where ok:true and diagnostics can
-	// coexist (§8.5.3) -- WriteYAML/WriteTOML/WriteXML/WriteJSONStrict
-	// return only (string, error), with no side-channel for a non-fatal
-	// adjustment diagnostic alongside success. If the vector expects
-	// diagnostics alongside ok:true, this repo's writers cannot surface
-	// them today, so treat that case as a driver-detected gap rather than
-	// silently ignoring the expected diagnostics.
-	if wantDiags, _ := decodeExpectDiagnostics(expect); len(wantDiags) > 0 {
-		return Result{Vector: v, Status: StatusSkip, Reason: "not yet implemented: this repository's Write* functions return (string, error) only, with no channel to report a non-fatal adjustment diagnostic alongside a successful write (spec allows ok:true + diagnostics together for write) -- flagged for a follow-up issue"}
+	// coexist (§8.5.3) -- since issue #49, every Write*/WriteStrict
+	// function returns (string, []omnist.Diagnostic, error) (oml.Write:
+	// (string, []omnist.Diagnostic), see its own doc comment for why it
+	// has no error return), so a successful write's adjustment
+	// diagnostics are compared here exactly like every other operation's.
+	if wantDiags, err := decodeExpectDiagnostics(expect); err != nil {
+		return fail(v, "decode expect.diagnostics: %v", err)
+	} else if _, hasDiagsKey := expect["diagnostics"]; hasDiagsKey {
+		got := diagsToPairs(gotDiags)
+		want := expectDiagPairs(wantDiags)
+		if !diagnosticSetsEqual(got, want) {
+			return fail(v, "diagnostics mismatch: got %v want %v", diagStrings(got), diagStrings(want))
+		}
 	}
 	wantText, ok := expect["text"]
 	if !ok {


### PR DESCRIPTION
Closes #49.

Adds an ok:true+diagnostics reporting channel to all 5 writer packages (formats/json, formats/yaml, formats/toml, formats/xml, oml), per spec Sec8.5.3/7.4 -- a write can succeed while reporting a non-fatal adjustment (a dropped null, a substituted NaN, a stringified temporal), which none of these functions could report before, only fail hard or succeed silently.

Signature convention: (string, []omnist.Diagnostic, error) for JSON/YAML/TOML/XML; (string, []omnist.Diagnostic) with no error return for OML specifically, since every scalar kind has a native, lossless OML spelling and nothing can ever fail -- adding an always-nil error purely for uniformity would falsely claim a failure mode OML doesn't have. Independently stress-tested by trying to construct a Document that fails to write as OML; none found.

Found a genuine bug along the way, not just a missing-diagnostic gap: TOML and XML writers previously hard-failed the *entire* write on encountering a single null leaf anywhere in the document, discarding an otherwise-correctly-written document. Now the null is dropped and reported (format.null-unrepresentable) while the rest writes faithfully -- a strict improvement, independently verified with the reviewer's own constructed test (siblings + a null inside a 3-element array, confirming no corruption, correct re-indexing, correctly-pathed diagnostics for both cases).

JSON gets format.temporal-stringified (every date/time/datetime leaf) and format.float-special (NaN/Infinity->null in lenient mode; WriteStrict still hard-fails on NaN/Infinity, independently confirmed both paths). YAML gets format.temporal-stringified only for its one sharp edge (bare KindTime, per issue #25's findings).

Independently verified end to end, including building the actual CLI binary and testing a real write-with-adjustment case through it (not just the library functions): writing a null-containing Document to TOML via the CLI printed the diagnostic to stderr, valid TOML to stdout, and used exit code 2 (ExitProblem), not a crash or the wrong code.

Conformance harness: 140/6/3 -> 143/5/1, independently reproduced in a separate worktree with the specific vectors confirmed (TOML null vector fail->pass, two JSON vectors skip->pass), all other vector statuses byte-identical. 100% coverage maintained on every touched package; cmd/omnist's pre-existing 99.2% gap confirmed unrelated to this change (same uncovered branch existed at the parent commit). 0 lint issues.

One honest, pre-existing (not introduced) limitation surfaced and documented rather than hidden: XML's null-as-empty-element is indistinguishable on read from an empty string leaf -- not a regression, since the old code hard-failed on nulls entirely rather than handling this case at all.