### PR TITLE
Fix validate integer<:number exception; make Track 1 lint code comparison code-agnostic

### DIFF
--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -17,29 +17,33 @@ conformance harness, and fuzz tests on every reader (`go test -fuzz`).
 
 Track 2 ([`tools/conformance/`](https://github.com/omnist-dev/omnist-go/tree/main/tools/conformance),
 JSON-vector, run against `omnist-spec`'s `test-suite/`) currently reports
-**149 pass / 1 fail / 1 skip** of 151 vectors. Track 1 (fixture-based,
-`conformance/fixtures/`) reports **18 pass / 1 fail / 0 skip** of 19
-fixtures. Both remaining fails are confirmed not `omnist-go` bugs — the
-Track 2 one is a genuine spec-vector defect at `test-suite/validate/
-basic_validate.json`'s `integer-satisfies-number-typed-field` case (the
-vector expects `validate` to accept an integer value against a
-`number`-typed field, conflating `materialize`'s §7.2 upgrade rule with
-`validate`'s stricter §3.6 kind-equality check — filed as
-[`omnist-spec#41`](https://github.com/omnist-dev/omnist-spec/issues/41));
-the Track 1 one is a fixture using an un-namespaced `lint.*` code
-(`unreachable-record` instead of `lint.unreachable-record`) in
-`conformance/fixtures/lint/edge-case-unreachable-record` — filed as
-[`omnist-spec#42`](https://github.com/omnist-dev/omnist-spec/issues/42).
-The one Track 2 skip needs a TOML strict-mode write parameter this repo
-hasn't built yet. Neither track's remaining item is CI-gating yet, per
-`docs/workflow-playbook.md` §4.
+**150 pass / 0 fail / 1 skip** of 151 vectors. Track 1 (fixture-based,
+`conformance/fixtures/`) reports **19 pass / 0 fail / 0 skip** of 19
+fixtures. Both tracks are at zero real fails — the two prior fails, filed
+as [`omnist-spec#41`](https://github.com/omnist-dev/omnist-spec/issues/41)
+and [`omnist-spec#42`](https://github.com/omnist-dev/omnist-spec/issues/42),
+were independently verified by the spec maintainer against the reference
+implementation and found to be backwards diagnoses (issue #60): #41 was a
+genuine `omnist-go` bug, not a spec-vector defect — `validate.go`'s
+`conformScalar` did a bare kind-equality check with no `integer <:
+number` value-level exception, which omnist-spec's now-formalized
+`matches_kind` pseudocode (§3.6.1) confirms live against the Python
+reference implementation is wrong; `validate` on an integer value against
+a `number`-typed field must succeed. That's fixed. #42 needed no
+production code change — the `lint/edge-case-unreachable-record` fixture
+was always correct (the reference implementation genuinely emits the bare
+`unreachable-record`, not a namespaced form); what was missing was
+extending §8.5.2 rule 4's code-agnostic comparison (already used for
+Track 2's diagnostics) to Track 1's finding `code` field, done in
+`tools/conformance/fixtures.go`. The one Track 2 skip needs a TOML
+strict-mode write parameter this repo hasn't built yet. Not CI-gating yet,
+per `docs/workflow-playbook.md` §4.
 
 ## Versioning
 
 Stays on `v0.0.x-alpha` until both conformance tracks pass with zero real
-fails (skips permitted and cited) — the 2 current fails are spec-side, not
-`omnist-go`'s to fix, so the bump is gated on upstream vector corrections
-landing and this repo's submodule pin catching up. See
+fails (skips permitted and cited) — as of issue #60 that condition is met;
+the version bump is a separate, deliberate step per
 `docs/workflow-playbook.md` §1.
 
 ## Spec version targeted

--- a/tools/conformance/fixtures.go
+++ b/tools/conformance/fixtures.go
@@ -393,14 +393,25 @@ func runFixtureLint(fc FixtureCase) Result {
 	if len(findings) != len(want.Findings) {
 		return fixFail(fc, "findings count mismatch: got %d want %d", len(findings), len(want.Findings))
 	}
+	// Findings' code field is compared code-agnostically (conformance-
+	// harness.md §8.5's lint paragraph, extending §8.5.2 rule 4's
+	// code-agnostic mode -- already used this way for Track 2's
+	// diagnostics -- to every operation whose fixture carries a code
+	// field, not lint alone): no implementation emits real §8.3-namespaced
+	// codes yet (§9.4 D-4), so a fixture's expected.json recorded against
+	// the reference implementation's still-bare codes (e.g.
+	// "unreachable-record") must not fail an implementation that has
+	// already adopted the namespaced form ahead of D-4 resolving (e.g.
+	// this repo's own "lint.unreachable-record"). severity and location
+	// are still compared exactly; only code is informational.
 	gotSet := map[string]int{}
 	for _, f := range findings {
-		gotSet[string(f.Code)+"\x00"+f.Severity.String()+"\x00"+f.Location]++
+		gotSet[f.Severity.String()+"\x00"+f.Location]++
 	}
 	for _, f := range want.Findings {
-		k := f.Code + "\x00" + f.Severity + "\x00" + f.Location
+		k := f.Severity + "\x00" + f.Location
 		if gotSet[k] == 0 {
-			return fixFail(fc, "findings mismatch: missing {code:%q severity:%q location:%q}", f.Code, f.Severity, f.Location)
+			return fixFail(fc, "findings mismatch: missing {severity:%q location:%q} (code %q compared informationally, not matched)", f.Severity, f.Location, f.Code)
 		}
 		gotSet[k]--
 	}

--- a/validate.go
+++ b/validate.go
@@ -104,9 +104,26 @@ func conformScalar(target Target, r Resolved, path Path, result *[]Diagnostic) {
 		}
 		return // null is never checked against kind, matching kind or not.
 	}
-	if v.Scalar.Kind != r.ScalarKind {
+	if !matchesKind(v.Scalar.Kind, r.ScalarKind) {
 		addDiagnostic(result, path, CodeValidateTypeMismatch, "value does not match declared kind")
 	}
+}
+
+// matchesKind is `matches_kind(value, declared_kind)` from §3.6.1. A
+// value's own kind satisfies the declared kind either by exact match, or
+// via the one sanctioned scalar subtype relation (§6.3): an integer value
+// satisfies a number-typed field directly. This is not materialization --
+// no conversion happens, the value's own kind is simply a subtype of the
+// declared one. No other subtype relation exists; this relation is
+// one-directional (a number value does NOT satisfy an integer-typed field).
+func matchesKind(valueKind, declaredKind ScalarKind) bool {
+	if valueKind == declaredKind {
+		return true
+	}
+	if valueKind == KindInteger && declaredKind == KindNumber {
+		return true
+	}
+	return false
 }
 
 // conformRecord is `conform_record(node, S, rec, path, result)` from

--- a/validate_test.go
+++ b/validate_test.go
@@ -140,20 +140,21 @@ func TestValidateWrongScalarKind(t *testing.T) {
 	}
 }
 
-// TestValidateIntegerDoesNotSatisfyNumberTypedField pins issue #33's
-// Category E finding: validate.go's conformScalar is a bare kind-equality
-// check (spec §3.6.1's conform_scalar/matches_kind), deliberately with no
-// integer<:number allowance. That allowance exists only for schema-level
-// subtyping (§6.3, compatible_with.go) and for materialize's try_upgrade
-// table (§7.2, "1 -> number: Yes") — a genuinely different operation from
-// validate ("Validation checks, it never converts", §3.6). Conformance
-// vector validate/scalar-kinds/integer-satisfies-number-typed-field
-// expects this to succeed, which contradicts both of those spec sections
-// read together; this repo treats that vector as a defect (it tests
-// materialize's allowance against validate's stricter rule) rather than
-// weakening validate to match it. See the issue report for the full
-// spec trace.
-func TestValidateIntegerDoesNotSatisfyNumberTypedField(t *testing.T) {
+// TestValidateIntegerSatisfiesNumberTypedField pins the corrected reading
+// of issue #33's Category E finding: omnist-spec now formally defines
+// matches_kind (§3.6.1), added specifically because its previous absence
+// let this repo's conformScalar take a defensible-but-wrong strict-kind-
+// equality reading. matches_kind sanctions exactly one scalar subtype
+// relation at the value level, the same one that already applies at the
+// schema level (§6.3): an integer VALUE satisfies a number-typed field
+// directly. This is NOT materialization — no conversion happens, the
+// value's own kind already satisfies the declared kind, nothing is
+// upgraded — so it doesn't touch materialize.go's tryUpgrade at all.
+// Confirmed live against the Python reference implementation, and matches
+// conformance vector validate/scalar-kinds/integer-satisfies-number-typed-field.
+// See issue #60 for the full spec trace and the reversal of #33's original
+// diagnosis.
+func TestValidateIntegerSatisfiesNumberTypedField(t *testing.T) {
 	rec := &Record{
 		Name:   "R",
 		Fields: []Field{{Label: "n", Type: ScalarType(KindNumber, false), Cardinality: DefaultCardinality()}},
@@ -162,8 +163,44 @@ func TestValidateIntegerDoesNotSatisfyNumberTypedField(t *testing.T) {
 	n := NewNode()
 	n.AddValue("n", ScalarValue(NewIntegerScalar(big.NewInt(1))))
 	got := Validate(NodeDocument(n), s)
+	if len(got) != 0 {
+		t.Fatalf("Validate() = %+v, want empty (integer satisfies a number-typed field per matches_kind, §3.6.1/§6.3)", got)
+	}
+}
+
+// TestValidateNumberDoesNotSatisfyIntegerTypedField confirms the
+// integer<:number relation is genuinely one-directional: a number value
+// must NOT satisfy an integer-typed field. matches_kind sanctions only
+// "integer VALUE satisfies number-typed field", not the reverse.
+func TestValidateNumberDoesNotSatisfyIntegerTypedField(t *testing.T) {
+	rec := &Record{
+		Name:   "R",
+		Fields: []Field{{Label: "n", Type: ScalarType(KindInteger, false), Cardinality: DefaultCardinality()}},
+	}
+	s := Schema{Root: "R", Env: map[string]*Record{"R": rec}}
+	n := NewNode()
+	n.AddValue("n", ScalarValue(NewNumberScalar(1.5)))
+	got := Validate(NodeDocument(n), s)
 	if len(got) != 1 || got[0].Code != CodeValidateTypeMismatch || got[0].Path != "$.n" {
-		t.Fatalf("Validate() = %+v, want single type-mismatch at $.n (integer must not satisfy a number-typed field at the validate layer)", got)
+		t.Fatalf("Validate() = %+v, want single type-mismatch at $.n (number must not satisfy an integer-typed field)", got)
+	}
+}
+
+// TestValidateUnrelatedKindStillMismatches confirms matches_kind's
+// exception is scoped to exactly the integer<:number pair, not scalar
+// kinds in general: a string value against a number-typed field must
+// still fail.
+func TestValidateUnrelatedKindStillMismatches(t *testing.T) {
+	rec := &Record{
+		Name:   "R",
+		Fields: []Field{{Label: "n", Type: ScalarType(KindNumber, false), Cardinality: DefaultCardinality()}},
+	}
+	s := Schema{Root: "R", Env: map[string]*Record{"R": rec}}
+	n := NewNode()
+	n.AddValue("n", ScalarValue(NewStringScalar("1")))
+	got := Validate(NodeDocument(n), s)
+	if len(got) != 1 || got[0].Code != CodeValidateTypeMismatch || got[0].Path != "$.n" {
+		t.Fatalf("Validate() = %+v, want single type-mismatch at $.n (string must not satisfy a number-typed field)", got)
 	}
 }
 


### PR DESCRIPTION
Resolves #60. Both original diagnoses in #33/#35/#55 were confirmed backwards by omnist-spec independent verification against the reference implementation. Track 2 now 150/0/1, Track 1 now 19/0/0 -- genuinely zero real fails on both tracks. materialize.go untouched (validate-only fix). See commit message for full detail.