### PR TITLE
Fix normalize local_signature to encode scalar kind/nullable and Any distinctly

### DIFF
--- a/algebra/normalize.go
+++ b/algebra/normalize.go
@@ -13,7 +13,9 @@ import (
 
 // localSig is the comparable value used as a map key for local_signature
 // (§6.8 step 2): a byte-encoding of each field's (label, min, max,
-// is-scalar-or-not), in declaration order. Record.Fields is already a
+// shape_of(type)) — shape_of distinguishes Any, Ref (target-blind), and
+// Scalar(kind, nullable), per §6.8's formal local_signature/shape_of
+// pseudocode — in declaration order. Record.Fields is already a
 // slice in declaration order (schema.go); two records with the same
 // fields in a different order are NOT the same local signature, matching
 // the spec's field-by-field tuple description — there is no sort here.
@@ -35,7 +37,7 @@ func computeLocalSignature(rec *omnist.Record) localSig {
 	return localSig(b)
 }
 
-// appendFieldSig appends one field's (label, min, max, is-scalar-or-not)
+// appendFieldSig appends one field's (label, min, max, shape_of(type))
 // encoding to b, using '\x00'/'\x01' as field/component separators that
 // cannot appear in the numeric or boolean components and are escaped out
 // of the label so a crafted label can't forge a delimiter collision.
@@ -51,10 +53,27 @@ func appendFieldSig(b []byte, f omnist.Field) []byte {
 		b = appendUint(b, f.Cardinality.Max)
 	}
 	b = append(b, '\x01')
-	if f.Type.Kind == omnist.TypeRefKind {
+	switch f.Type.Kind {
+	case omnist.TypeAnyKind:
+		b = append(b, 'A')
+	case omnist.TypeRefKind:
+		// Target name deliberately excluded here: refine_key resolves
+		// ref equivalence via the fixpoint step, not the local
+		// signature (§6.8's shape_of: `if t is Ref: return ("ref",)`).
 		b = append(b, 'R')
-	} else {
+	default: // omnist.TypeScalarKind
+		// §6.8's shape_of: `return ("scalar", t.kind, t.nullable)` —
+		// both the scalar kind and nullability are part of the
+		// signature, so distinct scalar kinds (and nullable vs
+		// non-nullable) never collapse into one bucket.
 		b = append(b, 'S')
+		b = append(b, byte(f.Type.ScalarKind))
+		b = append(b, '\x01')
+		if f.Type.Nullable {
+			b = append(b, 'N')
+		} else {
+			b = append(b, 'n')
+		}
 	}
 	return b
 }

--- a/algebra/normalize_public_test.go
+++ b/algebra/normalize_public_test.go
@@ -228,6 +228,74 @@ func TestEquivalenceClassesDoesNotPrune(t *testing.T) {
 	}
 }
 
+// TestEquivalenceClassesDistinguishesScalarKindsAndAny is the issue #68
+// repro at the EquivalenceClasses level: A/B/C all have a single field "x"
+// with the same label/cardinality but different type shapes (string,
+// integer, any respectively). Before the fix these all shared a local
+// signature and merged into one block; they must land in three separate
+// blocks, since they don't accept the same documents.
+func TestEquivalenceClassesDistinguishesScalarKindsAndAny(t *testing.T) {
+	s := mustParseOSD(t, `
+		record A { "x": string }
+		record B { "x": integer }
+		record C { "x": any }
+		record Top { "a": A, "b": B, "c": C }
+		root Top
+	`)
+	blocks := algebra.EquivalenceClasses(s)
+
+	blockOf := map[string]int{}
+	for i, block := range blocks {
+		for _, name := range block {
+			blockOf[name] = i
+		}
+	}
+	if blockOf["A"] == blockOf["B"] || blockOf["A"] == blockOf["C"] || blockOf["B"] == blockOf["C"] {
+		t.Fatalf("A, B, C should be in three separate equivalence-class blocks, got blocks = %v", blocks)
+	}
+}
+
+// TestEquivalenceClassesRefTargetBlindnessKeepsSameBlock is the positive
+// control for issue #68's fix: two records that differ ONLY in the target
+// name of a Ref field must still start out in the SAME initial block, since
+// local_signature is deliberately target-blind for Ref fields (only a
+// scalar's kind/nullable and Any-vs-scalar-vs-ref distinctions were added
+// by the fix; Ref target names remain excluded, left for the fixpoint
+// refinement step). LeftLeaf/RightLeaf are distinct but structurally
+// identical, so after full normalization HolderA/HolderB should merge too.
+func TestEquivalenceClassesRefTargetBlindnessKeepsSameBlock(t *testing.T) {
+	s := mustParseOSD(t, `
+		record LeafX { "v": string }
+		record LeafY { "v": string }
+		record HolderA { "target": LeafX }
+		record HolderB { "target": LeafY }
+		record Top { "a": HolderA, "b": HolderB }
+		root Top
+	`)
+	blocks := algebra.EquivalenceClasses(s)
+
+	blockOf := map[string]int{}
+	for i, block := range blocks {
+		for _, name := range block {
+			blockOf[name] = i
+		}
+	}
+	if blockOf["HolderA"] != blockOf["HolderB"] {
+		t.Fatalf("HolderA and HolderB should share an initial block (ref-target-blind local signature), got blocks = %v", blocks)
+	}
+
+	// Since LeafX/LeafY are themselves genuinely equivalent, the fixpoint
+	// should confirm the merge all the way through: normalize collapses
+	// both holder/leaf pairs.
+	got := algebra.Normalize(s)
+	wantNames := []string{"HolderA", "LeafX", "Top"}
+	gotNames := append([]string{}, got.EnvOrder...)
+	sort.Strings(gotNames)
+	if !reflect.DeepEqual(gotNames, wantNames) {
+		t.Fatalf("EnvOrder (sorted) = %v, want %v", gotNames, wantNames)
+	}
+}
+
 // TestEquivalenceClassesOrdering confirms blocks and names within blocks
 // come back in deterministic sorted order.
 func TestEquivalenceClassesOrdering(t *testing.T) {

--- a/algebra/normalize_test.go
+++ b/algebra/normalize_test.go
@@ -171,6 +171,57 @@ func TestLocalSignatureRefVsScalarDiffers(t *testing.T) {
 	}
 }
 
