### PR TITLE
Fix stale reference.md caveat, add runnable examples, doc-freshness standing rule

### DIFF
--- a/doc_examples_reference_test.go
+++ b/doc_examples_reference_test.go
@@ -1,0 +1,162 @@
+package omnist_test
+
+// This file backs the runnable Go code blocks added to docs/reference.md
+// by issue #64: real godoc Example functions covering package areas
+// getting-started.md doesn't touch -- oml, osd, a non-JSON/YAML codec
+// (toml), and the algebra package's schema operations. Same convention as
+// doc_examples_test.go: `go test` executes each Example and checks its
+// "// Output:" comment verbatim, so keep each Example's body in sync,
+// character-for-character where feasible, with its corresponding fenced
+// block in docs/reference.md.
+
+import (
+	"fmt"
+
+	omnist "github.com/omnist-dev/omnist-go"
+	"github.com/omnist-dev/omnist-go/algebra"
+	"github.com/omnist-dev/omnist-go/formats/toml"
+	"github.com/omnist-dev/omnist-go/oml"
+	"github.com/omnist-dev/omnist-go/osd"
+)
+
+// Example_omlRoundTrip backs reference.md's `oml` section: reading OML
+// text to a Document, then writing it back out compact.
+func Example_omlRoundTrip() {
+	doc, err := oml.Read(`name: "Ann"
+tags: "a"
+tags: "b"
+`, omnist.DefaultLimits())
+	if err != nil {
+		panic(err)
+	}
+
+	text, diagnostics := oml.WriteCompact(doc)
+	if len(diagnostics) != 0 {
+		panic("unexpected diagnostics")
+	}
+	fmt.Println(text)
+	// Output: name: "Ann"; tags: "a"; tags: "b"
+}
+
+// Example_osdRoundTrip backs reference.md's `osd` section: parsing an OSD
+// schema definition, then writing it back out.
+func Example_osdRoundTrip() {
+	schema, err := osd.Read(`
+		record Person { "name": string, "tags" [0,]: string }
+		root Person
+	`)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(osd.Write(schema, true))
+	// Output: record Person { "name": string, "tags" [0,]: string } root Person
+}
+
+// Example_tomlWrite backs reference.md's `formats/toml` section, covering
+// a codec beyond JSON/YAML: writers are schema-free and serialize
+// whatever Document they're given.
+func Example_tomlWrite() {
+	doc, err := oml.Read(`name: "Ann"`, omnist.DefaultLimits())
+	if err != nil {
+		panic(err)
+	}
+
+	text, diagnostics, err := toml.Write(doc)
+	if err != nil {
+		panic(err)
+	}
+	if len(diagnostics) != 0 {
+		panic("unexpected diagnostics")
+	}
+	fmt.Print(text)
+	// Output: "name" = "Ann"
+}
+
+// Example_algebraCompatibleWith backs reference.md's `algebra` section:
+// §6.6's own worked example. A has an optional "nick" field B doesn't;
+// compatible_with(A, B) is false (A may emit nick, B is closed) while
+// compatible_with(B, A) is true (everything B emits, A accepts).
+func Example_algebraCompatibleWith() {
+	a, err := osd.Read(`record User {
+		"id": string,
+		"name": string,
+		"nick" [0,1]: string,
+	} root User`)
+	if err != nil {
+		panic(err)
+	}
+	b, err := osd.Read(`record User {
+		"id": string,
+		"name": string,
+	} root User`)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(algebra.CompatibleWith(a, b))
+	fmt.Println(algebra.CompatibleWith(b, a))
+	// Output:
+	// false
+	// true
+}
+
+// Example_algebraNormalize backs reference.md's `algebra` section:
+// Normalize collapses two structurally-identical records (same fields,
+// different names) to a canonical shared form.
+func Example_algebraNormalize() {
+	s, err := osd.Read(`
+		record A { "id": string }
+		record B { "id": string }
+		record Root { "a": A, "b": B }
+		root Root
+	`)
+	if err != nil {
+		panic(err)
+	}
+
+	classes := algebra.EquivalenceClasses(algebra.Normalize(s))
+	fmt.Println(len(classes))
+	// Output: 2
+}
+
+// Example_algebraExtract backs reference.md's `algebra` section: Extract
+// trims a schema down to only the reachable records/fields needed to keep
+// a chosen field set, erroring if the root itself is invalidated.
+func Example_algebraExtract() {
+	s, err := osd.Read(`
+		record Root { "keep": string, "drop" [0,1]: string }
+		root Root
+	`)
+	if err != nil {
+		panic(err)
+	}
+
+	out, err := algebra.Extract(s, map[string]bool{"keep": true})
+	if err != nil {
+		panic(err)
+	}
+	root := out.Env[out.Root]
+	fmt.Println(len(root.Fields))
+	// Output: 1
+}
+
+// Example_algebraLint backs reference.md's `algebra` section: Lint
+// reports schema diagnostics -- here, an unreachable record no field ever
+// references.
+func Example_algebraLint() {
+	s, err := osd.Read(`
+		record Root { "id": string }
+		record Orphan { "id": string, "note": string }
+		root Root
+	`)
+	if err != nil {
+		panic(err)
+	}
+
+	findings := algebra.Lint(s)
+	for _, f := range findings {
+		fmt.Println(f.Code, f.Location)
+	}
+	// Output: lint.unreachable-record Orphan
+}

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -7,13 +7,15 @@ in this repo renders automatically, always in sync with the code. That's
 the idiomatic Go answer to "API reference": don't hand-maintain a second
 copy of `go doc`'s output here.
 
