### PR TITLE
Doc site: API reference page + CI-enforced doc-example verification gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,13 @@ jobs:
           # of its branches are per-operation drivers that only make sense
           # exercised against real vectors, not synthesized in isolation.
           #
+          # tools/check_doc_examples/ is excluded the same way (issue #62):
+          # its primary verification is the `doc-examples` job below
+          # actually running it against real docs/*.md content (including
+          # the adversarial "does it fail on a deliberately-unmarked
+          # block" check performed when that job was built), not unit
+          # coverage of a small, single-purpose CLI tool.
+          #
           # Two specific functions in cmd/omnist are excluded (issue #37),
           # scoped tightly rather than excluding the whole package -- every
           # other function in cmd/omnist holds the normal 100% bar via
@@ -56,7 +63,7 @@ jobs:
           #     today" (kept only for future signature stability) -- there
           #     is currently no way to make that branch return a non-nil
           #     error to exercise it.
-          uncovered=$(go tool cover -func=coverage.out | grep -v '^total:' | grep -v '100.0%$' | grep -v '^github.com/omnist-dev/omnist-go/tools/conformance/' | grep -v '^github.com/omnist-dev/omnist-go/cmd/omnist/app.go:.*[[:space:]]main[[:space:]]' | grep -v '^github.com/omnist-dev/omnist-go/cmd/omnist/cmd_materialize.go:.*[[:space:]]cmdMaterialize[[:space:]]' || true)
+          uncovered=$(go tool cover -func=coverage.out | grep -v '^total:' | grep -v '100.0%$' | grep -v '^github.com/omnist-dev/omnist-go/tools/conformance/' | grep -v '^github.com/omnist-dev/omnist-go/tools/check_doc_examples/' | grep -v '^github.com/omnist-dev/omnist-go/cmd/omnist/app.go:.*[[:space:]]main[[:space:]]' | grep -v '^github.com/omnist-dev/omnist-go/cmd/omnist/cmd_materialize.go:.*[[:space:]]cmdMaterialize[[:space:]]' || true)
           if [ -n "$uncovered" ]; then
             echo "The following functions are not fully covered:"
             echo "$uncovered"
@@ -114,6 +121,27 @@ jobs:
             go test "$pkg" -run=FuzzRead -fuzz=FuzzRead -fuzztime=10s
             echo "::endgroup::"
           done
