### PR TITLE
Eliminate quadratic path indexing and linear field scans (#71, #80)

### DIFF
--- a/algebra/compatible_with.go
+++ b/algebra/compatible_with.go
@@ -113,7 +113,7 @@ func fieldByLabel(r *omnist.Record, label string) (omnist.Field, bool) {
 	return *f, true
 }
 
-// recordSub implements ?6.6's `record_sub(SA, a, SB, b, sat_a, memo)`.
+// recordSub implements §6.6's `record_sub(SA, a, SB, b, sat_a, memo)`.
 func recordSub(sa omnist.Schema, a *omnist.Record, sb omnist.Schema, b *omnist.Record, satA map[string]bool, memo map[subKey]bool) bool {
 	bIdx := b.Index()
 	aIdx := a.Index()
@@ -151,9 +151,9 @@ func recordSub(sa omnist.Schema, a *omnist.Record, sb omnist.Schema, b *omnist.R
 	return true
 }
 
-// Equivalent implements ?6.7's `equivalent(A, B)`: exactly
+// Equivalent implements §6.7's `equivalent(A, B)`: exactly
 // CompatibleWith(A, B) && CompatibleWith(B, A). The spec explicitly forbids
-// any structural-equality shortcut here ? structural equality is strictly
+// any structural-equality shortcut here — structural equality is strictly
 // stronger than equivalence, so substituting one would reject equivalent
 // schemas that merely differ in record naming, declaration order, or
 // unreachable records.

--- a/algebra/compatible_with.go
+++ b/algebra/compatible_with.go
@@ -106,16 +106,18 @@ func sub(sa omnist.Schema, ta omnist.Type, sb omnist.Schema, tb omnist.Type, sat
 // fieldByLabel implements §6.2's `R.field(label)`: the field with that
 // label, or none.
 func fieldByLabel(r *omnist.Record, label string) (omnist.Field, bool) {
-	for _, f := range r.Fields {
-		if f.Label == label {
-			return f, true
-		}
+	f := r.Index().Field(label)
+	if f == nil {
+		return omnist.Field{}, false
 	}
-	return omnist.Field{}, false
+	return *f, true
 }
 
-// recordSub implements §6.6's `record_sub(SA, a, SB, b, sat_a, memo)`.
+// recordSub implements ?6.6's `record_sub(SA, a, SB, b, sat_a, memo)`.
 func recordSub(sa omnist.Schema, a *omnist.Record, sb omnist.Schema, b *omnist.Record, satA map[string]bool, memo map[subKey]bool) bool {
+	bIdx := b.Index()
+	aIdx := a.Index()
+
 	// 1. Every label A may emit must be allowed by B.
 	for _, fa := range a.Fields {
 		if !fa.Cardinality.Unbounded && fa.Cardinality.Max == 0 {
@@ -124,8 +126,8 @@ func recordSub(sa omnist.Schema, a *omnist.Record, sb omnist.Schema, b *omnist.R
 		if fa.Cardinality.Min == 0 && fa.Type.Kind == omnist.TypeRefKind && !satA[fa.Type.RefName] {
 			continue // A never emits it either
 		}
-		fb, ok := fieldByLabel(b, fa.Label)
-		if !ok {
+		fb := bIdx.Field(fa.Label)
+		if fb == nil {
 			return false // B is closed
 		}
 		if fb.Cardinality.Min > fa.Cardinality.Min ||
@@ -140,8 +142,8 @@ func recordSub(sa omnist.Schema, a *omnist.Record, sb omnist.Schema, b *omnist.R
 	// 2. Every label B requires must be guaranteed by A.
 	for _, fb := range b.Fields {
 		if fb.Cardinality.Min >= 1 {
-			fa, ok := fieldByLabel(a, fb.Label)
-			if !ok || fa.Cardinality.Min < fb.Cardinality.Min {
+			fa := aIdx.Field(fb.Label)
+			if fa == nil || fa.Cardinality.Min < fb.Cardinality.Min {
 				return false
 			}
 		}
@@ -149,9 +151,9 @@ func recordSub(sa omnist.Schema, a *omnist.Record, sb omnist.Schema, b *omnist.R
 	return true
 }
 
-// Equivalent implements §6.7's `equivalent(A, B)`: exactly
+// Equivalent implements ?6.7's `equivalent(A, B)`: exactly
 // CompatibleWith(A, B) && CompatibleWith(B, A). The spec explicitly forbids
-// any structural-equality shortcut here — structural equality is strictly
+// any structural-equality shortcut here ? structural equality is strictly
 // stronger than equivalence, so substituting one would reject equivalent
 // schemas that merely differ in record naming, declaration order, or
 // unreachable records.

--- a/algebra/compatible_with_test.go
+++ b/algebra/compatible_with_test.go
@@ -1,6 +1,8 @@
 package algebra
 
 import (
+	"fmt"
+	"strconv"
 	"testing"
 
 	"github.com/omnist-dev/omnist-go"
@@ -34,5 +36,48 @@ func TestScalarSub(t *testing.T) {
 				t.Errorf("scalarSub(%+v, %+v) = %v, want %v", c.a, c.b, got, c.want)
 			}
 		})
+	}
+}
+
+
+func BenchmarkCompatibleWithManyFields(b *testing.B) {
+	sizes := []int{50, 200, 1000}
+	for _, size := range sizes {
+		b.Run(strconv.Itoa(size), func(b *testing.B) {
+			fieldsA := make([]omnist.Field, size)
+			fieldsB := make([]omnist.Field, size)
+			for i := 0; i < size; i++ {
+				label := fmt.Sprintf("field_%d", i)
+				fieldsA[i] = omnist.Field{Label: label, Type: omnist.ScalarType(omnist.KindString, false), Cardinality: omnist.DefaultCardinality()}
+				fieldsB[i] = omnist.Field{Label: label, Type: omnist.ScalarType(omnist.KindString, false), Cardinality: omnist.DefaultCardinality()}
+			}
+			recA := &omnist.Record{Name: "Rec", Fields: fieldsA}
+			recB := &omnist.Record{Name: "Rec", Fields: fieldsB}
+			schemaA := omnist.Schema{Root: "Rec", Env: map[string]*omnist.Record{"Rec": recA}, EnvOrder: []string{"Rec"}}
+			schemaB := omnist.Schema{Root: "Rec", Env: map[string]*omnist.Record{"Rec": recB}, EnvOrder: []string{"Rec"}}
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_ = CompatibleWith(schemaA, schemaB)
+			}
+		})
+	}
+}
+
+func TestFieldByLabelHelper(t *testing.T) {
+	rec := &omnist.Record{
+		Name: "Test",
+		Fields: []omnist.Field{
+			{Label: "a", Type: omnist.ScalarType(omnist.KindString, false)},
+		},
+	}
+	if f, ok := fieldByLabel(rec, "a"); !ok || f.Label != "a" {
+		t.Errorf("expected field a, got %v, ok=%v", f, ok)
+	}
+	if _, ok := fieldByLabel(rec, "missing"); ok {
+		t.Errorf("expected not ok for missing field")
+	}
+	if _, ok := fieldByLabel(nil, "a"); ok {
+		t.Errorf("expected not ok for nil record")
 	}
 }

--- a/schema.go
+++ b/schema.go
@@ -88,6 +88,30 @@ type Field struct {
 	Cardinality Cardinality
 }
 
+// FieldIndex maps field labels to *Field for O(1) lookups on a Record.
+type FieldIndex map[string]*Field
+
+// Index returns a FieldIndex mapping each declared field label to its *Field.
+// If r is nil, returns nil.
+func (r *Record) Index() FieldIndex {
+	if r == nil {
+		return nil
+	}
+	idx := make(FieldIndex, len(r.Fields))
+	for i := range r.Fields {
+		idx[r.Fields[i].Label] = &r.Fields[i]
+	}
+	return idx
+}
+
+// Field returns the *Field with the given label from the indexed view, or nil if not present.
+func (idx FieldIndex) Field(label string) *Field {
+	if idx == nil {
+		return nil
+	}
+	return idx[label]
+}
+
 // Record is a closed set of fields (spec §3.3, §3.1): only the labels
 // listed are allowed, and nothing else — there is no wildcard.
 type Record struct {

--- a/validate.go
+++ b/validate.go
@@ -190,17 +190,24 @@ func walkRecordShape(target Target, rec *Record, path Path, checker *LimitChecke
 	// of that order for the cardinality check below, per D-3 order
 	// independence.
 	counts := make(map[string]int, len(node.Edges))
-	outEdges := make([]Edge, 0, len(node.Edges))
-	for i, e := range node.Edges {
+	for _, e := range node.Edges {
 		counts[e.Label]++
-		occurrence, repeated := PathIndexInNode(node, i)
+	}
+	runningIndex := make(map[string]int, len(counts))
+	fieldsIdx := rec.Index()
+
+	outEdges := make([]Edge, 0, len(node.Edges))
+	for _, e := range node.Edges {
+		occurrence := runningIndex[e.Label]
+		repeated := counts[e.Label] > 1
+		runningIndex[e.Label]++
 		childPath := path.Child(e.Label, occurrence, repeated)
 
-		f := findField(rec, e.Label)
+		f := fieldsIdx.Field(e.Label)
 		if f == nil {
 			addDiagnostic(result, childPath, CodeValidateUnexpectedField, "field not declared on this record")
 			// No further descent: an undeclared field has no type to check
-			// against (§3.6.1's first "easy to miss" detail). Kept
+			// against (?3.6.1's first "easy to miss" detail). Kept
 			// unchanged in the output, per materialize_record's pseudocode.
 			outEdges = append(outEdges, e)
 			continue
@@ -208,9 +215,9 @@ func walkRecordShape(target Target, rec *Record, path Path, checker *LimitChecke
 		outEdges = append(outEdges, Edge{Label: e.Label, Target: onMatched(e, f, childPath)})
 	}
 
-	// Cardinality (spec §3.6 point 1). The error's path is the record's
+	// Cardinality (spec ?3.6 point 1). The error's path is the record's
 	// own path, not any edge's, even when the count is nonzero-but-wrong
-	// (§3.6.1's second "easy to miss" detail) — never childPath.
+	// (?3.6.1's second "easy to miss" detail) ? never childPath.
 	if rec == nil {
 		return outEdges
 	}
@@ -226,15 +233,7 @@ func walkRecordShape(target Target, rec *Record, path Path, checker *LimitChecke
 // findField looks up rec.field(label) from the pseudocode. rec may be nil
 // (see Resolved's doc comment on conformRecord).
 func findField(rec *Record, label string) *Field {
-	if rec == nil {
-		return nil
-	}
-	for i := range rec.Fields {
-		if rec.Fields[i].Label == label {
-			return &rec.Fields[i]
-		}
-	}
-	return nil
+	return rec.Index().Field(label)
 }
 
 // cardinalityMessage renders the §3.6.1 message template: "field X occurs

--- a/validate.go
+++ b/validate.go
@@ -207,7 +207,7 @@ func walkRecordShape(target Target, rec *Record, path Path, checker *LimitChecke
 		if f == nil {
 			addDiagnostic(result, childPath, CodeValidateUnexpectedField, "field not declared on this record")
 			// No further descent: an undeclared field has no type to check
-			// against (?3.6.1's first "easy to miss" detail). Kept
+			// against (§3.6.1's first "easy to miss" detail). Kept
 			// unchanged in the output, per materialize_record's pseudocode.
 			outEdges = append(outEdges, e)
 			continue
@@ -215,9 +215,9 @@ func walkRecordShape(target Target, rec *Record, path Path, checker *LimitChecke
 		outEdges = append(outEdges, Edge{Label: e.Label, Target: onMatched(e, f, childPath)})
 	}
 
-	// Cardinality (spec ?3.6 point 1). The error's path is the record's
+	// Cardinality (spec §3.6 point 1). The error's path is the record's
 	// own path, not any edge's, even when the count is nonzero-but-wrong
-	// (?3.6.1's second "easy to miss" detail) ? never childPath.
+	// (§3.6.1's second "easy to miss" detail) — never childPath.
 	if rec == nil {
 		return outEdges
 	}

--- a/validate_test.go
+++ b/validate_test.go
@@ -1,6 +1,7 @@
 package omnist
 
 import (
+	"strconv"
 	"math/big"
 	"testing"
 )
@@ -493,5 +494,74 @@ func TestValidateUnresolvableRef(t *testing.T) {
 	got := Validate(NodeDocument(root), s)
 	if len(got) != 1 || got[0].Code != CodeValidateUnexpectedField || got[0].Path != "$.ghost.x" {
 		t.Fatalf("Validate() = %+v, want single unexpected-field at $.ghost.x (unresolvable ref treated as empty closed record)", got)
+	}
+}
+
+
+func BenchmarkValidateManyEdges(b *testing.B) {
+	sizes := []int{100, 1000, 5000, 10000}
+	for _, size := range sizes {
+		b.Run(strconv.Itoa(size), func(b *testing.B) {
+			rec := &Record{
+				Name: "ItemContainer",
+				Fields: []Field{
+					{Label: "item", Type: ScalarType(KindInteger, false), Cardinality: Cardinality{Min: 0, Unbounded: true}},
+				},
+			}
+			schema := Schema{Root: "ItemContainer", Env: map[string]*Record{"ItemContainer": rec}}
+			node := NewNode()
+			for i := 0; i < size; i++ {
+				node.AddValue("item", ScalarValue(NewIntegerScalar(big.NewInt(int64(i)))))
+			}
+			doc := NodeDocument(node)
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_ = Validate(doc, schema)
+			}
+		})
+	}
+}
+
+func BenchmarkMaterializeManyEdges(b *testing.B) {
+	sizes := []int{100, 1000, 5000, 10000}
+	for _, size := range sizes {
+		b.Run(strconv.Itoa(size), func(b *testing.B) {
+			rec := &Record{
+				Name: "ItemContainer",
+				Fields: []Field{
+					{Label: "item", Type: ScalarType(KindInteger, false), Cardinality: Cardinality{Min: 0, Unbounded: true}},
+				},
+			}
+			schema := Schema{Root: "ItemContainer", Env: map[string]*Record{"ItemContainer": rec}}
+			node := NewNode()
+			for i := 0; i < size; i++ {
+				node.AddValue("item", ScalarValue(NewIntegerScalar(big.NewInt(int64(i)))))
+			}
+			doc := NodeDocument(node)
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_, _, _ = Materialize(doc, schema)
+			}
+		})
+	}
+}
+
+func TestFindFieldHelper(t *testing.T) {
+	if f := findField(nil, "x"); f != nil {
+		t.Errorf("expected nil for nil record, got %v", f)
+	}
+	rec := &Record{
+		Name: "Test",
+		Fields: []Field{
+			{Label: "a", Type: ScalarType(KindString, false)},
+		},
+	}
+	if f := findField(rec, "a"); f == nil || f.Label != "a" {
+		t.Errorf("expected field a, got %v", f)
+	}
+	if f := findField(rec, "missing"); f != nil {
+		t.Errorf("expected nil for missing field, got %v", f)
 	}
 }


### PR DESCRIPTION
Fixes #71 and #80 by replacing quadratic PathIndexInNode calls with single-pass running index tracking in walkRecordShape, and introducing a shared FieldIndex on Record for O(1) field lookups in validation, materialization, and compatibility checks.