-**Not yet indexed.** As of this page, `omnist-go` has no tagged release
-(`git tag -l` is empty) — pkg.go.dev indexes tagged versions (and the
-`main` branch's latest commit as a pseudo-version) once a module has been
-`go get`-ed at least once from a public proxy. Until the first tag lands
-(tracked by `docs/workflow-playbook.md` §1's `v0.0.x-alpha` -> real version
-bump), treat this page's curated map below as authoritative, and use `go
-doc` locally for the mechanical dump:
+**Tagged, but pkg.go.dev hasn't indexed it yet.** `v0.1.0-alpha` is tagged
+and pushed, and the Go module proxy already knows about it —
+`curl https://proxy.golang.org/github.com/omnist-dev/omnist-go/@v/v0.1.0-alpha.info`
+returns a real result. pkg.go.dev itself, though, still 404s on
+`https://pkg.go.dev/github.com/omnist-dev/omnist-go` as of this page
+(indexing lags the proxy by anywhere from minutes to a few hours after
+the first `go get` of a new module path). Until that page comes up, treat
+this page's curated map below as authoritative, and use `go doc` locally
+for the mechanical dump:
 
 <!-- doc-illustrative -->
 ```bash
@@ -102,10 +104,42 @@ omnist.Limits) (omnist.Document, error)`, `Write(d omnist.Document, compact
 bool) (string, []omnist.Diagnostic)` (`WriteCompact` is a convenience
 wrapper for `Write(d, true)`). Round-trips Core and Extended OML per spec.
 
+<!-- verified-by: doc_examples_reference_test.go::Example_omlRoundTrip -->
+```go
+doc, err := oml.Read(`name: "Ann"
+tags: "a"
+tags: "b"
+`, omnist.DefaultLimits())
+if err != nil {
+    panic(err)
+}
+
+text, diagnostics := oml.WriteCompact(doc)
+if len(diagnostics) != 0 {
+    panic("unexpected diagnostics")
+}
+fmt.Println(text)
+// name: "Ann"; tags: "a"; tags: "b"
+```
+
 ## `osd` — `github.com/omnist-dev/omnist-go/osd`
 
 OSD (the schema definition format) reader and writer: `Read(text string)
 (omnist.Schema, error)`, `Write(s omnist.Schema, compact bool) string`.
+
+<!-- verified-by: doc_examples_reference_test.go::Example_osdRoundTrip -->
+```go
+schema, err := osd.Read(`
+    record Person { "name": string, "tags" [0,]: string }
+    root Person
+`)
+if err != nil {
+    panic(err)
+}
+
+fmt.Println(osd.Write(schema, true))
+// record Person { "name": string, "tags" [0,]: string } root Person
+```
 
 ## `formats/{json,yaml,toml,xml}`
 
@@ -120,6 +154,26 @@ errors. See each package's doc comment for format-specific caveats (e.g.
 XML leaf-typing, YAML sexagesimal integers, TOML's native date/time
 kinds).
 
+A codec beyond JSON/YAML, showing the shared writer shape:
+
+<!-- verified-by: doc_examples_reference_test.go::Example_tomlWrite -->
+```go
+doc, err := oml.Read(`name: "Ann"`, omnist.DefaultLimits())
+if err != nil {
+    panic(err)
+}
+
+text, diagnostics, err := toml.Write(doc)
+if err != nil {
+    panic(err)
+}
+if len(diagnostics) != 0 {
+    panic("unexpected diagnostics")
+}
+fmt.Print(text)
+// "name" = "Ann"
+```
+
 ## `algebra` — `github.com/omnist-dev/omnist-go/algebra`
 
 The Schema Algebra operations (spec §6): `CompatibleWith`, `Equivalent`,
