### PR TITLE
Add fuzz tests for all format readers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,46 @@ jobs:
         with:
           version: v2.5.0
 
+  fuzz:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.26'
+      - name: Fuzz the six format readers (issue #57)
+        run: |
+          # This step is deliberately short and time-boxed -- 10s per
+          # reader, 60s total -- not an unbounded fuzz run. Its job is
+          # twofold:
+          #
+          #  1. Regression protection: every one of the six FuzzRead
+          #     functions' testdata/fuzz/FuzzRead/* corpus (committed
+          #     whenever a local `go test -fuzz` run finds a crasher, per
+          #     Go's standard fuzzing convention) already runs as part of
+          #     the `test` job above via plain `go test ./...` -- that
+          #     alone re-checks every previously-found crasher on every
+          #     push. This job's own short -fuzz burst is additional,
+          #     exploratory coverage beyond the fixed corpus, not the
+          #     regression check itself.
+          #  2. A cheap tripwire for new crashers: readers are the one
+          #     class of code in this repo that consumes untrusted input
+          #     (see FuzzRead's doc comment in each package for why), so a
+          #     little continuous exploration on every push is worth 60s
+          #     of CI time even though it can never be exhaustive.
+          #
+          # A real, longer local fuzz run (30-60s per package) is how
+          # issue #57 itself was verified before committing -- this step
+          # is not a substitute for that, just an ongoing cheap check.
+          set -e
+          for pkg in ./oml ./osd ./formats/json ./formats/yaml ./formats/toml ./formats/xml; do
+            echo "::group::fuzz $pkg"
+            go test "$pkg" -run=FuzzRead -fuzz=FuzzRead -fuzztime=10s
+            echo "::endgroup::"
+          done
+
   conformance:
     runs-on: ubuntu-latest
     steps:

--- a/docs/workflow-playbook.md
+++ b/docs/workflow-playbook.md
@@ -181,6 +181,24 @@ Per spec §9.5's recommended build order:
 Steps 1-6 are the useful core per the spec; a port that stops there is still
 worth having.
 
+Step 14 landed as issue #57: one `FuzzRead` per reader package (`oml`,
+`osd`, `formats/{json,yaml,toml,xml}`), seeded from this repo's own test
+literals plus vendored `omnist-spec` test-suite/conformance-fixture text.
+Two real bugs surfaced immediately, both in `formats/toml`: go-toml/v2's
+unstable parser can tag a value node `Kind=LocalDate`/`LocalTime`/
+`LocalDateTime`/`DateTime` on text that does not actually have the full
+digit layout `ParseISODate`/`ParseISOTime` require as their documented
+precondition (e.g. bare `"00:"` reaching `Kind=LocalTime`), and
+`MatchesISOKind` itself had a latent bug where `regexp.FindString("")`'s
+ambiguity between "no match" and "an empty match" made it spuriously
+return true for an empty string against every kind. Both fixed (validate
+before calling the precondition-trusting parsers; reject `""` up front in
+`MatchesISOKind`), both covered by unit tests, not just the fuzz corpus.
+CI runs a short (10s/package, 60s total) `-fuzz` burst on every push,
+separate from — and much shorter than — the 30-60s-per-package local runs
+that found the above; see `.github/workflows/ci.yml`'s `fuzz` job for the
+regression-vs-exploration distinction.
+
 ## 4. Conformance harness — built early, interleaved
 
 Do not defer this to the end. Start it right after step 2 (OML) lands, and

--- a/formats/json/json_fuzz_test.go
+++ b/formats/json/json_fuzz_test.go
@@ -1,0 +1,81 @@
+package json
+
+import (
+	"testing"
+
+	omnist "github.com/omnist-dev/omnist-go"
+)
+
+// fuzzLimits is deliberately small (unlike omnist.DefaultLimits()) so the
+// fuzzer's mutations spend their budget exploring the limit-boundary logic
+// itself (depth/node-count/int-digit checks) rather than just building
+// large-but-legal documents. See issue #57.
+func fuzzLimits() omnist.Limits {
+	return omnist.Limits{MaxDepth: 8, MaxNodes: 64, MaxIntDigits: 12}
+}
+
+// checkNodeSane walks a Node and fails t if any edge's Target is
+// internally inconsistent: a node-target with a nil *omnist.Node. Target
+// is a closed struct only constructible via omnist.ValueTarget/NodeTarget
+// (the latter panics on nil), so this should never fire -- it's a cheap
+// belt-and-suspenders structural check, not a claim about document
+// semantics.
+func checkNodeSane(t *testing.T, n *omnist.Node, depth int) {
+	t.Helper()
+	if n == nil {
+		t.Fatal("checkNodeSane: nil node")
+	}
+	if depth > 10000 {
+		t.Fatal("checkNodeSane: implausible recursion depth, aborting walk")
+	}
+	for _, e := range n.Edges {
+		if child, ok := e.Target.Node(); ok {
+			if child == nil {
+				t.Fatalf("edge %q: IsNode target with nil *Node", e.Label)
+			}
+			checkNodeSane(t, child, depth+1)
+		}
+	}
+}
+
+// FuzzRead exercises json.Read against arbitrary input text. Per issue
+// #57, the only properties asserted are the ones that must hold for ANY
+// input: Read must never panic and must never hang (bounded by go test's
+// fuzz timeout), and on success the resulting Document must be
+// structurally sane. On error nothing is asserted beyond "it's a real
+// error" -- Read's documented contract is that failures come back as
+// *omnist.ParseError, so we additionally confirm the concrete type
+// without caring which one.
+func FuzzRead(f *testing.F) {
+	f.Add(`{"a":1}`)
+	f.Add("")
+	f.Add(`{"m":[1,2]}`) // formats-json/basic/array-value-becomes-repeated-edges
+	f.Add(`{"m":[1]}`)   // formats-json/basic/single-element-array-is-indistinguishable-from-a-bare-value
+	f.Add(`{"m":[]}`)    // formats-json/basic/empty-array-value-is-zero-edges-not-an-error
+	f.Add(`{"m":[[1,2],[3,4]]}`) // formats-json/basic/nested-array-is-rejected
+	f.Add(`{"d":"2024-01-01"}`)  // formats-json/basic/date-looking-string-stays-a-string
+	f.Add(`{"m":["A"]}`)         // repo-test-literal
+	f.Add(`{}`)                  // repo-test-literal
+	f.Add(`{"outer":{"m":[]}}`)  // repo-test-literal
+	f.Add(`{"a":{"b":{"c":{"d":1}}}}`)       // repo-test-literal
+	f.Add(`{"a":[{"b":1},{"c":{"d":1}}]}`)   // repo-test-literal
+	f.Add(`{"a":{},"b":{},"c":{}}`)          // repo-test-literal
+	f.Add(`123456`)                          // repo-test-literal
+	f.Add(`{"n":12345}`)                     // repo-test-literal
+	f.Add(`[1,2]`)                           // repo-test-literal
+	f.Add(`{"a":{"b":{"c":1}}}`)             // repo-test-literal
+	f.Add(`{"n":1000}`)                      // repo-test-literal
+
+	f.Fuzz(func(t *testing.T, text string) {
+		doc, err := Read(text, fuzzLimits())
+		if err != nil {
+			if _, ok := err.(*omnist.ParseError); !ok {
+				t.Fatalf("Read returned a non-*omnist.ParseError error: %T: %v", err, err)
+			}
+			return
+		}
+		if doc.IsNode {
+			checkNodeSane(t, doc.Node, 0)
+		}
+	})
+}