+// TestLocalSignatureDistinguishesScalarKindsAndAny is the regression test
+// for issue #68: appendFieldSig used to collapse every non-Ref field type
+// (string, integer, ..., and even Any) into a single 'S' byte, so records
+// differing only in a field's scalar kind (or Any vs a concrete scalar)
+// wrongly shared a local signature. Per §6.8's shape_of, Any, Ref, and each
+// (kind, nullable) scalar pairing must all be distinct.
+func TestLocalSignatureDistinguishesScalarKindsAndAny(t *testing.T) {
+	stringRec := &omnist.Record{Name: "StringRec", Fields: []omnist.Field{
+		{Label: "x", Type: omnist.ScalarType(omnist.KindString, false), Cardinality: omnist.DefaultCardinality()},
+	}}
+	integerRec := &omnist.Record{Name: "IntegerRec", Fields: []omnist.Field{
+		{Label: "x", Type: omnist.ScalarType(omnist.KindInteger, false), Cardinality: omnist.DefaultCardinality()},
+	}}
+	anyRec := &omnist.Record{Name: "AnyRec", Fields: []omnist.Field{
+		{Label: "x", Type: omnist.AnyType(), Cardinality: omnist.DefaultCardinality()},
+	}}
+
+	str := computeLocalSignature(stringRec)
+	integer := computeLocalSignature(integerRec)
+	any := computeLocalSignature(anyRec)
+
+	if str == integer {
+		t.Errorf("string and integer fields should have different local signatures, both got %q", str)
+	}
+	if str == any {
+		t.Errorf("string and any fields should have different local signatures, both got %q", str)
+	}
+	if integer == any {
+		t.Errorf("integer and any fields should have different local signatures, both got %q", integer)
+	}
+}
+
+// TestLocalSignatureDistinguishesNullability confirms a nullable scalar and
+// a non-nullable scalar of the same kind get different local signatures,
+// per §6.8's shape_of returning ("scalar", t.kind, t.nullable) — nullable
+// was previously dropped entirely, not just merged with other kinds.
+func TestLocalSignatureDistinguishesNullability(t *testing.T) {
+	nullableRec := &omnist.Record{Name: "Nullable", Fields: []omnist.Field{
+		{Label: "x", Type: omnist.ScalarType(omnist.KindString, true), Cardinality: omnist.DefaultCardinality()},
+	}}
+	nonNullableRec := &omnist.Record{Name: "NonNullable", Fields: []omnist.Field{
+		{Label: "x", Type: omnist.ScalarType(omnist.KindString, false), Cardinality: omnist.DefaultCardinality()},
+	}}
+
+	nullable := computeLocalSignature(nullableRec)
+	nonNullable := computeLocalSignature(nonNullableRec)
+	if nullable == nonNullable {
+		t.Errorf("nullable and non-nullable string fields should have different local signatures, both got %q", nullable)
+	}
+}
+
 // TestLocalSignatureIgnoresRefTarget confirms two records referencing
 // different (but at this stage un-refined) targets share a local
 // signature — the target-blindness the spec calls for in step 2, refined


### PR DESCRIPTION
Resolves #68. appendFieldsig previously only distinguished Ref from everything else, so {"x":string}/{"x":integer}/{"x":any} all produced an identical local signature and normalize would wrongly merge those non-equivalent records. Now encodes Any distinctly, Scalar(kind, nullable), and keeps Ref target-blind (unchanged), matching omnist-spec Sec6.8 formal pseudocode (commit f6ec180, already pinned on main). Conformance: Track 2 151/0/1 (submodule bump added one new vector, still zero real fails), Track 1 19/0/0 unchanged.