### PR TITLE
Close remaining doc coverage gaps in reference.md and cli.md

### DIFF
--- a/cmd/omnist/doc_examples_cli_test.go
+++ b/cmd/omnist/doc_examples_cli_test.go
@@ -1,0 +1,253 @@
+package main
+
+// This file backs the runnable CLI transcripts added to docs/cli.md by
+// issue #66: real subprocess invocations of the compiled omnist binary,
+// following the same buildOmnistBinary/runBinary mechanism
+// subprocess_test.go already established (see its doc comment) rather
+// than inventing a second one. Unlike doc_examples_test.go/
+// doc_examples_reference_test.go's godoc Example functions -- which
+// assert an exact "// Output:" comment -- these are plain *testing.T
+// tests that assert the exact stdout/stderr/exit-code triple shown in
+// docs/cli.md's fenced transcript, since a CLI example's "output" is a
+// terminal transcript (command *and* what it prints), not a single
+// Println value. Keep each test's asserted strings in sync,
+// character-for-character, with the corresponding block in
+// docs/cli.md; if you change one, change the other and re-run
+// `go test ./cmd/omnist` to confirm they still match.
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeFileT(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+// TestCLIExampleParseJSONToYAML backs cli.md's "Convert JSON to YAML"
+// example.
+func TestCLIExampleParseJSONToYAML(t *testing.T) {
+	bin := buildOmnistBinary(t)
+	code, stdout, stderr := runBinary(t, bin, `{"name": "Ann", "tags": ["a", "b"]}`, "parse", "--from", "json", "--to", "yaml", "-")
+	if code != ExitOK {
+		t.Fatalf("exit = %d, stderr = %q", code, stderr)
+	}
+	want := "\"name\": \"Ann\"\n\"tags\":\n    - \"a\"\n    - \"b\"\n"
+	if stdout != want {
+		t.Errorf("stdout = %q, want %q", stdout, want)
+	}
+}
+
+// TestCLIExampleValidate backs cli.md's "Validate a document against a
+// schema" example.
+func TestCLIExampleValidate(t *testing.T) {
+	bin := buildOmnistBinary(t)
+	dir := t.TempDir()
+	schemaPath := writeFileT(t, dir, "person.osd", "record Person { \"name\": string, \"age\": integer }\nroot Person\n")
+	docPath := writeFileT(t, dir, "person.json", `{"name": "Ann", "age": "42"}`)
+
+	code, stdout, stderr := runBinary(t, bin, "", "validate", "--from", "json", "--schema", schemaPath, docPath)
+	if code != ExitProblem {
+		t.Fatalf("exit = %d, want %d, stderr = %q", code, ExitProblem, stderr)
+	}
+	want := "$.age: validate.type-mismatch: value does not match declared kind\n"
+	if stdout != want {
+		t.Errorf("stdout = %q, want %q", stdout, want)
+	}
+}
+
+// TestCLIExampleSchemaCompatibleWith backs cli.md's "Check whether a
+// schema change is backward-compatible" example.
+func TestCLIExampleSchemaCompatibleWith(t *testing.T) {
+	bin := buildOmnistBinary(t)
+	dir := t.TempDir()
+	newPath := writeFileT(t, dir, "new.osd", "record User { \"id\": string, \"name\": string, \"nick\" [0,1]: string }\nroot User\n")
+	oldPath := writeFileT(t, dir, "old.osd", "record User { \"id\": string, \"name\": string }\nroot User\n")
+
+	code, stdout, stderr := runBinary(t, bin, "", "schema", "compatible-with", newPath, oldPath)
+	if code != ExitOK {
+		t.Fatalf("exit = %d, stderr = %q", code, stderr)
+	}
+	if stdout != "false\n" {
+		t.Errorf("stdout = %q, want %q", stdout, "false\n")
+	}
+}
+
+// TestCLIExampleMaterialize backs cli.md's `materialize` example: a JSON
+// string that looks like a date is upgraded to TOML's native date kind.
+func TestCLIExampleMaterialize(t *testing.T) {
+	bin := buildOmnistBinary(t)
+	dir := t.TempDir()
+	schemaPath := writeFileT(t, dir, "event.osd", "record Event { \"when\": date }\nroot Event\n")
+	docPath := writeFileT(t, dir, "event.json", `{"when": "2024-01-01"}`)
+
+	code, stdout, stderr := runBinary(t, bin, "", "materialize", "--from", "json", "--schema", schemaPath, "--to", "toml", docPath)
+	if code != ExitOK {
+		t.Fatalf("exit = %d, stderr = %q", code, stderr)
+	}
+	want := "\"when\" = 2024-01-01\n"
+	if stdout != want {
+		t.Errorf("stdout = %q, want %q", stdout, want)
+	}
+}
+
+// TestCLIExampleSchemaNormalize backs cli.md's `schema normalize`
+// example: two structurally-identical records (A, B) collapse to one
+// shared shape.
+func TestCLIExampleSchemaNormalize(t *testing.T) {
+	bin := buildOmnistBinary(t)
+	dir := t.TempDir()
+	schemaPath := writeFileT(t, dir, "dup.osd", "record A { \"id\": string }\nrecord B { \"id\": string }\nrecord Root { \"a\": A, \"b\": B }\nroot Root\n")
+
+	code, stdout, stderr := runBinary(t, bin, "", "schema", "normalize", schemaPath)
+	if code != ExitOK {
+		t.Fatalf("exit = %d, stderr = %q", code, stderr)
+	}
+	want := "record A {\n    \"id\": string,\n}\nrecord Root {\n    \"a\": A,\n    \"b\": A,\n}\nroot Root\n"
+	if stdout != want {
+		t.Errorf("stdout = %q, want %q", stdout, want)
+	}
+}
+
+// TestCLIExampleSchemaPrune backs cli.md's `schema prune` example: a
+// never-emittable field ([0,0]) and the record it alone referenced both
+// disappear.
+func TestCLIExampleSchemaPrune(t *testing.T) {
+	bin := buildOmnistBinary(t)
+	dir := t.TempDir()
+	schemaPath := writeFileT(t, dir, "dead.osd", "record Root { \"id\": string, \"dead\" [0,0]: Orphan }\nrecord Orphan { \"note\": string }\nroot Root\n")
+
+	code, stdout, stderr := runBinary(t, bin, "", "schema", "prune", schemaPath)
+	if code != ExitOK {
+		t.Fatalf("exit = %d, stderr = %q", code, stderr)
+	}
+	want := "record Root {\n    \"id\": string,\n}\nroot Root\n"
+	if stdout != want {
+		t.Errorf("stdout = %q, want %q", stdout, want)
+	}
+}
+
+// TestCLIExampleSchemaExtract backs cli.md's `schema extract` example:
+// --keep trims the schema down to only the named field.
+func TestCLIExampleSchemaExtract(t *testing.T) {
+	bin := buildOmnistBinary(t)
+	dir := t.TempDir()
+	schemaPath := writeFileT(t, dir, "extract.osd", "record Root { \"keep\": string, \"drop\" [0,1]: string }\nroot Root\n")
+
+	code, stdout, stderr := runBinary(t, bin, "", "schema", "extract", "--keep", "keep", schemaPath)
+	if code != ExitOK {
+		t.Fatalf("exit = %d, stderr = %q", code, stderr)
+	}
+	want := "record Root {\n    \"keep\": string,\n}\nroot Root\n"
+	if stdout != want {
+		t.Errorf("stdout = %q, want %q", stdout, want)
+	}
+}
+
+// TestCLIExampleSchemaEquivalent backs cli.md's `schema equivalent`
+// example: two schemas differing only in record naming are equivalent.
+func TestCLIExampleSchemaEquivalent(t *testing.T) {
+	bin := buildOmnistBinary(t)
+	dir := t.TempDir()
+	personPath := writeFileT(t, dir, "person.osd", "record Person { \"id\": string, \"name\": string }\nroot Person\n")
+	userPath := writeFileT(t, dir, "user.osd", "record User { \"id\": string, \"name\": string }\nroot User\n")
+
+	code, stdout, stderr := runBinary(t, bin, "", "schema", "equivalent", personPath, userPath)
+	if code != ExitOK {
+		t.Fatalf("exit = %d, stderr = %q", code, stderr)
+	}
+	if stdout != "true\n" {
+		t.Errorf("stdout = %q, want %q", stdout, "true\n")
+	}
+}
+
+// TestCLIExampleSchemaIsEmpty backs cli.md's `schema is-empty` example:
+// a record that can only ever satisfy itself by requiring itself
+// ([1,1], the OSD default) is unsatisfiable.
+func TestCLIExampleSchemaIsEmpty(t *testing.T) {
+	bin := buildOmnistBinary(t)
+	dir := t.TempDir()
+	schemaPath := writeFileT(t, dir, "empty.osd", "record Root { \"self\": Root }\nroot Root\n")
+
+	code, stdout, stderr := runBinary(t, bin, "", "schema", "is-empty", schemaPath)
+	if code != ExitOK {
+		t.Fatalf("exit = %d, stderr = %q", code, stderr)
+	}
+	if stdout != "true\n" {
+		t.Errorf("stdout = %q, want %q", stdout, "true\n")
+	}
+}
+
+// TestCLIExampleInfer backs cli.md's `infer` example: two samples that
+// disagree on whether "tags" is present produce an optional field.
+func TestCLIExampleInfer(t *testing.T) {
+	bin := buildOmnistBinary(t)
+	dir := t.TempDir()
+	s1 := writeFileT(t, dir, "s1.json", `{"name": "Ann", "tags": ["a"]}`)
+	s2 := writeFileT(t, dir, "s2.json", `{"name": "Bo"}`)
+
+	code, stdout, stderr := runBinary(t, bin, "", "infer", "--from", "json", s1, s2)
+	if code != ExitOK {
+		t.Fatalf("exit = %d, stderr = %q", code, stderr)
+	}
+	want := "record Root {\n    \"name\": string,\n    \"tags\" [0,1]: string,\n}\nroot Root\n"
+	if stdout != want {
+		t.Errorf("stdout = %q, want %q", stdout, want)
+	}
+}
+
+// TestCLIExampleInferAllowAny backs cli.md's `--allow-any` example: a
+// label that mixes scalar kinds fails infer outright without the flag,
+// and opens to `any` (with an informational stderr line) with it.
+func TestCLIExampleInferAllowAny(t *testing.T) {
+	bin := buildOmnistBinary(t)
+	dir := t.TempDir()
+	a1 := writeFileT(t, dir, "a1.json", `{"val": "a"}`)
+	a2 := writeFileT(t, dir, "a2.json", `{"val": 42}`)
+
+	code, _, stderr := runBinary(t, bin, "", "infer", "--from", "json", a1, a2)
+	if code != ExitProblem {
+		t.Fatalf("without --allow-any: exit = %d, want %d", code, ExitProblem)
+	}
+	wantErr := "omnist infer: Root.val: algebra.infer-conflicting-scalars: label \"val\" has values of more than one scalar kind\n"
+	if stderr != wantErr {
+		t.Errorf("without --allow-any: stderr = %q, want %q", stderr, wantErr)
+	}
+
+	code, stdout, stderr := runBinary(t, bin, "", "infer", "--from", "json", "--allow-any", a1, a2)
+	if code != ExitOK {
+		t.Fatalf("with --allow-any: exit = %d, stderr = %q", code, stderr)
+	}
+	wantOut := "record Root {\n    \"val\": any,\n}\nroot Root\n"
+	if stdout != wantOut {
+		t.Errorf("with --allow-any: stdout = %q, want %q", stdout, wantOut)
+	}
+	wantErr = "Root.val: opened to any: values of more than one scalar kind (integer, string)\n"
+	if stderr != wantErr {
+		t.Errorf("with --allow-any: stderr = %q, want %q", stderr, wantErr)
+	}
+}
+
+// TestCLIExampleLint backs cli.md's `lint` example: an unreachable
+// record produces a warning-level finding, which is also a reported
+// "problem" per lint's own doc comment.
+func TestCLIExampleLint(t *testing.T) {
+	bin := buildOmnistBinary(t)
+	dir := t.TempDir()
+	schemaPath := writeFileT(t, dir, "orphan.osd", "record Root { \"id\": string }\nrecord Orphan { \"id\": string, \"note\": string }\nroot Root\n")
+
+	code, stdout, stderr := runBinary(t, bin, "", "lint", schemaPath)
+	if code != ExitProblem {
+		t.Fatalf("exit = %d, want %d, stderr = %q", code, ExitProblem, stderr)
+	}
+	want := "Orphan: warning: lint.unreachable-record: record \"Orphan\" is defined but not reachable from root by any reference\n"
+	if stdout != want {
+		t.Errorf("stdout = %q, want %q", stdout, want)
+	}
+}

--- a/doc_examples_reference_test.go
+++ b/doc_examples_reference_test.go
@@ -11,10 +11,14 @@ package omnist_test
 
 import (
 	"fmt"
+	"math/big"
 
 	omnist "github.com/omnist-dev/omnist-go"
 	"github.com/omnist-dev/omnist-go/algebra"
+	"github.com/omnist-dev/omnist-go/formats/json"
 	"github.com/omnist-dev/omnist-go/formats/toml"
+	"github.com/omnist-dev/omnist-go/formats/xml"
+	"github.com/omnist-dev/omnist-go/formats/yaml"
 	"github.com/omnist-dev/omnist-go/oml"
 	"github.com/omnist-dev/omnist-go/osd"
 )
@@ -159,4 +163,244 @@ func Example_algebraLint() {
 		fmt.Println(f.Code, f.Location)
 	}
 	// Output: lint.unreachable-record Orphan
+}
+
+// Example_algebraPrune backs reference.md's `algebra` section: Prune
+// removes a never-emittable field (cardinality max 0) and, as a
+// consequence, the now-unreachable record it alone referenced.
+func Example_algebraPrune() {
+	s, err := osd.Read(`
+		record Root { "id": string, "dead" [0,0]: Orphan }
+		record Orphan { "note": string }
+		root Root
+	`)
+	if err != nil {
+		panic(err)
+	}
+
+	pruned := algebra.Prune(s)
+	root := pruned.Env[pruned.Root]
+	fmt.Println(len(root.Fields))
+	fmt.Println(len(pruned.Env))
+	// Output:
+	// 1
+	// 1
+}
+
+// Example_algebraEquivalent backs reference.md's `algebra` section:
+// Equivalent is strictly stronger than CompatibleWith in one direction --
+// two schemas that only differ in record naming and declaration order are
+// equivalent even though they are not structurally equal.
+func Example_algebraEquivalent() {
+	a, err := osd.Read(`
+		record Person { "id": string, "name": string }
+		root Person
+	`)
+	if err != nil {
+		panic(err)
+	}
+	b, err := osd.Read(`
+		record User { "id": string, "name": string }
+		root User
+	`)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(algebra.Equivalent(a, b))
+	// Output: true
+}
+
+// Example_algebraInfer backs reference.md's `algebra` section: Infer
+// drafts a Schema from sample Documents -- here, two JSON samples that
+// disagree on whether "tags" is present, producing an optional [0,1]
+// field in the inferred schema.
+func Example_algebraInfer() {
+	s1, err := json.Read(`{"name": "Ann", "tags": ["a"]}`, omnist.DefaultLimits())
+	if err != nil {
+		panic(err)
+	}
+	s2, err := json.Read(`{"name": "Bo"}`, omnist.DefaultLimits())
+	if err != nil {
+		panic(err)
+	}
+
+	schema, err := algebra.Infer([]omnist.Document{s1, s2}, "", false)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(osd.Write(schema, true))
+	// Output: record Root { "name": string, "tags" [0,1]: string } root Root
+}
+
+// Example_validate backs reference.md's Operations section: Validate
+// checks shape and cardinality without ever converting a value's type --
+// here a schema-typed "age" field rejects a JSON string, producing a
+// populated Diagnostic with a real Path/Code/Message.
+func Example_validate() {
+	schema, err := osd.Read(`
+		record Person { "name": string, "age": integer }
+		root Person
+	`)
+	if err != nil {
+		panic(err)
+	}
+	doc, err := json.Read(`{"name": "Ann", "age": "42"}`, omnist.DefaultLimits())
+	if err != nil {
+		panic(err)
+	}
+
+	diagnostics := omnist.Validate(doc, schema)
+	for _, d := range diagnostics {
+		fmt.Println(d.Path, d.Code, d.Severity)
+	}
+	// Output: $.age validate.type-mismatch error
+}
+
+// Example_materialize backs reference.md's Operations section:
+// Materialize upgrades a leaf scalar to its schema-declared kind only
+// when the conversion is value-exact -- a JSON string that looks like a
+// date becomes a real `date` scalar.
+func Example_materialize() {
+	schema, err := osd.Read(`
+		record Event { "when": date }
+		root Event
+	`)
+	if err != nil {
+		panic(err)
+	}
+	doc, err := json.Read(`{"when": "2024-01-01"}`, omnist.DefaultLimits())
+	if err != nil {
+		panic(err)
+	}
+
+	result, diagnostics, err := omnist.Materialize(doc, schema)
+	if err != nil {
+		panic(err)
+	}
+	if len(diagnostics) != 0 {
+		panic("unexpected diagnostics")
+	}
+	edge := result.Node.Edges[0]
+	v, _ := edge.Target.Value()
+	d := v.Scalar.Date
+	fmt.Printf("%s %04d-%02d-%02d\n", v.Scalar.Kind, d.Year, d.Month, d.Day)
+	// Output: date 2024-01-01
+}
+
+// Example_newIntegerScalar backs reference.md's Document model section:
+// integer scalars use *big.Int, not int64, to support the spec's
+// 4,300-decimal-digit limit -- constructing one from a small literal
+// still goes through big.NewInt.
+func Example_newIntegerScalar() {
+	s := omnist.NewIntegerScalar(big.NewInt(42))
+	fmt.Println(s.Kind, s.Int)
+	// Output: integer 42
+}
+
+// Example_parseError backs reference.md's Diagnostics and errors section:
+// a stage-1 reader's failure is a *ParseError with a real Line/Col text
+// position, not yet a Document-relative Path (no Document exists yet).
+func Example_parseError() {
+	_, err := json.Read(`{"name": }`, omnist.DefaultLimits())
+	perr, ok := err.(*omnist.ParseError)
+	if !ok {
+		panic("expected a *ParseError")
+	}
+	fmt.Println(perr.Line, perr.Col, perr.Code)
+	// Output: 1 10 parse.unexpected-token
+}
+
+// Example_documentsEqual backs reference.md's Operations section:
+// DocumentsEqual is order-sensitive -- two documents with the same edges
+// in different order are not equal.
+func Example_documentsEqual() {
+	a, err := oml.Read(`x: "1"
+y: "2"
+`, omnist.DefaultLimits())
+	if err != nil {
+		panic(err)
+	}
+	b, err := oml.Read(`y: "2"
+x: "1"
+`, omnist.DefaultLimits())
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(omnist.DocumentsEqual(a, a))
+	fmt.Println(omnist.DocumentsEqual(a, b))
+	// Output:
+	// true
+	// false
+}
+
+// Example_schemasEqual backs reference.md's Operations section:
+// SchemasEqual's two modes differ on record naming -- ModeExact requires
+// matching record names, ModeIsomorphic accepts structurally identical
+// schemas that merely name their records differently.
+func Example_schemasEqual() {
+	a, err := osd.Read(`record Person { "id": string } root Person`)
+	if err != nil {
+		panic(err)
+	}
+	b, err := osd.Read(`record User { "id": string } root User`)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(omnist.SchemasEqual(a, b, omnist.ModeExact))
+	fmt.Println(omnist.SchemasEqual(a, b, omnist.ModeIsomorphic))
+	// Output:
+	// false
+	// true
+}
+
+// Example_jsonRoundTrip backs reference.md's `formats/json` section.
+func Example_jsonRoundTrip() {
+	doc, err := json.Read(`{"name": "Ann"}`, omnist.DefaultLimits())
+	if err != nil {
+		panic(err)
+	}
+
+	text, diagnostics, err := json.Write(doc)
+	if err != nil {
+		panic(err)
+	}
+	if len(diagnostics) != 0 {
+		panic("unexpected diagnostics")
+	}
+	fmt.Print(text)
+	// Output: {"name": "Ann"}
+}
+
+// Example_yamlSexagesimal backs reference.md's `formats/yaml` section:
+// YAML 1.1's sexagesimal-integer sharp edge -- a bare `1:30:00` resolves
+// to the base-60 integer 5400, NOT a time value, even though it looks
+// like one.
+func Example_yamlSexagesimal() {
+	doc, err := yaml.Read("n: 1:30:00\n", omnist.DefaultLimits())
+	if err != nil {
+		panic(err)
+	}
+
+	v, _ := doc.Node.Edges[0].Target.Value()
+	fmt.Println(v.Scalar.Kind, v.Scalar.Int)
+	// Output: integer 5400
+}
+
+// Example_xmlLeafTyping backs reference.md's `formats/xml` section: XML
+// carries no type information at all, so every leaf arrives as a string
+// scalar -- unlike JSON/YAML/TOML, `42` inside an element is never
+// resolved to an integer.
+func Example_xmlLeafTyping() {
+	doc, err := xml.Read(`<root><age>42</age></root>`, omnist.DefaultLimits())
+	if err != nil {
+		panic(err)
+	}
+
+	ageNode, _ := doc.Node.Edges[0].Target.Node()
+	v, _ := ageNode.Edges[0].Target.Value()
+	fmt.Println(v.Scalar.Kind, v.Scalar.Str)
+	// Output: string 42
 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -40,23 +40,151 @@ The three boolean schema commands (`compatible-with`, `equivalent`, `is-empty`) 
 
 ## Examples
 
+Every example below shows the exact command and its exact captured
+output, backed by a real subprocess test that compiles and runs the
+actual `omnist` binary — see `cmd/omnist/doc_examples_cli_test.go`'s doc
+comment for why this differs mechanically from `reference.md`'s godoc
+`Example` functions (a CLI transcript is a stdout/stderr/exit-code
+triple, not a single `fmt.Println` value).
+
 Convert JSON to YAML:
 
-<!-- doc-illustrative -->
-```bash
-echo '{"name": "Ann", "tags": ["a", "b"]}' | omnist parse --from json --to yaml -
+<!-- verified-by: cmd/omnist/doc_examples_cli_test.go::TestCLIExampleParseJSONToYAML -->
+```console
+$ echo '{"name": "Ann", "tags": ["a", "b"]}' | omnist parse --from json --to yaml -
+"name": "Ann"
+"tags":
+    - "a"
+    - "b"
 ```
 
-Validate a document against a schema:
+Validate a document against a schema (exit code `2`: validation ran and
+found a problem — `age` is a JSON string but the schema declares
+`integer`, and `Validate` never converts a value's type):
 
-<!-- doc-illustrative -->
-```bash
-omnist validate --from json --schema person.osd person.json
+<!-- verified-by: cmd/omnist/doc_examples_cli_test.go::TestCLIExampleValidate -->
+```console
+$ omnist validate --from json --schema person.osd person.json
+$.age: validate.type-mismatch: value does not match declared kind
 ```
 
-Check whether a schema change is backward-compatible:
+Check whether a schema change is backward-compatible (`new.osd` adds an
+optional `nick` field `old.osd` doesn't have, so `new` may emit something
+`old`'s closed shape rejects):
 
-<!-- doc-illustrative -->
-```bash
-omnist schema compatible-with new.osd old.osd
+<!-- verified-by: cmd/omnist/doc_examples_cli_test.go::TestCLIExampleSchemaCompatibleWith -->
+```console
+$ omnist schema compatible-with new.osd old.osd
+false
+```
+
+Materialize a document against a schema, upgrading a JSON string that
+looks like a date to TOML's native date kind:
+
+<!-- verified-by: cmd/omnist/doc_examples_cli_test.go::TestCLIExampleMaterialize -->
+```console
+$ omnist materialize --from json --schema event.osd --to toml event.json
+"when" = 2024-01-01
+```
+
+Normalize a schema, collapsing two structurally-identical records (`A`,
+`B`) into one shared shape:
+
+<!-- verified-by: cmd/omnist/doc_examples_cli_test.go::TestCLIExampleSchemaNormalize -->
+```console
+$ omnist schema normalize dup.osd
+record A {
+    "id": string,
+}
+record Root {
+    "a": A,
+    "b": A,
+}
+root Root
+```
+
+Prune a schema, removing a never-emittable field (`[0,0]`) and, as a
+consequence, the record it alone referenced:
+
+<!-- verified-by: cmd/omnist/doc_examples_cli_test.go::TestCLIExampleSchemaPrune -->
+```console
+$ omnist schema prune dead.osd
+record Root {
+    "id": string,
+}
+root Root
+```
+
+Extract a schema down to only the fields named by `--keep`:
+
+<!-- verified-by: cmd/omnist/doc_examples_cli_test.go::TestCLIExampleSchemaExtract -->
+```console
+$ omnist schema extract --keep keep extract.osd
+record Root {
+    "keep": string,
+}
+root Root
+```
+
+Check whether two schemas accept exactly the same documents, even though
+they name their records differently:
+
+<!-- verified-by: cmd/omnist/doc_examples_cli_test.go::TestCLIExampleSchemaEquivalent -->
+```console
+$ omnist schema equivalent person.osd user.osd
+true
+```
+
+Check whether a schema is unsatisfiable — here, a record whose only field
+requires itself at the OSD-default cardinality `[1,1]` can never be
+satisfied by any finite document:
+
+<!-- verified-by: cmd/omnist/doc_examples_cli_test.go::TestCLIExampleSchemaIsEmpty -->
+```console
+$ omnist schema is-empty empty.osd
+true
+```
+
+Infer a schema from sample documents — two samples disagreeing on
+whether `tags` is present produce an optional `[0,1]` field:
+
+<!-- verified-by: cmd/omnist/doc_examples_cli_test.go::TestCLIExampleInfer -->
+```console
+$ omnist infer --from json s1.json s2.json
+record Root {
+    "name": string,
+    "tags" [0,1]: string,
+}
+root Root
+```
+
+`--allow-any`'s effect: without it, a label whose samples disagree on
+scalar kind is a hard failure (exit `2`):
+
+<!-- verified-by: cmd/omnist/doc_examples_cli_test.go::TestCLIExampleInferAllowAny -->
+```console
+$ omnist infer --from json a1.json a2.json
+omnist infer: Root.val: algebra.infer-conflicting-scalars: label "val" has values of more than one scalar kind
+```
+
+With it, the field opens to `any` instead, and the CLI reports what it
+opened on stderr (exit `0`):
+
+<!-- verified-by: cmd/omnist/doc_examples_cli_test.go::TestCLIExampleInferAllowAny -->
+```console
+$ omnist infer --from json --allow-any a1.json a2.json
+record Root {
+    "val": any,
+}
+root Root
+$ # stderr: Root.val: opened to any: values of more than one scalar kind (integer, string)
+```
+
+Lint a schema — an unreachable record is a warning-level finding, which
+also makes `lint`'s exit code `2` (an operation-reported problem):
+
+<!-- verified-by: cmd/omnist/doc_examples_cli_test.go::TestCLIExampleLint -->
+```console
+$ omnist lint orphan.osd
+Orphan: warning: lint.unreachable-record: record "Orphan" is defined but not reachable from root by any reference
 ```

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -55,6 +55,17 @@ that don't belong to a specific codec or the algebra package.
   `NewNumberScalar`, `NewBooleanScalar`, `NewDateScalar`, `NewTimeScalar`,
   `NewDateTimeScalar`; compare with `Scalar.Equal`.
 
+  `NewIntegerScalar` takes a `*big.Int`, not a plain `int` — the one
+  constructor here that needs a concrete example, since `big.Int` isn't
+  the obvious first reach for a small literal:
+
+  <!-- verified-by: doc_examples_reference_test.go::Example_newIntegerScalar -->
+  ```go
+  s := omnist.NewIntegerScalar(big.NewInt(42))
+  fmt.Println(s.Kind, s.Int)
+  // integer 42
+  ```
+
 ### Schema model (`schema.go`)
 
 - **`Schema`** — an environment of named `Record`s plus a `Root` type
@@ -72,24 +83,104 @@ that don't belong to a specific codec or the algebra package.
   checks shape and cardinality against the schema. Never converts a
   value's type; a JSON string in a `date`-typed field fails, because
   validation checks what's already there.
+
+  A schema-typed `age: integer` field rejects a JSON string outright,
+  producing a real, populated `Diagnostic`:
+
+  <!-- verified-by: doc_examples_reference_test.go::Example_validate -->
+  ```go
+  schema, _ := osd.Read(`
+      record Person { "name": string, "age": integer }
+      root Person
+  `)
+  doc, _ := json.Read(`{"name": "Ann", "age": "42"}`, omnist.DefaultLimits())
+
+  diagnostics := omnist.Validate(doc, schema)
+  for _, d := range diagnostics {
+      fmt.Println(d.Path, d.Code, d.Severity)
+  }
+  // $.age validate.type-mismatch error
+  ```
+
 - **`Materialize(doc Document, s Schema) (Document, []Diagnostic, error)`**
   (`materialize.go`) — walks the document against the schema in one pass,
   upgrading leaf scalars to their schema-declared kind only when the
   conversion is value-exact (e.g. `"2024-01-01"` -> `date`, but never
   string -> number).
+
+  A JSON string that looks like a date becomes a real `date` scalar once
+  materialized against a schema that says so:
+
+  <!-- verified-by: doc_examples_reference_test.go::Example_materialize -->
+  ```go
+  schema, _ := osd.Read(`record Event { "when": date } root Event`)
+  doc, _ := json.Read(`{"when": "2024-01-01"}`, omnist.DefaultLimits())
+
+  result, diagnostics, err := omnist.Materialize(doc, schema)
+  if err != nil {
+      panic(err)
+  }
+  if len(diagnostics) != 0 {
+      panic("unexpected diagnostics")
+  }
+  v, _ := result.Node.Edges[0].Target.Value()
+  fmt.Println(v.Scalar.Kind, v.Scalar.Date)
+  // date {2024 1 1}
+  ```
+
 - **`DocumentsEqual`, `SchemasEqual`** (`referee.go`) — order-sensitive
   document equality and two schema-equality modes (`exact`: record names
   must match; `isomorphic`: same structure up to renaming), used by this
   repo's own conformance harness and available for any caller comparing
   documents/schemas the same way.
 
+  `DocumentsEqual` is order-sensitive — the same edges in a different
+  order are not equal:
+
+  <!-- verified-by: doc_examples_reference_test.go::Example_documentsEqual -->
+  ```go
+  a, _ := oml.Read("x: \"1\"\ny: \"2\"\n", omnist.DefaultLimits())
+  b, _ := oml.Read("y: \"2\"\nx: \"1\"\n", omnist.DefaultLimits())
+
+  fmt.Println(omnist.DocumentsEqual(a, a))
+  fmt.Println(omnist.DocumentsEqual(a, b))
+  // true
+  // false
+  ```
+
+  `SchemasEqual`'s two modes differ on record naming — `ModeExact`
+  requires matching names, `ModeIsomorphic` accepts the same structure
+  under any consistent renaming:
+
+  <!-- verified-by: doc_examples_reference_test.go::Example_schemasEqual -->
+  ```go
+  a, _ := osd.Read(`record Person { "id": string } root Person`)
+  b, _ := osd.Read(`record User { "id": string } root User`)
+
+  fmt.Println(omnist.SchemasEqual(a, b, omnist.ModeExact))
+  fmt.Println(omnist.SchemasEqual(a, b, omnist.ModeIsomorphic))
+  // false
+  // true
+  ```
+
 ### Diagnostics and errors (`errors.go`)
 
 - **`Diagnostic`** — `(Path, Code, Severity, Message)`, spec §8's
-  `(path, code, message)` error taxonomy plus a severity.
+  `(path, code, message)` error taxonomy plus a severity. See
+  `Validate`'s example above for one populated from a real failing call.
 - **`ParseError`** — the structured error a stage-1 (text to `Document`)
   reader reports: `(Line, Col, Path, Code, Message)`. A text-position path
   (`"14:8"`), since no `Document` exists yet when a parse error fires.
+
+  Triggering a real parse error shows the shape:
+
+  <!-- verified-by: doc_examples_reference_test.go::Example_parseError -->
+  ```go
+  _, err := json.Read(`{"name": }`, omnist.DefaultLimits())
+  perr := err.(*omnist.ParseError)
+  fmt.Println(perr.Line, perr.Col, perr.Code)
+  // 1 10 parse.unexpected-token
+  ```
 
 ### Limits (`limits.go`)
 
@@ -153,6 +244,59 @@ stringified temporal value, a substituted `NaN`) as diagnostics rather than
 errors. See each package's doc comment for format-specific caveats (e.g.
 XML leaf-typing, YAML sexagesimal integers, TOML's native date/time
 kinds).
+
+`json`, round-tripping the shared reader/writer shape:
+
+<!-- verified-by: doc_examples_reference_test.go::Example_jsonRoundTrip -->
+```go
+doc, err := json.Read(`{"name": "Ann"}`, omnist.DefaultLimits())
+if err != nil {
+    panic(err)
+}
+
+text, diagnostics, err := json.Write(doc)
+if err != nil {
+    panic(err)
+}
+if len(diagnostics) != 0 {
+    panic("unexpected diagnostics")
+}
+fmt.Print(text)
+// {"name": "Ann"}
+```
+
+`yaml`'s sexagesimal-integer sharp edge — YAML 1.1 resolves a bare
+`1:30:00` to the base-60 integer `5400`, not a time value, even though it
+looks like one:
+
+<!-- verified-by: doc_examples_reference_test.go::Example_yamlSexagesimal -->
+```go
+doc, err := yaml.Read("n: 1:30:00\n", omnist.DefaultLimits())
+if err != nil {
+    panic(err)
+}
+
+v, _ := doc.Node.Edges[0].Target.Value()
+fmt.Println(v.Scalar.Kind, v.Scalar.Int)
+// integer 5400
+```
+
+`xml`'s leaf-typing caveat — XML carries no type information at all, so
+every leaf arrives as a string scalar, never resolved to an integer or
+other kind the way JSON/YAML/TOML would:
+
+<!-- verified-by: doc_examples_reference_test.go::Example_xmlLeafTyping -->
+```go
+doc, err := xml.Read(`<root><age>42</age></root>`, omnist.DefaultLimits())
+if err != nil {
+    panic(err)
+}
+
+ageNode, _ := doc.Node.Edges[0].Target.Node()
+v, _ := ageNode.Edges[0].Target.Value()
+fmt.Println(v.Scalar.Kind, v.Scalar.Str)
+// string 42
+```
 
 A codec beyond JSON/YAML, showing the shared writer shape:
 
@@ -256,6 +400,54 @@ for _, f := range findings {
     fmt.Println(f.Code, f.Location)
 }
 // lint.unreachable-record Orphan
+```
+
+`Prune` — removes a never-emittable field (cardinality `[0,0]`) and, as a
+consequence, the now-unreachable record it alone referenced:
+
+<!-- verified-by: doc_examples_reference_test.go::Example_algebraPrune -->
+```go
+s, _ := osd.Read(`
+    record Root { "id": string, "dead" [0,0]: Orphan }
+    record Orphan { "note": string }
+    root Root
+`)
+
+pruned := algebra.Prune(s)
+root := pruned.Env[pruned.Root]
+fmt.Println(len(root.Fields))
+fmt.Println(len(pruned.Env))
+// 1
+// 1
+```
+
+`Equivalent` — strictly stronger than `CompatibleWith` in one direction:
+two schemas differing only in record naming and declaration order are
+equivalent even though they aren't structurally equal:
+
+<!-- verified-by: doc_examples_reference_test.go::Example_algebraEquivalent -->
+```go
+a, _ := osd.Read(`record Person { "id": string, "name": string } root Person`)
+b, _ := osd.Read(`record User { "id": string, "name": string } root User`)
+
+fmt.Println(algebra.Equivalent(a, b))
+// true
+```
+
+`Infer` — drafts a schema from sample documents; two samples that
+disagree on whether `tags` is present produce an optional `[0,1]` field:
+
+<!-- verified-by: doc_examples_reference_test.go::Example_algebraInfer -->
+```go
+s1, _ := json.Read(`{"name": "Ann", "tags": ["a"]}`, omnist.DefaultLimits())
+s2, _ := json.Read(`{"name": "Bo"}`, omnist.DefaultLimits())
+
+schema, err := algebra.Infer([]omnist.Document{s1, s2}, "", false)
+if err != nil {
+    panic(err)
+}
+fmt.Println(osd.Write(schema, true))
+// record Root { "name": string, "tags" [0,1]: string } root Root
 ```
 
 ## Command-line interface


### PR DESCRIPTION
Resolves #66. Adds verified-by examples for Validate/Materialize/DocumentsEqual/SchemasEqual/ParseError/NewIntegerScalar/Prune/Equivalent/Infer and the JSON/YAML/XML codecs in reference.md; adds all 8 missing CLI command examples and upgrades the 3 existing doc-illustrative ones to verified-by (real captured stdout/stderr/exit code via the existing subprocess_test.go binary-execution helpers) in cli.md.