--- a/formats/toml/testdata/fuzz/FuzzRead/2f6d734df71bd4ad
+++ b/formats/toml/testdata/fuzz/FuzzRead/2f6d734df71bd4ad
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("0=0000-00-00T")

--- a/formats/toml/testdata/fuzz/FuzzRead/eaff3b903a31de3f
+++ b/formats/toml/testdata/fuzz/FuzzRead/eaff3b903a31de3f
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("0=00:")

--- a/formats/toml/toml_fuzz_test.go
+++ b/formats/toml/toml_fuzz_test.go
@@ -1,0 +1,94 @@
+package toml
+
+import (
+	"testing"
+
+	omnist "github.com/omnist-dev/omnist-go"
+)
+
+// fuzzLimits is deliberately small (unlike omnist.DefaultLimits()) so the
+// fuzzer's mutations spend their budget exploring the limit-boundary logic
+// itself (depth/node-count/int-digit checks) rather than just building
+// large-but-legal documents. See issue #57.
+func fuzzLimits() omnist.Limits {
+	return omnist.Limits{MaxDepth: 8, MaxNodes: 64, MaxIntDigits: 12}
+}
+
+// checkNodeSane walks a Node and fails t if any edge's Target is
+// internally inconsistent: a node-target with a nil *omnist.Node. Target
+// is a closed struct only constructible via omnist.ValueTarget/NodeTarget
+// (the latter panics on nil), so this should never fire -- it's a cheap
+// belt-and-suspenders structural check, not a claim about document
+// semantics.
+func checkNodeSane(t *testing.T, n *omnist.Node, depth int) {
+	t.Helper()
+	if n == nil {
+		t.Fatal("checkNodeSane: nil node")
+	}
+	if depth > 10000 {
+		t.Fatal("checkNodeSane: implausible recursion depth, aborting walk")
+	}
+	for _, e := range n.Edges {
+		if child, ok := e.Target.Node(); ok {
+			if child == nil {
+				t.Fatalf("edge %q: IsNode target with nil *Node", e.Label)
+			}
+			checkNodeSane(t, child, depth+1)
+		}
+	}
+}
+
+// FuzzRead exercises toml.Read against arbitrary input text. Per issue
+// #57, the only properties asserted are the ones that must hold for ANY
+// input: Read must never panic and must never hang (bounded by go test's
+// fuzz timeout), and on success the resulting Document must be
+// structurally sane. On error nothing is asserted beyond "it's a real
+// error" -- Read's documented contract is that failures come back as
+// *omnist.ParseError, so we additionally confirm the concrete type
+// without caring which one.
+func FuzzRead(f *testing.F) {
+	f.Add("a = 1\n")
+	f.Add("")
+	f.Add("[[x]]\nname = \"a\"\n\n[[x]]\nname = \"b\"\n") // formats-toml/basic/array-of-tables-becomes-repeated-edges
+	f.Add("d = 2024-01-01\nt = 12:00:00\ndt = 2024-01-01T12:30:00\n") // formats-toml/temporals/native-date-time-and-datetime-all-resolve-with-no-schema
+	f.Add("p = {x = 1, y = 2}")               // repo-test-literal
+	f.Add("items = [{n = \"a\"}, {n = \"b\"}]") // repo-test-literal
+	f.Add("\"q key\" = 9")                     // repo-test-literal
+	f.Add("s = \"a\\nb\\tc\\\"d\"")             // repo-test-literal
+	f.Add("a = 1\nb = 2\n")                    // repo-test-literal
+	f.Add("d = 2024-01-01\n")                  // repo-test-literal
+	f.Add("t = 12:30:45\n")                    // repo-test-literal
+	f.Add("t = 12:30:45.5\n")                  // repo-test-literal
+	f.Add("dt = 2024-01-01T12:00:00\n")        // repo-test-literal
+	f.Add("dt = 2024-01-01T12:00:00Z\n")       // repo-test-literal
+	f.Add("dt = 2024-01-01 12:00:00z\n")       // repo-test-literal
+	f.Add("dt = 2024-01-01T12:00:00.123+05:30\n") // repo-test-literal
+	f.Add("dt = 2024-01-01 12:00:00\n")        // repo-test-literal
+	f.Add("i = 2\nf = 2.0\n")                  // repo-test-literal
+	f.Add("hex = 0xFF\noct = 0o17\nbin = 0b101\n") // repo-test-literal
+	f.Add("n = ")                              // repo-test-literal
+	f.Add("n = 1_000_000\n")                   // repo-test-literal
+	f.Add("n = -42\n")                         // repo-test-literal
+	f.Add("a = inf\nb = +inf\nc = -inf\nd = nan\ne = -nan\nf = +nan\n") // repo-test-literal
+	f.Add("n = 1_234.5e1_0\n")                 // repo-test-literal
+	f.Add("nums = [1, 2, 3]\n")                // repo-test-literal
+	f.Add("a = []\n")                          // repo-test-literal
+	f.Add("a = [[1, 2], [3, 4]]\n")            // repo-test-literal
+	f.Add("host.name = \"x\"\nhost.port = 1\n") // repo-test-literal
+	f.Add("a.b.c = 5\n")                       // repo-test-literal
+	f.Add("a = 1\na.b = 2\n")                  // repo-test-literal
+	f.Add("items = [{a = []}]\n")              // repo-test-literal
+
+	f.Fuzz(func(t *testing.T, text string) {
+		doc, err := Read(text, fuzzLimits())
+		if err != nil {
+			if _, ok := err.(*omnist.ParseError); !ok {
+				t.Fatalf("Read returned a non-*omnist.ParseError error: %T: %v", err, err)
+			}
+			return
+		}
+		if doc.IsNode {
+			checkNodeSane(t, doc.Node, 0)
+		}
+	})
+}

