### PR TITLE
Fix JSON empty-array and YAML y/n boolean table

### DIFF
--- a/formats/json/json_reader.go
+++ b/formats/json/json_reader.go
@@ -269,25 +269,27 @@ func (r *jsonReader) readNestedObject() (*omnist.Node, error) {
 // readDocument uses for a bare top-level array, which is the same
 // "array with nothing to hold it" situation one level up.
 //
-// An empty array ('[]') is treated the same way OML treats its identical
-// array-as-repeated-label-sugar construct (oml_parser.go's parseArray):
-// rejected with omnist.CodeParseEmptyArray, rather than silently producing zero
-// edges for the label. This is a narrow, cosmetic reading rather than a
-// load-bearing one — docs/formats/json.md's model-mapping table has no
-// empty-array row to consult, but JSON's array sugar is explicitly the
-// same mechanism OML's array sugar is ("the array is not a value in the
-// model, it is the same label occurring more than once"), and OML's reader
-// already treats zero repeats of that sugar as an error rather than a
-// silent no-op; this reader follows that existing, in-repo precedent for
-// the identical construct rather than inventing a second behavior for it.
+// An empty array ('[]') is a legitimate zero-edge encoding, not an error
+// (spec docs/formats/json.md: "An empty array is a legitimate zero-edge
+// encoding, not an error. `{"m":[]}` reads to zero `m` edges: the label
+// simply doesn't appear in the result, the same as if the key were absent
+// entirely."). This is explicitly JSON-specific and does not extend to
+// OML's `[...]` array sugar (oml_parser.go's parseArray correctly keeps
+// rejecting a zero-length OML array run): OML's array syntax is sugar for
+// a *run* of same-label edges, and a zero-length run is indistinguishable
+// from no sugar at all, while JSON's arrays are a real container
+// independent of the Document model's edge-repetition mechanism, so an
+// empty one is just as meaningful as a non-empty one. omnist.CodeParseEmptyArray
+// stays a valid code in errors.go for OML's use; it is simply never
+// produced here.
 func (r *jsonReader) readArrayElements(key string) ([]omnist.Target, error) {
 	if !r.dec.More() {
-		// Consume the ']' before erroring so callers don't have to.
-		errPos := r.errHere(omnist.CodeParseEmptyArray, "'[]' is not a valid value")
+		// Consume the ']' and return zero targets for this label — the
+		// label simply doesn't appear in the resulting Document.
 		if _, err := r.next(); err != nil {
 			return nil, err
 		}
-		return nil, errPos
+		return nil, nil
 	}
 
 	var targets []omnist.Target

--- a/formats/json/json_reader_test.go
+++ b/formats/json/json_reader_test.go
@@ -197,17 +197,50 @@ func TestJSONBareNestedArrayRejected(t *testing.T) {
 	}
 }
 
-func TestJSONEmptyArrayRejected(t *testing.T) {
-	_, err := Read(`{"m":[]}`, omnist.DefaultLimits())
-	if err == nil {
-		t.Fatal("Read(`{\"m\":[]}`) succeeded, want a rejection error")
+// TestJSONEmptyArrayReadsToZeroEdges confirms spec docs/formats/json.md's
+// resolution of omnist-spec#38: "{\"m\":[]}" reads to zero `m` edges — the
+// label simply doesn't appear in the result, the same as if the key were
+// absent entirely. This is JSON-specific and does not extend to OML's
+// `[...]` sugar, which correctly keeps rejecting a zero-length run
+// (see oml_parser_test.go for that coverage).
+func TestJSONEmptyArrayReadsToZeroEdges(t *testing.T) {
+	got, err := Read(`{"m":[]}`, omnist.DefaultLimits())
+	if err != nil {
+		t.Fatalf("Read(`{\"m\":[]}`) = error %v, want success", err)
 	}
-	pe, ok := err.(*omnist.ParseError)
-	if !ok {
-		t.Fatalf("error is %T, want *omnist.ParseError", err)
+	want := omnist.NodeDocument(omnist.NewNode())
+	if !docEqual(got, want) {
+		t.Errorf("Read(`{\"m\":[]}`) = %+v, want %+v (structurally equal to {})", got, want)
 	}
-	if pe.Code != omnist.CodeParseEmptyArray {
-		t.Errorf("error code = %s, want %s", pe.Code, omnist.CodeParseEmptyArray)
+}
+
+// TestJSONEmptyArrayMatchesAbsentKey confirms the empty-array result is
+// structurally identical to the result of the key being entirely absent.
+func TestJSONEmptyArrayMatchesAbsentKey(t *testing.T) {
+	withEmptyArray, err := Read(`{"m":[]}`, omnist.DefaultLimits())
+	if err != nil {
+		t.Fatalf("Read(`{\"m\":[]}`) = error %v, want success", err)
+	}
+	withoutKey, err := Read(`{}`, omnist.DefaultLimits())
+	if err != nil {
+		t.Fatalf("Read(`{}`) = error %v, want success", err)
+	}
+	if !docEqual(withEmptyArray, withoutKey) {
+		t.Errorf("Read(`{\"m\":[]}`) = %+v, want structurally equal to Read(`{}`) = %+v", withEmptyArray, withoutKey)
+	}
+}
+
+// TestJSONEmptyArrayNestedReadsToZeroEdges confirms the same zero-edge
+// behavior for an empty array nested as an object member's value, not just
+// at the top level.
+func TestJSONEmptyArrayNestedReadsToZeroEdges(t *testing.T) {
+	got, err := Read(`{"outer":{"m":[]}}`, omnist.DefaultLimits())
+	if err != nil {
+		t.Fatalf("Read failed: %v", err)
+	}
+	want := omnist.NodeDocument(omnist.NewNode().AddNode("outer", omnist.NewNode()))
+	if !docEqual(got, want) {
+		t.Errorf("got %+v, want %+v", got, want)
 	}
 }
 

--- a/formats/yaml/yaml_reader.go
+++ b/formats/yaml/yaml_reader.go
@@ -369,15 +369,19 @@ func (r *yamlReader) readScalar(n *yamllib.Node) (omnist.Value, error) {
 // documented escape hatch (docs/formats/yaml.md: "Quoting the key (\"on\":)
 // sidesteps the problem entirely").
 var (
-	// yamlBoolWords is YAML 1.1's bool type's exact word list
-	// (http://yaml.org/type/bool.html), reproduced here rather than
-	// sourced from either library (gopkg.in/yaml.v2 carries this same
-	// table internally, but it is unexported). This is the full list,
-	// including the single-letter y/n forms alongside the Norway
-	// problem's on/off/yes/no and the case variants of true/false.
+	// yamlBoolWords is the spec's exact six-word alias set (spec
+	// docs/formats/yaml.md: "This alias set is exactly these six words,
+	// not the raw YAML 1.1 specification's fuller list. ... only
+	// on/off/yes/no/true/false (case variants included) resolve as
+	// booleans."). The raw YAML 1.1 core-schema bool type
+	// (http://yaml.org/type/bool.html) also resolves bare y/Y/n/N, but
+	// the reference implementation's resolver deliberately does not
+	// (matching PyYAML's default SafeLoader) — confirmed live for
+	// n/N/y/Y in both key and value position, so those single-letter
+	// forms are intentionally absent here.
 	yamlBoolWords = map[string]bool{
-		"y": true, "Y": true, "yes": true, "Yes": true, "YES": true,
-		"n": false, "N": false, "no": false, "No": false, "NO": false,
+		"yes": true, "Yes": true, "YES": true,
+		"no": false, "No": false, "NO": false,
 		"true": true, "True": true, "TRUE": true,
 		"false": false, "False": false, "FALSE": false,
 		"on": true, "On": true, "ON": true,

--- a/formats/yaml/yaml_reader_test.go
+++ b/formats/yaml/yaml_reader_test.go
@@ -227,8 +227,8 @@ func TestYAMLNorwayWordsAsValues(t *testing.T) {
 		text string
 		want bool
 	}{
-		{"y", true}, {"Y", true}, {"yes", true}, {"Yes", true}, {"YES", true},
-		{"n", false}, {"N", false}, {"no", false}, {"No", false}, {"NO", false},
+		{"yes", true}, {"Yes", true}, {"YES", true},
+		{"no", false}, {"No", false}, {"NO", false},
 		{"true", true}, {"True", true}, {"TRUE", true},
 		{"false", false}, {"False", false}, {"FALSE", false},
 		{"on", true}, {"On", true}, {"ON", true},
@@ -243,6 +243,38 @@ func TestYAMLNorwayWordsAsValues(t *testing.T) {
 		if v.Scalar.Kind != omnist.KindBoolean || v.Scalar.Bool != c.want {
 			t.Errorf("%q: got %+v, want boolean %v", c.text, v.Scalar, c.want)
 		}
+	}
+}
+
+// TestYAMLBareSingleLetterYNStayStrings confirms spec docs/formats/yaml.md's
+// resolution of omnist-spec#40: "This alias set is exactly these six words,
+// not the raw YAML 1.1 specification's fuller list." The raw YAML 1.1 core
+// schema also resolves bare y/Y/n/N as booleans, but the reference
+// implementation's resolver deliberately does not (matching PyYAML's
+// default SafeLoader) -- confirmed live for n/N/y/Y in both key and value
+// position, so a bare y/Y/n/N stays an ordinary string label here, not a
+// Norway-problem case.
+func TestYAMLBareSingleLetterYNStayStrings(t *testing.T) {
+	for _, text := range []string{"y", "Y", "n", "N"} {
+		t.Run("value/"+text, func(t *testing.T) {
+			d, err := Read("v: "+text+"\n", omnist.DefaultLimits())
+			if err != nil {
+				t.Fatalf("%q: unexpected error: %v", text, err)
+			}
+			v, _ := d.Node.Edges[0].Target.Value()
+			if v.Scalar.Kind != omnist.KindString || v.Scalar.Str != text {
+				t.Errorf("%q: got %+v, want string %q", text, v.Scalar, text)
+			}
+		})
+		t.Run("key/"+text, func(t *testing.T) {
+			d, err := Read(text+": true\n", omnist.DefaultLimits())
+			if err != nil {
+				t.Fatalf("%q key: unexpected error: %v", text, err)
+			}
+			if len(d.Node.Edges) != 1 || d.Node.Edges[0].Label != text {
+				t.Errorf("%q key: got edges %+v, want single edge labeled %q", text, d.Node.Edges, text)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Closes #51.

Fixes two real bugs found via a resolved spec-gap batch this repo sent to omnist-spec: JSON's {"m":[]} now reads to zero edges for that label instead of erroring (this repo's prior behavior was a deliberate but incorrect analogy to OML's array-sugar rule, which the spec's own resolution of omnist-spec#38 confirmed doesn't transfer to JSON -- JSON's arrays are a real container independent of the edge-repetition mechanism, unlike OML's sugar, where a zero-length run is indistinguishable from no sugar at all); and YAML's boolean-resolution table no longer treats bare single-letter y/Y/n/N as booleans, matching the spec's clarification (omnist-spec#40, resolved after live verification against the reference implementation) that only the six full words (on/off/yes/no/true/false, case variants) are in the reference's actual boolean set, not YAML 1.1's raw fuller spec.

Fixing the YAML boolean table incidentally also fixed formats-yaml/sharp-edges/bare-time-resolves-to-sexagesimal-integer-not-a-time, whose vector uses key n -- previously rejected at the Norway-problem check before ever reaching the sexagesimal-time resolution the vector is actually about. Conformance: 143/5/1 -> 147/3/1.

Independently verified with real adversarial tests beyond the committed suite: confirmed OML's own [...] array-sugar rejection is completely untouched (a bare m: [] in OML still correctly errors); confirmed the JSON fix with a sibling-field case and a nested case, both structurally verified against reading the equivalent key-absent document directly; confirmed the YAML fix removed only the four single-letter entries (all ten full-word case variants intact) and that the Norway-problem key-rejection mechanism itself still fires correctly for on:/yes:/etc.; confirmed the sexagesimal-vector explanation by reproducing the exact before/after behavior directly. All three remaining conformance failures and the one skip independently confirmed as the same pre-existing, unrelated items.

100% coverage on formats/json and formats/yaml. 0 lint issues.