+
+  doc-examples:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.26'
+      - name: Verify docs/*.md code-block markers (issue #62)
+        run: |
+          # Every fenced code block in docs/*.md must carry a
+          # <!-- verified-by: ... --> or <!-- doc-illustrative --> marker
+          # for any block that's new or changed relative to origin/main.
+          # This is a doc-quality gate, not a judgment-call conformance
+          # gate (unlike the `conformance` job below) -- a missing marker
+          # is unambiguous, so this job is blocking. See
+          # docs/workflow-playbook.md Sec7 and tools/check_doc_examples/.
+          git fetch origin main
+          go run ./tools/check_doc_examples -base=origin/main
 
   conformance:
     runs-on: ubuntu-latest

--- a/doc_examples_test.go
+++ b/doc_examples_test.go
@@ -1,0 +1,122 @@
+package omnist_test
+
+// This file backs the runnable Go code blocks in docs/getting-started.md
+// with real godoc Example functions (issue #62). `go test` executes each
+// Example and checks its "// Output:" comment verbatim, so these functions
+// are not just "tests with a plausible name" -- they assert the doc's
+// literal displayed output. Each Example's body is kept in sync,
+// character-for-character where feasible, with the corresponding fenced
+// code block in docs/getting-started.md; if you change one, change the
+// other and re-run `go test .` to confirm the Output: comment still
+// matches.
+//
+// Document has no String() method (spec's Document model is an edge list,
+// not a map, and there's no single obviously-right stringification -- see
+// docs/workflow-playbook.md Sec2.3). formatDocument below is a small,
+// test-local helper that renders a flat Node's edges as
+// `(label,"value"), ...`, purely so these examples have deterministic,
+// human-readable Output: text. It is intentionally not part of the public
+// API.
+
+import (
+	"fmt"
+	"strconv"
+
+	omnist "github.com/omnist-dev/omnist-go"
+	"github.com/omnist-dev/omnist-go/formats/json"
+	"github.com/omnist-dev/omnist-go/formats/yaml"
+	"github.com/omnist-dev/omnist-go/osd"
+)
+
+// formatDocument renders a flat (non-nested) Node document as a
+// comma-separated list of (label,value) pairs, in edge order, matching the
+// style used in docs/getting-started.md's prose. Only the scalar kinds
+// exercised by these examples are handled.
+func formatDocument(d omnist.Document) string {
+	if !d.IsNode {
+		return formatValue(d.Value)
+	}
+	parts := make([]string, 0, len(d.Node.Edges))
+	for _, e := range d.Node.Edges {
+		v, ok := e.Target.Value()
+		if !ok {
+			parts = append(parts, fmt.Sprintf("(%s,<node>)", e.Label))
+			continue
+		}
+		parts = append(parts, fmt.Sprintf("(%s,%s)", e.Label, formatValue(v)))
+	}
+	out := "["
+	for i, p := range parts {
+		if i > 0 {
+			out += ", "
+		}
+		out += p
+	}
+	return out + "]"
+}
+
+func formatValue(v omnist.Value) string {
+	if v.IsNull {
+		return "null"
+	}
+	switch v.Scalar.Kind {
+	case omnist.KindString:
+		return strconv.Quote(v.Scalar.Str)
+	case omnist.KindBoolean:
+		return strconv.FormatBool(v.Scalar.Bool)
+	default:
+		return "<scalar>"
+	}
+}
+
+// Example_readDocument backs the first code block in docs/getting-started.md
+// ("Read a document, no schema"): reading JSON produces a flat edge list
+// where a JSON array becomes repeated edges sharing one label, not one edge
+// holding a list.
+func Example_readDocument() {
+	doc, err := json.Read(`{"name": "Ann", "tags": ["a", "b"]}`, omnist.DefaultLimits())
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(formatDocument(doc))
+	// Output: [(name,"Ann"), (tags,"a"), (tags,"b")]
+}
+
+// Example_validateDocument backs the second code block in
+// docs/getting-started.md ("Validate against a schema").
+func Example_validateDocument() {
+	schema, err := osd.Read(`
+		record Person { "name": string, "tags" [0,]: string }
+		root Person
+	`)
+	if err != nil {
+		panic(err)
+	}
+
+	doc, err := json.Read(`{"name": "Ann", "tags": ["a", "b"]}`, omnist.DefaultLimits())
+	if err != nil {
+		panic(err)
+	}
+
+	diagnostics := omnist.Validate(doc, schema)
+	if len(diagnostics) == 0 {
+		fmt.Println("valid")
+	}
+	// Output: valid
+}
+
+// Example_convertFormats backs the fourth code block in
+// docs/getting-started.md ("Convert between formats"): writers are
+// schema-free and serialize whatever Document they're given.
+func Example_convertFormats() {
+	doc, _ := json.Read(`{"name": "Ann"}`, omnist.DefaultLimits())
+	text, diagnostics, err := yaml.Write(doc)
+	if err != nil {
+		panic(err)
+	}
+	if len(diagnostics) != 0 {
+		panic("unexpected diagnostics")
+	}
+	fmt.Print(text)
+	// Output: "name": "Ann"
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,5 +1,6 @@
 # CLI reference
 
+<!-- doc-illustrative -->
 ```bash
 go install github.com/omnist-dev/omnist-go/cmd/omnist@latest
 ```
@@ -8,6 +9,7 @@ There's no spec-mandated CLI contract — `omnist-spec` documents Python's CLI s
 
 ## Commands
 
+<!-- doc-illustrative -->
 ```
 omnist parse --from FORMAT [--to FORMAT] [-o FILE] INPUT
 omnist validate --from FORMAT --schema SCHEMA INPUT
@@ -40,18 +42,21 @@ The three boolean schema commands (`compatible-with`, `equivalent`, `is-empty`) 
 
 Convert JSON to YAML:
 
+<!-- doc-illustrative -->
 ```bash
 echo '{"name": "Ann", "tags": ["a", "b"]}' | omnist parse --from json --to yaml -
 ```
 
 Validate a document against a schema:
 
+<!-- doc-illustrative -->
 ```bash
 omnist validate --from json --schema person.osd person.json
 ```
 
 Check whether a schema change is backward-compatible:
 
+<!-- doc-illustrative -->
 ```bash
 omnist schema compatible-with new.osd old.osd
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -19,9 +19,10 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	fmt.Println(doc) // (name,"Ann"), (tags,"a"), (tags,"b") -- two edges, not one list
+	fmt.Println(doc) // two edges, not one list: (name,"Ann"), (tags,"a"), (tags,"b")
 }
 ```
+<!-- verified-by: doc_examples_test.go::Example_readDocument -->
 
 `tags` reads to two edges sharing one label, not one edge holding a two-element list. That's the whole model: an array is a repeated label, handled the same way whether it came from JSON's `[...]`, OML's repeated `tags:` lines, or XML's repeated `<tag>` elements.
 
@@ -58,6 +59,7 @@ func main() {
 	}
 }
 ```
+<!-- verified-by: doc_examples_test.go::Example_validateDocument -->
 
 `Validate` checks shape and cardinality against the schema — it never converts a value's type. A JSON `date` field that arrives as a plain string (JSON has no native temporal type) stays a string here; validating it against a `date`-typed field fails, and that's correct: validation checks what's already there.
 
@@ -65,6 +67,7 @@ func main() {
 
 To actually get a `date`-kind value out of a JSON string, use `Materialize` instead — it walks the document against the schema in one pass, upgrading leaves only when the conversion is value-exact (`"2024-01-01"` → `date`: yes; `"1"` → `integer`: no, a string is never coerced to a number).
 
+<!-- doc-illustrative -->
 ```go
 materialized, diagnostics, err := omnist.Materialize(doc, schema)
 ```
@@ -93,11 +96,13 @@ func main() {
 	fmt.Print(text)
 }
 ```
+<!-- verified-by: doc_examples_test.go::Example_convertFormats -->
 
 `diagnostics` reports non-fatal adjustments a write made — a dropped null (TOML has none), a stringified temporal value (JSON has no native date type), a substituted `NaN`. A write can succeed and still have something worth knowing about.
 
 ## From the command line
 
+<!-- doc-illustrative -->
 ```bash
 echo '{"name": "Ann", "tags": ["a", "b"]}' | omnist parse --from json --to yaml -
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,12 +12,14 @@ This port is built directly from [omnist-spec](https://spec.omnist.dev), with no
 
 ## Install
 
+<!-- doc-illustrative -->
 ```bash
 go install github.com/omnist-dev/omnist-go/cmd/omnist@latest
 ```
 
 Or add the library to a module:
 
+<!-- doc-illustrative -->
 ```bash
 go get github.com/omnist-dev/omnist-go
 ```

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1,0 +1,136 @@
+# API reference
+
+`omnist-go`'s canonical, mechanically-generated API reference is
+[pkg.go.dev](https://pkg.go.dev/github.com/omnist-dev/omnist-go) — once the
+module is published there, every exported type, function, and doc comment
+in this repo renders automatically, always in sync with the code. That's
+the idiomatic Go answer to "API reference": don't hand-maintain a second
+copy of `go doc`'s output here.
+
+**Not yet indexed.** As of this page, `omnist-go` has no tagged release
+(`git tag -l` is empty) — pkg.go.dev indexes tagged versions (and the
+`main` branch's latest commit as a pseudo-version) once a module has been
+`go get`-ed at least once from a public proxy. Until the first tag lands
+(tracked by `docs/workflow-playbook.md` §1's `v0.0.x-alpha` -> real version
+bump), treat this page's curated map below as authoritative, and use `go
+doc` locally for the mechanical dump:
+
+<!-- doc-illustrative -->
+```bash
+go doc github.com/omnist-dev/omnist-go
+go doc github.com/omnist-dev/omnist-go.Validate
+```
+
+## What this page is
+
+A curated map of the public API surface, organized by package, with a
+one-line description and doc-comment excerpt per major exported group —
+not a full mechanical dump. Read the linked source doc comments (or run
+`go doc`) for the complete, authoritative signatures.
+
+## Root package — `github.com/omnist-dev/omnist-go`
+
+The Document model, Schema model, and the two document/schema operations
+that don't belong to a specific codec or the algebra package.
+
+### Document model (`document.go`)
+
+- **`Document`** — a node or a bare value (spec §2.2:
+  `Document = node | value`). `IsNode` selects which.
+- **`Node`** — an ordered list of labeled `Edge`s (spec §2.1/§2.2). Labels
+  may repeat; a repeated label is `omnist-go`'s only representation of "an
+  array" — there is no separate list type.
+- **`Edge`** — a single `(Label, Target)` pair.
+- **`Target`** — what an edge points to: exactly a `Value` or a `*Node`
+  (spec D-4). Constructed via `ValueTarget` / `NodeTarget`, read via
+  `IsNode`/`Node()`/`Value()`.
+- **`Value`** / **`Scalar`** — `Value` is a `Scalar` or null (`IsNull`).
+  `Scalar` is a tagged union over the seven kinds spec §2.2.1 defines
+  (`ScalarKind`: string, integer, number, boolean, date, time, datetime) —
+  implementations must not add or collapse kinds. `integer` uses
+  `*math/big.Int` (not `int64`) to support the spec's 4,300-decimal-digit
+  limit. Construct with `NewStringScalar`, `NewIntegerScalar`,
+  `NewNumberScalar`, `NewBooleanScalar`, `NewDateScalar`, `NewTimeScalar`,
+  `NewDateTimeScalar`; compare with `Scalar.Equal`.
+
+### Schema model (`schema.go`)
+
+- **`Schema`** — an environment of named `Record`s plus a `Root` type
+  reference.
+- **`Record`** / **`Field`** — a record's ordered field list; each `Field`
+  carries a `Type` and a `Cardinality`.
+- **`Type`** — a scalar type, a `Record` reference (`RefType`), or `any`
+  (`AnyType`). `ScalarType(kind, nullable)` builds a scalar field type.
+- **`Cardinality`** — `[min, max]` occurrence bounds on a field;
+  `DefaultCardinality()` is `[1,1]` (exactly one, per spec's default).
+
+### Operations
+
+- **`Validate(doc Document, s Schema) []Diagnostic`** (`validate.go`) —
+  checks shape and cardinality against the schema. Never converts a
+  value's type; a JSON string in a `date`-typed field fails, because
+  validation checks what's already there.
+- **`Materialize(doc Document, s Schema) (Document, []Diagnostic, error)`**
+  (`materialize.go`) — walks the document against the schema in one pass,
+  upgrading leaf scalars to their schema-declared kind only when the
+  conversion is value-exact (e.g. `"2024-01-01"` -> `date`, but never
+  string -> number).
+- **`DocumentsEqual`, `SchemasEqual`** (`referee.go`) — order-sensitive
+  document equality and two schema-equality modes (`exact`: record names
+  must match; `isomorphic`: same structure up to renaming), used by this
+  repo's own conformance harness and available for any caller comparing
+  documents/schemas the same way.
+
+### Diagnostics and errors (`errors.go`)
+
+- **`Diagnostic`** — `(Path, Code, Severity, Message)`, spec §8's
+  `(path, code, message)` error taxonomy plus a severity.
+- **`ParseError`** — the structured error a stage-1 (text to `Document`)
+  reader reports: `(Line, Col, Path, Code, Message)`. A text-position path
+  (`"14:8"`), since no `Document` exists yet when a parse error fires.
+
+### Limits (`limits.go`)
+
+- **`Limits`** / **`DefaultLimits()`** — the finite, documented safety
+  bounds (depth, node count, integer digit count) spec §2.4 requires every
+  implementation to enforce. Passed to every format reader.
+
+## `oml` — `github.com/omnist-dev/omnist-go/oml`
+
+OML (the native format) reader and writer: `Read(text string, limits
+omnist.Limits) (omnist.Document, error)`, `Write(d omnist.Document, compact
+bool) (string, []omnist.Diagnostic)` (`WriteCompact` is a convenience
+wrapper for `Write(d, true)`). Round-trips Core and Extended OML per spec.
+
+## `osd` — `github.com/omnist-dev/omnist-go/osd`
+
+OSD (the schema definition format) reader and writer: `Read(text string)
+(omnist.Schema, error)`, `Write(s omnist.Schema, compact bool) string`.
+
+## `formats/{json,yaml,toml,xml}`
+
+One reader/writer pair per format, all with the same reader shape —
+`Read(text string, limits omnist.Limits) (omnist.Document, error)` — and a
+writer shape shared by `xml`/`toml`/`yaml`/`json`:
+`Write(d omnist.Document) (string, []omnist.Diagnostic, error)`. Writers
+are schema-free by design — they serialize whatever `Document` they're
+given, faithfully, and report non-fatal adjustments (a dropped null, a
+stringified temporal value, a substituted `NaN`) as diagnostics rather than
+errors. See each package's doc comment for format-specific caveats (e.g.
+XML leaf-typing, YAML sexagesimal integers, TOML's native date/time
+kinds).
+
+## `algebra` — `github.com/omnist-dev/omnist-go/algebra`
+
+The Schema Algebra operations (spec §6): `CompatibleWith`, `Equivalent`,
+`Normalize`, `Extract`, `Prune`, `Lint`, `Infer`. Each operates purely on
+`omnist.Schema` values — no document, no I/O. See the package doc comment
+for the operation-by-operation contract (each mirrors its spec §6
+subsection).
+
+## Command-line interface
+
+`cmd/omnist` is a thin binding over the library (direct calls, not a
+subprocess wrapper internally) — see the [CLI reference](cli.md) for its
+own documented contract, which is `omnist-go`'s own design, not
+spec-mandated.

--- a/docs/workflow-playbook.md
+++ b/docs/workflow-playbook.md
@@ -73,6 +73,7 @@ representable without an extra indirection layer.
 **Decision**: a tagged struct with a `Kind` discriminant and one field per
 kind's Go-native representation:
 
+<!-- doc-illustrative -->
 ```go
 type ScalarKind int
 
@@ -136,6 +137,7 @@ in code.
 
 **Decision**: structured errors from day one —
 
+<!-- doc-illustrative -->
 ```go
 type ParseError struct {
     Line    int
@@ -282,3 +284,35 @@ sat undetected through several releases as a result.
   itself, not just in a PR description.
 - Don't trust a "this gate is just flaky" claim without checking the gate's
   actual current behavior first.
+
+## 7. Doc-example verification gate (issue #62)
+
+Every fenced code block in `docs/*.md` needs an HTML-comment marker
+directly above the block:
+
+- `<!-- verified-by: path/to/test.go::TestOrExampleName -->` -- there is a
+  real Go test (prefer a `godoc`-style `Example` function with a real
+  `// Output:` comment, since `go test` executes it directly) whose
+  assertions cover this exact block's literal displayed content, not just
+  a related code path.
+- `<!-- doc-illustrative -->` -- the block is conceptual/non-runnable (a
+  CLI transcript, a design-decision snapshot, a bare fragment) and
+  deliberately has no backing test. Don't force a test onto something that
+  isn't real runnable code just to satisfy the gate.
+
+`tools/check_doc_examples.go` (run as the CI job `doc-examples` in
+`.github/workflows/ci.yml`) diffs `docs/*.md` against `origin/main...HEAD`
+and fails if any *added or changed* code block lacks one of the two
+markers. It does not retroactively flag pre-existing unmarked blocks --
+but as of issue #62 there are none, so keep it that way going forward:
+mark every new or edited block when you touch a doc page.
+
+**Known trap**: a local run of the checker against uncommitted changes
+gives a false "passed", because it diffs against `origin/main`, not the
+working tree. Commit before trusting a local run.
+
+When writing `verified-by`, actually open the test and confirm it asserts
+the doc's literal displayed text/output -- a test whose name merely sounds
+related is not sufficient. (The Python port shipped a stale version-string
+doc example undetected for 5+ releases this way; the guarding test checked
+the live version constant, never the doc's own literal text.)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,5 +41,6 @@ nav:
   - Home: index.md
   - Getting started: getting-started.md
   - CLI: cli.md
+  - API reference: reference.md
   - Workflow playbook: workflow-playbook.md
   - Status & limitations: limitations.md

--- a/tools/check_doc_examples/main.go
+++ b/tools/check_doc_examples/main.go
@@ -1,0 +1,266 @@
+// Command check_doc_examples is the CI gate for issue #62: every fenced
+// code block in docs/*.md must carry an HTML-comment marker, directly
+// above or below the block, declaring how it's verified:
+//
+//   - <!-- verified-by: path/to/test.go::TestOrExampleName --> -- a real
+//     Go test backs this exact block's literal content/output.
+//   - <!-- doc-illustrative --> -- the block is conceptual or non-runnable
+//     (a CLI transcript, a design-decision snapshot, a bare fragment) and
+//     deliberately has no backing test.
+//
+// The gate only requires a marker on code blocks that are new or changed
+// relative to the PR's base branch (default origin/main, see -base) --
+// pre-existing unmarked blocks at the time this gate ships are not
+// retroactively flagged. It never gates on blocks that are unchanged.
+//
+// Known trap (see docs/workflow-playbook.md Sec7): running this against an
+// uncommitted working tree gives a false "passed", because the diff is
+// against the base branch's committed history, not the working tree.
+// Commit before trusting a local run.
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// codeBlock is one fenced ```...``` block found in a Markdown file, along
+// with the marker (if any) found on the line immediately before the
+// opening fence or immediately after the closing fence.
+type codeBlock struct {
+	file string
+	// fenceStart/fenceEnd are 1-indexed line numbers of the opening and
+	// closing ``` lines, inclusive.
+	fenceStart, fenceEnd int
+	// markerLine is the 1-indexed line number the marker comment was found
+	// on (0 if no marker was found at all).
+	markerLine int
+	marker     string // "verified-by:<ref>", "doc-illustrative", or "" if absent/invalid
+}
+
+// spanLines returns every line number this block "occupies" for the
+// purpose of matching against a diff: the fence lines themselves, plus the
+// marker line if present, plus (if absent) the line directly above the
+// fence -- since that's where a marker would need to be added, and a
+// docs-diff that only touches the fence body should still be caught even
+// when the marker line itself wasn't touched.
+func (b codeBlock) spanLines() []int {
+	lines := []int{b.fenceStart, b.fenceEnd}
+	if b.markerLine != 0 {
+		lines = append(lines, b.markerLine)
+	} else if b.fenceStart > 1 {
+		lines = append(lines, b.fenceStart-1)
+	}
+	return lines
+}
+
+var markerRe = regexp.MustCompile(`^\s*<!--\s*(verified-by:\s*\S+|doc-illustrative)\s*-->\s*$`)
+
+// parseMarkdown scans a Markdown file's lines for fenced code blocks and
+// the marker comment adjacent to each (checked above the opening fence
+// first, then below the closing fence).
+func parseMarkdown(path string, lines []string) []codeBlock {
+	var blocks []codeBlock
+	inFence := false
+	fenceStart := 0
+	for i, line := range lines {
+		lineNo := i + 1
+		trimmed := strings.TrimSpace(line)
+		if !inFence && strings.HasPrefix(trimmed, "```") {
+			inFence = true
+			fenceStart = lineNo
+			continue
+		}
+		if inFence && trimmed == "```" {
+			inFence = false
+			b := codeBlock{file: path, fenceStart: fenceStart, fenceEnd: lineNo}
+
+			// Marker directly above the opening fence.
+			if fenceStart-2 >= 0 && fenceStart-2 < len(lines) {
+				above := lines[fenceStart-2]
+				if m := markerRe.FindStringSubmatch(above); m != nil {
+					b.markerLine = fenceStart - 1
+					b.marker = normalizeMarker(m[1])
+				}
+			}
+			// Marker directly below the closing fence, if none found above.
+			if b.marker == "" && lineNo < len(lines) {
+				below := lines[lineNo]
+				if m := markerRe.FindStringSubmatch(below); m != nil {
+					b.markerLine = lineNo + 1
+					b.marker = normalizeMarker(m[1])
+				}
+			}
+			blocks = append(blocks, b)
+			continue
+		}
+	}
+	return blocks
+}
+
+func normalizeMarker(s string) string {
+	return strings.TrimSpace(s)
+}
+
+// changedLines runs `git diff <base>...HEAD -- <path>` and returns the set
+// of 1-indexed line numbers in the new (HEAD-side) version of the file
+// that were added or are part of a changed hunk.
+func changedLines(repoRoot, base, path string) (map[int]bool, error) {
+	cmd := exec.Command("git", "diff", "--unified=0", base+"...HEAD", "--", path)
+	cmd.Dir = repoRoot
+	out, err := cmd.Output()
+	if err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			return nil, fmt.Errorf("git diff failed: %v\n%s", err, ee.Stderr)
+		}
+		return nil, err
+	}
+	lines := map[int]bool{}
+	hunkRe := regexp.MustCompile(`^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@`)
+	sc := bufio.NewScanner(bytes.NewReader(out))
+	sc.Buffer(make([]byte, 0, 64*1024), 1<<20)
+	for sc.Scan() {
+		line := sc.Text()
+		m := hunkRe.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		start := atoi(m[1])
+		count := 1
+		if m[2] != "" {
+			count = atoi(m[2])
+		}
+		if count == 0 {
+			// A pure deletion hunk (count 0) touches no new-side lines; the
+			// reported start is the line *after* which the deletion
+			// happened. Nothing to mark on the new side.
+			continue
+		}
+		for l := start; l < start+count; l++ {
+			lines[l] = true
+		}
+	}
+	return lines, sc.Err()
+}
+
+func atoi(s string) int {
+	n := 0
+	for _, c := range s {
+		n = n*10 + int(c-'0')
+	}
+	return n
+}
+
+func readLines(path string) ([]string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	text := strings.ReplaceAll(string(data), "\r\n", "\n")
+	// Keep a trailing empty element out of the slice for a final newline.
+	lines := strings.Split(text, "\n")
+	if len(lines) > 0 && lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1]
+	}
+	return lines, nil
+}
+
+func main() {
+	base := flag.String("base", "origin/main", "base ref/branch to diff against (git ... syntax, e.g. origin/main)")
+	docsDir := flag.String("docs", "docs", "directory containing the *.md files to check")
+	flag.Parse()
+
+	repoRoot, err := gitRoot()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "check_doc_examples:", err)
+		os.Exit(2)
+	}
+
+	pattern := filepath.Join(repoRoot, *docsDir, "*.md")
+	files, err := filepath.Glob(pattern)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "check_doc_examples:", err)
+		os.Exit(2)
+	}
+	sort.Strings(files)
+
+	if len(files) == 0 {
+		fmt.Fprintf(os.Stderr, "check_doc_examples: no files matched %s\n", pattern)
+		os.Exit(2)
+	}
+
+	var failures []string
+	totalBlocks, markedBlocks := 0, 0
+
+	for _, f := range files {
+		rel, err := filepath.Rel(repoRoot, f)
+		if err != nil {
+			rel = f
+		}
+		rel = filepath.ToSlash(rel)
+
+		lines, err := readLines(f)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "check_doc_examples:", err)
+			os.Exit(2)
+		}
+		blocks := parseMarkdown(rel, lines)
+
+		changed, err := changedLines(repoRoot, *base, rel)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "check_doc_examples:", err)
+			os.Exit(2)
+		}
+
+		for _, b := range blocks {
+			totalBlocks++
+			if b.marker != "" {
+				markedBlocks++
+				continue
+			}
+			// Unmarked. Only a gate failure if this block is new/changed.
+			touched := false
+			for _, ln := range b.spanLines() {
+				if changed[ln] {
+					touched = true
+					break
+				}
+			}
+			if touched {
+				failures = append(failures, fmt.Sprintf(
+					"%s:%d: code block (lines %d-%d) added or changed but has no <!-- verified-by: ... --> or <!-- doc-illustrative --> marker",
+					b.file, b.fenceStart, b.fenceStart, b.fenceEnd))
+			}
+		}
+	}
+
+	fmt.Printf("check_doc_examples: %d code block(s) scanned across %d file(s), %d marked, %d unmarked\n",
+		totalBlocks, len(files), markedBlocks, totalBlocks-markedBlocks)
+
+	if len(failures) > 0 {
+		fmt.Println("\nFAIL: the following added/changed code blocks are missing a marker:")
+		for _, f := range failures {
+			fmt.Println(" -", f)
+		}
+		os.Exit(1)
+	}
+
+	fmt.Println("PASS: every added/changed code block has a verified-by or doc-illustrative marker.")
+}
+
+func gitRoot() (string, error) {
+	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}

--- a/tools/check_doc_examples/main.go
+++ b/tools/check_doc_examples/main.go
@@ -56,9 +56,17 @@ func (b codeBlock) spanLines() []int {
 	lines := []int{b.fenceStart, b.fenceEnd}
 	if b.markerLine != 0 {
 		lines = append(lines, b.markerLine)
-	} else if b.fenceStart > 1 {
+		return lines
+	}
+	// No marker found: a marker could legally be added either directly
+	// above the opening fence or directly below the closing fence, so
+	// both candidate lines count as part of this block's span -- a diff
+	// touching either one (e.g. a marker that was just deleted) must be
+	// caught.
+	if b.fenceStart > 1 {
 		lines = append(lines, b.fenceStart-1)
 	}
+	lines = append(lines, b.fenceEnd+1)
 	return lines
 }
 


### PR DESCRIPTION
Resolves #62. Adds tools/check_doc_examples (marker-diff checker, blocking CI job), backfills all 15 code blocks across docs/*.md with verified-by/doc-illustrative markers (3 new honest Example tests), adds docs/reference.md as a curated API reference, and documents the standing rule in workflow-playbook.md Sec7. Also closes out issue #59 items 2-3 (logo already wired, content depth addressed via the new reference page).