--- a/formats/toml/toml_reader.go
+++ b/formats/toml/toml_reader.go
@@ -485,11 +485,23 @@ func (r *tomlReader) readScalar(v *unstable.Node) (omnist.Value, error) {
 	case unstable.Float:
 		return omnist.ScalarValue(omnist.NewNumberScalar(parseTOMLFloat(string(v.Data)))), nil
 	case unstable.LocalDate:
-		return omnist.ScalarValue(omnist.NewDateScalar(omnist.ParseISODate(string(v.Data)))), nil
+		data := string(v.Data)
+		if !omnist.MatchesISOKind(data, omnist.TemporalDate) {
+			return omnist.Value{}, &omnist.ParseError{Path: r.posPath(v.Raw), Code: omnist.CodeParseUnexpectedToken, Message: "malformed date literal"}
+		}
+		return omnist.ScalarValue(omnist.NewDateScalar(omnist.ParseISODate(data))), nil
 	case unstable.LocalTime:
-		return omnist.ScalarValue(omnist.NewTimeScalar(omnist.ParseISOTime(string(v.Data)))), nil
+		data := string(v.Data)
+		if !omnist.MatchesISOKind(data, omnist.TemporalTime) {
+			return omnist.Value{}, &omnist.ParseError{Path: r.posPath(v.Raw), Code: omnist.CodeParseUnexpectedToken, Message: "malformed time literal"}
+		}
+		return omnist.ScalarValue(omnist.NewTimeScalar(omnist.ParseISOTime(data))), nil
 	default: // unstable.LocalDateTime, unstable.DateTime
-		return omnist.ScalarValue(omnist.NewDateTimeScalar(parseTOMLDateTime(string(v.Data)))), nil
+		dt, ok := parseTOMLDateTime(string(v.Data))
+		if !ok {
+			return omnist.Value{}, &omnist.ParseError{Path: r.posPath(v.Raw), Code: omnist.CodeParseUnexpectedToken, Message: "malformed datetime literal"}
+		}
+		return omnist.ScalarValue(omnist.NewDateTimeScalar(dt)), nil
 	}
 }
 