@@ -127,6 +181,82 @@ The Schema Algebra operations (spec §6): `CompatibleWith`, `Equivalent`,
 `omnist.Schema` values — no document, no I/O. See the package doc comment
 for the operation-by-operation contract (each mirrors its spec §6
 subsection).
+
+`CompatibleWith` — §6.6's own worked example: `A` has an optional `nick`
+field `B` doesn't, so `A` may emit something `B`'s closed shape rejects,
+but everything `B` emits, `A` accepts:
+
+<!-- verified-by: doc_examples_reference_test.go::Example_algebraCompatibleWith -->
+```go
+a, _ := osd.Read(`record User {
+    "id": string,
+    "name": string,
+    "nick" [0,1]: string,
+} root User`)
+b, _ := osd.Read(`record User {
+    "id": string,
+    "name": string,
+} root User`)
+
+fmt.Println(algebra.CompatibleWith(a, b))
+fmt.Println(algebra.CompatibleWith(b, a))
+// false
+// true
+```
+
+`Normalize` — collapses structurally-identical records (same fields,
+different names) into shared equivalence classes:
+
+<!-- verified-by: doc_examples_reference_test.go::Example_algebraNormalize -->
+```go
+s, _ := osd.Read(`
+    record A { "id": string }
+    record B { "id": string }
+    record Root { "a": A, "b": B }
+    root Root
+`)
+
+classes := algebra.EquivalenceClasses(algebra.Normalize(s))
+fmt.Println(len(classes))
+// 2
+```
+
+`Extract` — trims a schema down to only what's needed to keep a chosen
+field set, erroring if that would invalidate the root:
+
+<!-- verified-by: doc_examples_reference_test.go::Example_algebraExtract -->
+```go
+s, _ := osd.Read(`
+    record Root { "keep": string, "drop" [0,1]: string }
+    root Root
+`)
+
+out, err := algebra.Extract(s, map[string]bool{"keep": true})
+if err != nil {
+    panic(err)
+}
+root := out.Env[out.Root]
+fmt.Println(len(root.Fields))
+// 1
+```
+
+`Lint` — reports schema diagnostics such as an unreachable record no
+field ever references:
+
+<!-- verified-by: doc_examples_reference_test.go::Example_algebraLint -->
+```go
+s, _ := osd.Read(`
+    record Root { "id": string }
+    record Orphan { "id": string, "note": string }
+    root Root
+`)
+
+findings := algebra.Lint(s)
+for _, f := range findings {
+    fmt.Println(f.Code, f.Location)
+}
+// lint.unreachable-record Orphan
+```
 
 ## Command-line interface
 

--- a/docs/workflow-playbook.md
+++ b/docs/workflow-playbook.md
@@ -320,3 +320,30 @@ the doc's literal displayed text/output -- a test whose name merely sounds
 related is not sufficient. (The Python port shipped a stale version-string
 doc example undetected for 5+ releases this way; the guarding test checked
 the live version constant, never the doc's own literal text.)
+
+## 8. Docs update in the same PR as the state they describe
+
+If a change touches a public API surface, a documented number (a version,
+a pass/fail/skip count, a coverage percentage), or an external-state claim
+(tag status, an upstream issue's status, pkg.go.dev's indexing state,
+anything else observable outside this repo), the docs describing it MUST
+be updated in the *same PR* -- not filed as a follow-up issue, not left
+for "next time someone notices."
+
+This is the second time in this repo's history a doc was found stale on
+exactly this pattern -- a claim about external state that was true when
+written and silently went false. The first was `docs/limitations.md`
+citing spec-vector defects that had already been fixed weeks earlier
+(issue #59). The second was `docs/reference.md`'s tag-status caveat, found
+stale within hours of `v0.1.0-alpha` landing (issue #64). Two instances of
+the same failure mode is a pattern, not a coincidence, which is why this
+is a standing rule now instead of a reminder left for the next person to
+rediscover.
+
+`doc-illustrative` (§7) is the deliberate exception for genuinely
+non-runnable content -- a CLI transcript, a bare fragment, a
+decision-record snapshot of a debate that's now settled. It is not the
+default for an entire page or section. If a code block is real, runnable
+Go (or another language with an equivalent test story), it gets a real
+test and a `verified-by` marker by default; reach for `doc-illustrative`
+only when there's genuinely nothing to run.


### PR DESCRIPTION
Resolves #64. Updates docs/reference.md's stale pkg.go.dev caveat to reflect the actual current indexing state (proxy knows v0.1.0-alpha, pkg.go.dev itself not yet indexed), adds 7 new real verified-by examples covering OML/OSD round-trip, TOML, and 4 schema-algebra operations not covered by getting-started.md, and adds workflow-playbook.md Sec8: docs touching a public API surface/documented number/external-state claim must update in the same PR, per the second occurrence of that staleness pattern this session (first was #59).