### PR TITLE
Enable strict CI gating on conformance harness tracks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,27 +168,9 @@ jobs:
           go-version: '1.26.6'
       - name: Run conformance harness (Track 2, JSON-vector)
         run: |
-          if [ -d tools/conformance/cmd/conformance ]; then
-            # Informational for now, not gating: as of issue #31 there are
-            # 26 known real failures against omnist-spec's test-suite,
-            # each already filed for a follow-up fix. CI gating (fail the
-            # build on nonzero fail count, per spec Sec8.5.5) lands once
-            # those are cleared -- see workflow-playbook.md Sec4.
-            go run ./tools/conformance/cmd/conformance || true
-          else
-            echo "conformance harness not yet built - skipping (tracked in workflow-playbook.md Sec4)"
-          fi
+          # Gated CI execution (issue #74): fails build on nonzero fail count (?8.5.5).
+          go run ./tools/conformance/cmd/conformance
       - name: Run conformance harness (Track 1, fixture-based)
         run: |
-          if [ -d tools/conformance/cmd/conformance-fixtures ]; then
-            # Informational for now, not gating, same reasoning as Track 2
-            # above: issue #55 found one real, upstream fixture defect
-            # (lint/edge-case-unreachable-record's expected.json omits the
-            # "lint." code-namespace prefix every other lint code and
-            # Track 2's own vectors use) -- filed upstream, not something
-            # this repo can fix in a vendored submodule. CI gating lands
-            # once that's cleared.
-            go run ./tools/conformance/cmd/conformance-fixtures || true
-          else
-            echo "Track 1 conformance harness not yet built - skipping"
-          fi
+          # Gated CI execution (issue #74): fails build on nonzero fail count (?8.5.5).
+          go run ./tools/conformance/cmd/conformance-fixtures


### PR DESCRIPTION
Resolves #74. Removes || true from both conformance jobs and their now-stale rationale comments (both tracks have been at zero real fails for a while). Adversarial-verified directly: temporarily broke formats/json.Write to append a marker string, confirmed the Track 2 job now genuinely exits 1 (3/152 real fails), then reverted and confirmed exit 0/151-0-1 again -- proof the gate actually gates, not just that || true was removed.