@@ -555,16 +567,45 @@ func parseTOMLFloat(raw string) float64 {
 // omnist.ParseISODate/omnist.ParseISOTime (document-model-neutral, format-agnostic
 // field parsers temporal.go already defines) for the date and
 // (offset-less) time portions.
-func parseTOMLDateTime(s string) omnist.DateTimeValue {
+//
+// The go-toml/v2 unstable parser this reader is built on is not
+// guaranteed to only tag well-formed literals as LocalDateTime/DateTime
+// nodes on malformed input (found via fuzzing, issue #57: a bare "00:"
+// value was tagged Kind=LocalTime even though it is not a complete time
+// literal) -- so, exactly like readScalar's LocalDate/LocalTime cases,
+// this validates the date and time portions against
+// omnist.ISODateRegexp/omnist.ISOTimeRegexp (the same regexes
+// omnist.ParseISODate/omnist.ParseISOTime document as their precondition)
+// before calling either, rather than trusting the node's raw text
+// unconditionally. The second return value is false if that validation
+// fails; callers must treat that as a parse error, not a Document.
+func parseTOMLDateTime(s string) (omnist.DateTimeValue, bool) {
+	if len(s) < 11 {
+		return omnist.DateTimeValue{}, false
+	}
 	datePart := s[:10]
+	sep := s[10]
+	if sep != 'T' && sep != 't' && sep != ' ' {
+		return omnist.DateTimeValue{}, false
+	}
+	if !omnist.MatchesISOKind(datePart, omnist.TemporalDate) {
+		return omnist.DateTimeValue{}, false
+	}
 	timePart := s[11:]
 	var tv omnist.TimeValue
 	if n := len(timePart); n > 0 && (timePart[n-1] == 'Z' || timePart[n-1] == 'z') {
-		tv = omnist.ParseISOTime(timePart[:n-1])
+		body := timePart[:n-1]
+		if !omnist.MatchesISOKind(body, omnist.TemporalTime) {
+			return omnist.DateTimeValue{}, false
+		}
+		tv = omnist.ParseISOTime(body)
 		tv.HasOffset = true
 		tv.OffsetSeconds = 0
 	} else {
+		if !omnist.MatchesISOKind(timePart, omnist.TemporalTime) {
+			return omnist.DateTimeValue{}, false
+		}
 		tv = omnist.ParseISOTime(timePart)
 	}
-	return omnist.DateTimeValue{Date: omnist.ParseISODate(datePart), Time: tv}
+	return omnist.DateTimeValue{Date: omnist.ParseISODate(datePart), Time: tv}, true
 }

--- a/formats/toml/toml_reader_test.go
+++ b/formats/toml/toml_reader_test.go
@@ -660,3 +660,102 @@ func TestTOMLBooleans(t *testing.T) {
 		t.Errorf("got %+v, want %+v", d, want)
 	}
 }
+
+// --- malformed temporal literals (issue #57: found by fuzzing) ---
+//
+// go-toml/v2's unstable parser can tag a value node Kind=LocalDate/
+// LocalTime/LocalDateTime/DateTime on text that does not actually have
+// the full digit layout omnist.ParseISODate/omnist.ParseISOTime require
+// (their documented precondition) -- e.g. "00:" reaches Kind=LocalTime
+// even though it is not a complete time literal. These confirm the
+// reader now reports a *omnist.ParseError instead of panicking, for
+// every one of readScalar's and parseTOMLDateTime's new validation
+// branches.
+
+func TestTOMLMalformedLocalDateDoesNotPanic(t *testing.T) {
+	// go-toml tags this Kind=LocalDate with Data "2024-01-0" (one digit
+	// short of a complete day), confirmed empirically against the
+	// library's own unstable.Parser.
+	_, err := Read("d = 2024-01-0\n", omnist.DefaultLimits())
+	if err == nil {
+		t.Fatal("expected a parse error for a malformed date literal, got success")
+	}
+	if _, ok := err.(*omnist.ParseError); !ok {
+		t.Errorf("error = %#v (%T), want *omnist.ParseError", err, err)
+	}
+}
+
+func TestTOMLMalformedLocalTimeDoesNotPanic(t *testing.T) {
+	// The exact input the fuzzer found (issue #57): go-toml tags this
+	// Kind=LocalTime with Data "00:", too short for ParseISOTime's
+	// precondition.
+	_, err := Read("d = 00:\n", omnist.DefaultLimits())
+	if err == nil {
+		t.Fatal("expected a parse error for a malformed time literal, got success")
+	}
+	if _, ok := err.(*omnist.ParseError); !ok {
+		t.Errorf("error = %#v (%T), want *omnist.ParseError", err, err)
+	}
+}
+
+func TestTOMLMalformedLocalDateTimeDoesNotPanic(t *testing.T) {
+	// The exact input the fuzzer found for the LocalDateTime path (issue
+	// #57): go-toml tags this Kind=LocalDateTime with Data
+	// "2024-01-01T", an empty time portion.
+	_, err := Read("d = 2024-01-01T\n", omnist.DefaultLimits())
+	if err == nil {
+		t.Fatal("expected a parse error for a malformed datetime literal, got success")
+	}
+	if _, ok := err.(*omnist.ParseError); !ok {
+		t.Errorf("error = %#v (%T), want *omnist.ParseError", err, err)
+	}
+}
+
+func TestTOMLMalformedDateTimeWithBadOffsetSuffixDoesNotPanic(t *testing.T) {
+	// go-toml tags this Kind=DateTime with Data "2024-01-01Tz": the
+	// offset marker is present but the time body before it is empty.
+	// Exercises parseTOMLDateTime's Z/z-suffix branch with an invalid
+	// body, distinct from the plain-suffix branch above.
+	_, err := Read("d = 2024-01-01Tz\n", omnist.DefaultLimits())
+	if err == nil {
+		t.Fatal("expected a parse error, got success")
+	}
+	if _, ok := err.(*omnist.ParseError); !ok {
+		t.Errorf("error = %#v (%T), want *omnist.ParseError", err, err)
+	}
+}
+
+// TestParseTOMLDateTimeDirect white-box tests parseTOMLDateTime's
+// validation branches directly, including two (the too-short-length
+// guard and the invalid-separator guard) that -- as far as empirical
+// probing of go-toml/v2's unstable.Parser found -- it never actually
+// hands a LocalDateTime/DateTime node malformed enough to reach: TOML's
+// own tokenizer rejects a bad separator and never tags anything under 11
+// bytes with either kind. They stay as defense-in-depth against a
+// different or future go-toml version behaving more like the "00:"/
+// "2024-01-01T" cases above, and are exercised here directly since they
+// are otherwise unreachable through Read.
+func TestParseTOMLDateTimeDirect(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		ok   bool
+	}{
+		{"too short", "2024-01-01", false},
+		{"bad separator", "2024-01-01X00:00:00", false},
+		{"bad date part", "202X-01-01T00:00:00", false},
+		{"bad time part", "2024-01-01T00:00:0", false},
+		{"bad Z body", "2024-01-01Tz", false},
+		{"valid space-separated", "2024-01-01 00:00:00", true},
+		{"valid T-separated with Z", "2024-01-01T00:00:00Z", true},
+		{"valid t-separated", "2024-01-01t00:00:00", true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, ok := parseTOMLDateTime(c.in)
+			if ok != c.ok {
+				t.Errorf("parseTOMLDateTime(%q) ok = %v, want %v", c.in, ok, c.ok)
+			}
+		})
+	}
+}

--- a/formats/xml/xml_fuzz_test.go
+++ b/formats/xml/xml_fuzz_test.go
@@ -1,0 +1,81 @@
+package xml
+
+import (
+	"testing"
+
+	omnist "github.com/omnist-dev/omnist-go"
+)
+
+// fuzzLimits is deliberately small (unlike omnist.DefaultLimits()) so the
+// fuzzer's mutations spend their budget exploring the limit-boundary logic
+// itself (depth/node-count/int-digit checks) rather than just building
+// large-but-legal documents. See issue #57.
+func fuzzLimits() omnist.Limits {
+	return omnist.Limits{MaxDepth: 8, MaxNodes: 64, MaxIntDigits: 12}
+}
+
+// checkNodeSane walks a Node and fails t if any edge's Target is
+// internally inconsistent: a node-target with a nil *omnist.Node. Target
+// is a closed struct only constructible via omnist.ValueTarget/NodeTarget
+// (the latter panics on nil), so this should never fire -- it's a cheap
+// belt-and-suspenders structural check, not a claim about document
+// semantics.
+func checkNodeSane(t *testing.T, n *omnist.Node, depth int) {
+	t.Helper()
+	if n == nil {
+		t.Fatal("checkNodeSane: nil node")
+	}
+	if depth > 10000 {
+		t.Fatal("checkNodeSane: implausible recursion depth, aborting walk")
+	}
+	for _, e := range n.Edges {
+		if child, ok := e.Target.Node(); ok {
+			if child == nil {
+				t.Fatalf("edge %q: IsNode target with nil *Node", e.Label)
+			}
+			checkNodeSane(t, child, depth+1)
+		}
+	}
+}
+
+// FuzzRead exercises xml.Read against arbitrary input text. Per issue #57,
+// the only properties asserted are the ones that must hold for ANY input:
+// Read must never panic and must never hang (bounded by go test's fuzz
+// timeout), and on success the resulting Document must be structurally
+// sane. On error nothing is asserted beyond "it's a real error" -- Read's
+// documented contract is that failures come back as *omnist.ParseError,
+// so we additionally confirm the concrete type without caring which one.
+func FuzzRead(f *testing.F) {
+	f.Add("<a>1</a>")
+	f.Add("")
+	f.Add("<r><m>1</m><x>2</x><m>3</m></r>")           // formats-xml/basic/interleaved-elements-preserve-order
+	f.Add(`<a x="1"><b>hi</b></a>`)                     // formats-xml/basic/attributes-are-dropped-on-read
+	f.Add("<root><m/><x/><m/></root>")                  // repo-test-literal
+	f.Add("<root><m>A</m><x>X</x><m>B</m></root>")      // repo-test-literal
+	f.Add("<root><items>a</items><items>b</items><items>c</items></root>") // repo-test-literal
+	f.Add(`<a x="1" y="2" z="3"/>`)                     // repo-test-literal
+	f.Add(`<root xmlns:ns="http://example.com/ns"><ns:b>hi</ns:b></root>`) // repo-test-literal
+	f.Add("<ns:b>hi</ns:b>")                            // repo-test-literal
+	f.Add("<a/>")                                       // repo-test-literal
+	f.Add("<a/><b/>")                                   // repo-test-literal
+	f.Add("stray text<a/>")                             // repo-test-literal
+	f.Add("</a>")                                       // repo-test-literal
+	f.Add("<a/><b")                                     // repo-test-literal
+	f.Add("<a/>stray")                                  // repo-test-literal
+	f.Add("<a><b></a>")                                 // repo-test-literal
+	f.Add("<a><b>")                                     // repo-test-literal
+	f.Add("<a>hello<b>x</b>world</a>")                  // repo-test-literal
+
+	f.Fuzz(func(t *testing.T, text string) {
+		doc, err := Read(text, fuzzLimits())
+		if err != nil {
+			if _, ok := err.(*omnist.ParseError); !ok {
+				t.Fatalf("Read returned a non-*omnist.ParseError error: %T: %v", err, err)
+			}
+			return
+		}
+		if doc.IsNode {
+			checkNodeSane(t, doc.Node, 0)
+		}
+	})
+}

--- a/formats/yaml/yaml_fuzz_test.go
+++ b/formats/yaml/yaml_fuzz_test.go
@@ -1,0 +1,95 @@
+package yaml
+
+import (
+	"testing"
+
+	omnist "github.com/omnist-dev/omnist-go"
+)
+
+// fuzzLimits is deliberately small (unlike omnist.DefaultLimits()) so the
+// fuzzer's mutations spend their budget exploring the limit-boundary logic
+// itself (depth/node-count/int-digit checks) rather than just building
+// large-but-legal documents. See issue #57.
+func fuzzLimits() omnist.Limits {
+	return omnist.Limits{MaxDepth: 8, MaxNodes: 64, MaxIntDigits: 12}
+}
+
+// checkNodeSane walks a Node and fails t if any edge's Target is
+// internally inconsistent: a node-target with a nil *omnist.Node. Target
+// is a closed struct only constructible via omnist.ValueTarget/NodeTarget
+// (the latter panics on nil), so this should never fire -- it's a cheap
+// belt-and-suspenders structural check, not a claim about document
+// semantics.
+func checkNodeSane(t *testing.T, n *omnist.Node, depth int) {
+	t.Helper()
+	if n == nil {
+		t.Fatal("checkNodeSane: nil node")
+	}
+	if depth > 10000 {
+		t.Fatal("checkNodeSane: implausible recursion depth, aborting walk")
+	}
+	for _, e := range n.Edges {
+		if child, ok := e.Target.Node(); ok {
+			if child == nil {
+				t.Fatalf("edge %q: IsNode target with nil *Node", e.Label)
+			}
+			checkNodeSane(t, child, depth+1)
+		}
+	}
+}
+
+// FuzzRead exercises yaml.Read against arbitrary input text. Per issue
+// #57, the only properties asserted are the ones that must hold for ANY
+// input: Read must never panic and must never hang (bounded by go test's
+// fuzz timeout), and on success the resulting Document must be
+// structurally sane. On error nothing is asserted beyond "it's a real
+// error" -- Read's documented contract is that failures come back as
+// *omnist.ParseError, so we additionally confirm the concrete type
+// without caring which one.
+func FuzzRead(f *testing.F) {
+	f.Add("a: 1\n")
+	f.Add("")
+	f.Add("m:\n  - 1\n  - 2\n") // formats-yaml/basic/sequence-becomes-repeated-edges
+	f.Add("d: 2024-01-01\n")    // formats-yaml/temporals/native-date-resolves-with-no-schema
+	f.Add("n: 12:00:00\n")      // formats-yaml/sharp-edges/bare-time-resolves-to-sexagesimal-integer-not-a-time
+	f.Add("on:\n  push: true\n") // formats-yaml/sharp-edges/norway-problem-bare-on-key-resolves-to-boolean-and-is-rejected
+	f.Add("v: \"no\"")          // repo-test-literal
+	f.Add("a: 1\nb: 2\n")       // repo-test-literal
+	f.Add("m:\n  - A\n  - B\n") // repo-test-literal
+	f.Add("status: no\n")       // repo-test-literal
+	f.Add("placed: 2024-01-01\n") // repo-test-literal
+	f.Add("a: &x foo\nb: *x\n")   // repo-test-literal
+	f.Add("a: &x {k: v}\nb: *x\n") // repo-test-literal
+	f.Add("t: 12:00:00\n")         // repo-test-literal
+	f.Add("t: -1:02\n")            // repo-test-literal
+	f.Add("on: true\n")            // repo-test-literal
+	f.Add("\"on\": true\n")        // repo-test-literal
+	f.Add("v: ")                   // repo-test-literal
+	f.Add("~: value\n")            // repo-test-literal
+	f.Add("? {a: 1}\n: value\n")   // repo-test-literal
+	f.Add("v: 0x_\n")              // repo-test-literal
+	f.Add("v: 1e400\n")            // repo-test-literal
+	f.Add("v: hello world\n")      // repo-test-literal
+	f.Add("- 1\n- 2\n")            // repo-test-literal
+	f.Add("a: []\n")               // repo-test-literal
+	f.Add("a:\n  - 1\n  - - 2\n")  // repo-test-literal
+	f.Add("42\n")                  // repo-test-literal
+	f.Add("a:\n  b:\n    c:\n      d: 1\n") // repo-test-literal
+	f.Add("a:\n  - b: 1\n  - c:\n      d: 1\n") // repo-test-literal
+	f.Add("a: {}\nb: {}\nc: {}\n") // repo-test-literal
+	f.Add("123456\n")              // repo-test-literal
+	f.Add("num: 12345\n")          // repo-test-literal
+
+	f.Fuzz(func(t *testing.T, text string) {
+		doc, err := Read(text, fuzzLimits())
+		if err != nil {
+			if _, ok := err.(*omnist.ParseError); !ok {
+				t.Fatalf("Read returned a non-*omnist.ParseError error: %T: %v", err, err)
+			}
+			return
+		}
+		if doc.IsNode {
+			checkNodeSane(t, doc.Node, 0)
+		}
+	})
+}

--- a/oml/oml_fuzz_test.go
+++ b/oml/oml_fuzz_test.go
@@ -1,0 +1,105 @@
+package oml
+
+import (
+	"testing"
+
+	omnist "github.com/omnist-dev/omnist-go"
+)
+
+// fuzzLimits is deliberately small (unlike omnist.DefaultLimits()) so the
+// fuzzer's mutations spend their budget exploring the limit-boundary logic
+// itself (depth/node-count/int-digit checks) rather than just building
+// large-but-legal documents. See issue #57.
+func fuzzLimits() omnist.Limits {
+	return omnist.Limits{MaxDepth: 8, MaxNodes: 64, MaxIntDigits: 12}
+}
+
+// checkNodeSane walks a Node and fails t if any edge's Target is
+// internally inconsistent: a node-target with a nil *omnist.Node. Target
+// is a closed struct only constructible via omnist.ValueTarget/NodeTarget
+// (the latter panics on nil), so this should never fire — it's a cheap
+// belt-and-suspenders structural check, not a claim about document
+// semantics.
+func checkNodeSane(t *testing.T, n *omnist.Node, depth int) {
+	t.Helper()
+	if n == nil {
+		t.Fatal("checkNodeSane: nil node")
+	}
+	if depth > 10000 {
+		// Guard the checker itself against unbounded recursion; a Document
+		// built under fuzzLimits() can never actually be this deep.
+		t.Fatal("checkNodeSane: implausible recursion depth, aborting walk")
+	}
+	for _, e := range n.Edges {
+		if child, ok := e.Target.Node(); ok {
+			if child == nil {
+				t.Fatalf("edge %q: IsNode target with nil *Node", e.Label)
+			}
+			checkNodeSane(t, child, depth+1)
+		}
+	}
+}
+
+// FuzzRead exercises oml.Read against arbitrary input text. Per issue #57,
+// the only properties asserted are the ones that must hold for ANY input:
+// Read must never panic and must never hang (bounded by go test's fuzz
+// timeout), and on success the resulting Document must be structurally
+// sane. On error nothing is asserted beyond "it's a real error" -- Read's
+// documented contract is that failures come back as *omnist.ParseError,
+// so we additionally confirm the concrete type without caring which one.
+func FuzzRead(f *testing.F) {
+	f.Add("a: 1\n")
+	f.Add("")
+	f.Add("nan: 1\n") // oml-grammar/reserved/nan-bare-is-a-number-token-not-a-label
+	f.Add("\"nan\": 1\n") // oml-grammar/reserved/quoted-nan-is-an-ordinary-label
+	f.Add("null: 1\n") // oml-grammar/reserved/null-bare-label-at-top-level-fails-on-trailing-colon
+	f.Add("a: { null: 1 }\n") // oml-grammar/reserved/null-bare-label-inside-a-node-is-the-reserved-word-error
+	f.Add("b: [1, 2, 3]\n") // oml-grammar/arrays/repeated-label-sugar-expands-in-place
+	f.Add("b: []\n") // oml-grammar/arrays/empty-array-is-an-error-not-a-zero-edge-expansion
+	f.Add("b: [[1, 2], [3, 4]]\n") // oml-grammar/arrays/nested-array-is-rejected
+	f.Add("b: [1\n2]\n") // oml-grammar/arrays/newline-inside-array-is-an-error
+	f.Add("a: 'C:\\no\\escapes'\n") // oml-grammar/strings/raw-string-performs-no-escape-processing
+	f.Add("a: \"\"\"\nhello\nworld\"\"\"\n") // oml-grammar/strings/multiline-string-strips-leading-newline
+	f.Add("a: \"\"\"\nsays \"\"hi\"\" there\"\"\"\n") // oml-grammar/strings/multiline-string-closes-at-first-run-of-three-quotes
+	f.Add("a: 2024-01-01T10:30\n") // oml-grammar/temporals/date-then-time-lookahead-yields-one-datetime-token
+	f.Add("a: 2024-01-01T99\n") // oml-grammar/temporals/date-then-non-time-suffix-is-date-plus-trailing-content
+	f.Add("\"hello\"\n") // oml-grammar/shape/single-top-level-scalar-is-the-whole-document
+	f.Add("a: hello\n") // oml-grammar/errors/bare-word-in-value-position-is-an-error
+	f.Add("a: \"hi\nthere\"\n") // oml-grammar/errors/literal-control-character-in-string-is-an-error
+	f.Add("a: \"\\q\"\n") // oml-grammar/errors/unrecognized-escape-is-an-error
+	f.Add("a: \"\\ud800\"\n") // oml-grammar/errors/unpaired-high-surrogate-is-an-error
+	f.Add("a: \"hello") // oml-grammar/errors/unterminated-string-is-an-error
+	f.Add("2024-01-01T10:30") // repo-test-literal
+	f.Add("a: 'C:\\no\\escapes'") // repo-test-literal
+	f.Add("\"nan\": 1") // repo-test-literal
+	f.Add("b: [1, 2, 3]") // repo-test-literal
+	f.Add("a: {}") // repo-test-literal
+	f.Add("\"hello\"") // repo-test-literal
+	f.Add("2024-01-01") // repo-test-literal
+	f.Add("a: \"\\\"\\\\\\/\\b\\f\\n\\r\\t\"") // repo-test-literal
+	f.Add("a: \"\\u00e9\"") // repo-test-literal
+	f.Add("a: \"\\ud83d\\ude00\"") // repo-test-literal
+	f.Add("a: 'a\\b'") // repo-test-literal
+	f.Add("a: \"\"\"hi\"\"\"") // repo-test-literal
+	f.Add("a: \"\"\"x\"y\"\"\"") // repo-test-literal
+	f.Add("a: [1, 2,]") // repo-test-literal
+	f.Add("a: [{x: 1}, {x: 2}]") // repo-test-literal
+	f.Add("42") // repo-test-literal
+	f.Add("null") // repo-test-literal
+	f.Add("true") // repo-test-literal
+	f.Add("false") // repo-test-literal
+	f.Add("name: \"Ann\"; address: { city: \"Zurich\"; postcode: \"8001\" }; tag: \"x\"; tag: \"y\"") // repo-test-literal
+
+	f.Fuzz(func(t *testing.T, text string) {
+		doc, err := Read(text, fuzzLimits())
+		if err != nil {
+			if _, ok := err.(*omnist.ParseError); !ok {
+				t.Fatalf("Read returned a non-*omnist.ParseError error: %T: %v", err, err)
+			}
+			return
+		}
+		if doc.IsNode {
+			checkNodeSane(t, doc.Node, 0)
+		}
+	})
+}

--- a/osd/osd_fuzz_test.go
+++ b/osd/osd_fuzz_test.go
@@ -1,0 +1,95 @@
+package osd
+
+import (
+	"testing"
+
+	omnist "github.com/omnist-dev/omnist-go"
+)
+
+// checkSchemaSane performs a cheap, meaningful structural check on a
+// successfully parsed Schema: every record referenced by Root and by every
+// field's type must actually resolve in Env, and EnvOrder must describe
+// the same key set as Env (see the invariant documented on omnist.Schema).
+// It intentionally does not assert full spec well-formedness (S-1..S-7) --
+// that is validate.go's job, not the reader's, and not what fuzzing this
+// reader is for.
+func checkSchemaSane(t *testing.T, s omnist.Schema) {
+	t.Helper()
+	if len(s.EnvOrder) != len(s.Env) {
+		t.Fatalf("EnvOrder has %d entries but Env has %d", len(s.EnvOrder), len(s.Env))
+	}
+	seen := make(map[string]bool, len(s.EnvOrder))
+	for _, name := range s.EnvOrder {
+		if seen[name] {
+			t.Fatalf("EnvOrder lists %q more than once", name)
+		}
+		seen[name] = true
+		if _, ok := s.Env[name]; !ok {
+			t.Fatalf("EnvOrder lists %q but Env has no entry for it", name)
+		}
+		if s.Env[name] == nil {
+			t.Fatalf("Env[%q] is nil", name)
+		}
+	}
+}
+
+// FuzzRead exercises osd.Read against arbitrary input text. Unlike the
+// other five readers, osd.Read takes no Limits: an OSD schema is authored
+// text, not attacker-controlled data (see the doc comment on Read), so
+// there is no small-limits variant to construct here. The only properties
+// asserted are: Read must never panic, must never hang, and on success
+// must return a structurally sane Schema. On error nothing is asserted
+// beyond "it's a real error" -- Read's documented contract is that
+// failures come back as either *omnist.ParseError or omnist.Diagnostic,
+// and fuzzing isn't about which one.
+func FuzzRead(f *testing.F) {
+	f.Add("record R { \"a\": string } root R")
+	f.Add("")
+	f.Add("record R {\n    \"a\\nb\": string,\n}\nroot R\n") // osd-grammar/strings/label-unescaping-has-no-named-escape-table
+	f.Add("record R {\n    \"a\" [1,5]: string,\n}\nroot R\n") // osd-grammar/cardinality/bounded-range
+	f.Add("record R {\n    \"a\" [5,]: string,\n}\nroot R\n") // osd-grammar/cardinality/at-least-m-unbounded
+	f.Add("record R {\n    \"a\" [,5]: string,\n}\nroot R\n") // osd-grammar/cardinality/comma-first-at-most-n
+	f.Add("record R {\n    \"a\" [,]: string,\n}\nroot R\n") // osd-grammar/cardinality/comma-only-any-count
+	f.Add("record R {\n    \"a\" []: string,\n}\nroot R\n") // osd-grammar/cardinality/empty-brackets-is-an-error
+	f.Add("record R {\n    \"a\" [-1]: string,\n}\nroot R\n") // osd-grammar/cardinality/negative-minimum-is-invalid-not-a-syntax-error
+	f.Add("record R {\n    \"a\" [1,0]: string,\n}\nroot R\n") // osd-grammar/cardinality/inverted-range-is-invalid
+	f.Add("record R {\n    \"a\" [1.5]: string,\n}\nroot R\n") // osd-grammar/cardinality/non-integer-bound-is-an-error
+	f.Add("record R {\n    \"a\": string?,\n}\nroot R\n") // osd-grammar/nullable/nullable-scalar-is-legal
+	f.Add("record Other {\n    \"x\": string,\n}\nrecord R {\n    \"a\": Other?,\n}\nroot R\n") // osd-grammar/nullable/question-mark-on-a-reference-is-rejected
+	f.Add("record R {\n    \"data\": any?,\n}\nroot R\n") // osd-grammar/any/any-with-question-mark-is-rejected
+	f.Add("record R {\n    \"data\": Any,\n}\nroot R\n") // osd-grammar/any/capitalized-any-is-an-ordinary-reference
+	f.Add("record string {\n    \"a\": string,\n}\nroot string\n") // osd-grammar/reserved-names/record-named-after-a-scalar-keyword-is-rejected
+	f.Add("record any {\n    \"a\": string,\n}\nroot any\n") // osd-grammar/reserved-names/record-named-any-is-rejected
+	f.Add("record R {\n    \"a\": string,\n}\nrecord R {\n    \"b\": integer,\n}\nroot R\n") // osd-grammar/reserved-names/duplicate-record-definition-is-an-error
+	f.Add("record R {\n    \"a\": string,\n}\n") // osd-grammar/root/missing-root-is-an-error
+	f.Add("record R {\n    a: string,\n}\nroot R\n") // osd-grammar/labels/unquoted-field-name-is-rejected
+	f.Add("record R {\n    \"a\": \"string\",\n}\nroot R\n") // osd-grammar/labels/quoted-string-in-type-position-is-rejected
+	f.Add("record R {\n    \"a\": string,\n}\nroot R\n") // osd-grammar/records/trailing-comma-after-last-field-is-legal
+	f.Add("record R {\n    \"a\": string,\n    \"a\": integer,\n}\nroot R\n") // osd-grammar/records/duplicate-field-label-in-one-record-is-an-error
+	f.Add("record R {\n    \"data\" [0,]: any,\n}\nroot R\n") // osd-grammar/any/cardinality-is-orthogonal-to-any
+	f.Add("record R { \"a\" [1,5]: string } root R") // repo-test-literal
+	f.Add("record R { \"a\" [5,]: string } root R") // repo-test-literal
+	f.Add("record R { \"a\" [,5]: string } root R") // repo-test-literal
+	f.Add("record R { \"a\" [,]: string } root R") // repo-test-literal
+	f.Add("record R { \"a\": string? } root R") // repo-test-literal
+	f.Add("record R { \"a\": string, } root R") // repo-test-literal
+	f.Add("record R { \"data\": any } root R") // repo-test-literal
+	f.Add("record R { \"data\" [0,]: any } root R") // repo-test-literal
+	f.Add("record R { \"a\\\\b\": string } root R") // repo-test-literal
+	f.Add("record R { \"a\\\"b\": string } root R") // repo-test-literal
+	f.Add("record R { \"a\\tb\": string } root R") // repo-test-literal
+	f.Add("record R { \"a\": ") // repo-test-literal
+	f.Add("record R { \"b\": B } record B { \"x\": string } root R") // repo-test-literal
+	f.Add("record A { \"b\" [0,1]: B } record B { \"a\" [0,1]: A } root A") // repo-test-literal
+	f.Add("record A{\"x\":string} record B{\"x\":string} root A root B") // repo-test-literal
+	f.Add("record R{\"a\":string} record Unused{\"x\":string} root R") // repo-test-literal
+	f.Add("record R { } root R") // repo-test-literal
+
+	f.Fuzz(func(t *testing.T, text string) {
+		schema, err := Read(text)
+		if err != nil {
+			return
+		}
+		checkSchemaSane(t, schema)
+	})
+}

--- a/temporal.go
+++ b/temporal.go
@@ -62,6 +62,16 @@ const (
 // OML is the format whose native literal syntax the temporal scalar kinds
 // were designed around (§2.2.1/§4).
 func MatchesISOKind(s string, kind TemporalKind) bool {
+	// Found via fuzzing (issue #57): regexp.FindString returns "" both when
+	// there is no match and when the match itself is the empty string, so
+	// without this guard an empty s would spuriously "match" every kind
+	// (none of ISODateRegexp/ISOTimeRegexp/ISODateTimeRegexp can ever
+	// legitimately match "" — they all require at least a fixed run of
+	// digits). Reject it upfront rather than relying on that ambiguous
+	// equality check to happen to come out false.
+	if s == "" {
+		return false
+	}
 	var re *regexp.Regexp
 	switch kind {
 	case TemporalDate:

--- a/temporal_test.go
+++ b/temporal_test.go
@@ -96,3 +96,19 @@ func TestFormatISODate(t *testing.T) {
 		t.Errorf("FormatISODate(...) = %q, want %q", got, want)
 	}
 }
+
+// TestMatchesISOKindEmptyString exercises MatchesISOKind's empty-string
+// guard directly, for the same cross-package coverage-attribution reason
+// as the tests above: formats/toml's fuzz-found regression tests (issue
+// #57) call this guard by way of parseTOMLDateTime, but that only
+// instruments formats/toml's own coverage, not this package's. Found via
+// fuzzing: regexp.FindString("") == "" whether or not the regex actually
+// matched, so without this guard an empty string would spuriously
+// "match" every kind.
+func TestMatchesISOKindEmptyString(t *testing.T) {
+	for _, kind := range []TemporalKind{TemporalDate, TemporalTime, TemporalDateTime} {
+		if MatchesISOKind("", kind) {
+			t.Errorf("MatchesISOKind(\"\", %v) = true, want false", kind)
+		}
+	}
+}


### PR DESCRIPTION
Closes #57.

Adds fuzz tests (FuzzRead) to all 6 reader packages (oml, osd, formats/{json,yaml,toml,xml}), seeded from the vendored omnist-spec test-suite and each package's own existing tests. This is the last item on the port's original build list.

Real fuzzing found two genuine bugs in formats/toml, both fixed here:

1. A crash: go-toml/v2's unstable.Parser can tag a node as a temporal kind on text that doesn't have the full digit layout ParseISODate/ParseISOTime require as a precondition (e.g. bare "00:"). Fixed by validating against the shared ISODateRegexp/ISOTimeRegexp before parsing.

2. The root cause underneath it, in shared root-level temporal.go: MatchesISOKind had a latent bug where regexp.FindString("") returns "" on both no-match and empty-match, so an empty string spuriously matched every temporal kind. Fixed by rejecting empty strings up front.

Independently reproduced both against the parent commit, not just re-read: built the old MatchesISOKind logic standalone and confirmed it really does return true for "" against all three kinds; checked out the parent commit in a scratch worktree and confirmed the two committed crash-corpus inputs (formats/toml/testdata/fuzz/FuzzRead/) genuinely panic there and don't at this commit.

The materialize.go exposure turned out to matter more than the original bug description suggested: traced tryUpgrade directly and found the old MatchesISOKind bug created a clean, TOML-independent panic path -- any Scalar{Kind: KindString, Str: ""} upgraded toward a temporal kind during materialize reached ParseISODateTime("")'s strings.IndexByte(s,'T') returning -1, then an out-of-bounds slice. Reproduced this panic directly against the parent commit and confirmed it's now a clean error instead. This was a real, previously-unguarded crash reachable from any codec or direct Document construction, not a TOML-specific issue.

All 6 fuzz functions independently re-run clean for 30s each, including formats/toml. All gates pass with real output; every touched package (root, formats/toml, oml, osd, formats/json, formats/yaml, formats/xml) confirmed genuinely 100% coverage, pre-existing cmd/omnist exceptions unchanged. CI fuzz job confirmed genuinely time-boxed (10s per package, 60s total) and wired to actually fail on a real crash, not silently swallow one. Seed corpus spot-checked as genuinely spec-derived, not fabricated.