### PR TITLE
Eliminate O(N^2) lexer suffix allocations in OML and OSD (#72)

### DIFF
--- a/oml/oml_lexer.go
+++ b/oml/oml_lexer.go
@@ -1,6 +1,7 @@
 package oml
 
 import (
+	"unicode/utf8"
 	"fmt"
 	"math"
 	"math/big"
@@ -70,22 +71,22 @@ type token struct {
 // consequence of the algorithm as specified in §4.2, not a bug worked
 // around here.
 type lexer struct {
-	src  []rune
-	pos  int
-	line int
-	col  int
+	raw       string
+	bytePos   int
+	line      int
+	col       int
 
 	limits *omnist.LimitChecker
 
-	// valuePath is the omnist.Document path (spec §8.4) of the edge value the
-	// parser is about to tokenize, e.g. "$.n" — set by the parser right
+	// valuePath is the omnist.Document path (spec ?8.4) of the edge value the
+	// parser is about to tokenize, e.g. "$.n" ? set by the parser right
 	// before it calls advance() to read a value token, and used only to
 	// path a document.limit.int-digits diagnostic correctly (that code is
-	// document.*, so per §8.4 it MUST carry an omnist.Document path, never the
+	// document.*, so per ?8.4 it MUST carry an omnist.Document path, never the
 	// text-position path every other diagnostic in this file uses; a
 	// parse.* diagnostic never consults this field). Left empty when no
 	// value is pending (e.g. while reading a label or punctuation), in
-	// which case CheckIntDigits falls back to a text-position path — this
+	// which case CheckIntDigits falls back to a text-position path ? this
 	// only matters for a lone top-level integer with no enclosing label,
 	// which document.limit.int-digits cannot presently pin an example of
 	// an omnist.Document path for since there's no label to name.
@@ -93,29 +94,39 @@ type lexer struct {
 }
 
 func newLexer(text string, limits *omnist.LimitChecker) *lexer {
-	return &lexer{src: []rune(text), pos: 0, line: 1, col: 1, limits: limits}
+	return &lexer{raw: text, bytePos: 0, line: 1, col: 1, limits: limits}
 }
 
-func (l *lexer) atEOF() bool { return l.pos >= len(l.src) }
+func (l *lexer) atEOF() bool { return l.bytePos >= len(l.raw) }
 
 func (l *lexer) peekRune() rune {
 	if l.atEOF() {
 		return 0
 	}
-	return l.src[l.pos]
+	r, _ := utf8.DecodeRuneInString(l.raw[l.bytePos:])
+	return r
 }
 
 func (l *lexer) peekRuneAt(offset int) rune {
-	if l.pos+offset >= len(l.src) {
+	pos := l.bytePos
+	for i := 0; i < offset; i++ {
+		if pos >= len(l.raw) {
+			return 0
+		}
+		_, width := utf8.DecodeRuneInString(l.raw[pos:])
+		pos += width
+	}
+	if pos >= len(l.raw) {
 		return 0
 	}
-	return l.src[l.pos+offset]
+	r, _ := utf8.DecodeRuneInString(l.raw[pos:])
+	return r
 }
 
 // advance consumes one rune, updating line/col.
 func (l *lexer) advance() rune {
-	r := l.src[l.pos]
-	l.pos++
+	r, width := utf8.DecodeRuneInString(l.raw[l.bytePos:])
+	l.bytePos += width
 	if r == '\n' {
 		l.line++
 		l.col = 1
@@ -177,7 +188,7 @@ var (
 // remainingString returns the source from the current position onward, as
 // a string, for regexp matching. Cheap enough: called once per token.
 func (l *lexer) remainingString() string {
-	return string(l.src[l.pos:])
+	return l.raw[l.bytePos:]
 }
 
 // next returns the next token, or a *omnist.ParseError. It is the single entry
@@ -433,10 +444,10 @@ func (l *lexer) scanEscape(b *strings.Builder, escLine, escCol int) *omnist.Pars
 }
 
 func (l *lexer) scanHex4(errLine, errCol int) (int, *omnist.ParseError) {
-	if l.pos+4 > len(l.src) {
+	if l.bytePos+4 > len(l.raw) {
 		return 0, l.errAt(errLine, errCol, omnist.CodeParseUnterminatedString, "unterminated \\u escape")
 	}
-	digits := string(l.src[l.pos : l.pos+4])
+	digits := l.raw[l.bytePos : l.bytePos+4]
 	v, err := strconv.ParseUint(digits, 16, 32)
 	if err != nil {
 		return 0, l.errAt(errLine, errCol, omnist.CodeParseInvalidEscape, "invalid \\u escape")

--- a/oml/oml_lexer.go
+++ b/oml/oml_lexer.go
@@ -1,13 +1,13 @@
 package oml
 
 import (
-	"unicode/utf8"
 	"fmt"
 	"math"
 	"math/big"
 	"regexp"
 	"strconv"
 	"strings"
+	"unicode/utf8"
 
 	omnist "github.com/omnist-dev/omnist-go"
 )
@@ -71,22 +71,22 @@ type token struct {
 // consequence of the algorithm as specified in §4.2, not a bug worked
 // around here.
 type lexer struct {
-	raw       string
-	bytePos   int
-	line      int
-	col       int
+	raw     string
+	bytePos int
+	line    int
+	col     int
 
 	limits *omnist.LimitChecker
 
-	// valuePath is the omnist.Document path (spec ?8.4) of the edge value the
-	// parser is about to tokenize, e.g. "$.n" ? set by the parser right
+	// valuePath is the omnist.Document path (spec §8.4) of the edge value the
+	// parser is about to tokenize, e.g. "$.n" — set by the parser right
 	// before it calls advance() to read a value token, and used only to
 	// path a document.limit.int-digits diagnostic correctly (that code is
-	// document.*, so per ?8.4 it MUST carry an omnist.Document path, never the
+	// document.*, so per §8.4 it MUST carry an omnist.Document path, never the
 	// text-position path every other diagnostic in this file uses; a
 	// parse.* diagnostic never consults this field). Left empty when no
 	// value is pending (e.g. while reading a label or punctuation), in
-	// which case CheckIntDigits falls back to a text-position path ? this
+	// which case CheckIntDigits falls back to a text-position path — this
 	// only matters for a lone top-level integer with no enclosing label,
 	// which document.limit.int-digits cannot presently pin an example of
 	// an omnist.Document path for since there's no label to name.

--- a/oml/oml_parser_test.go
+++ b/oml/oml_parser_test.go
@@ -1,8 +1,10 @@
 package oml
 
 import (
+	"fmt"
 	"math"
 	"math/big"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -997,5 +999,31 @@ func TestIntDigitsLimitUsesNestedDocumentPath(t *testing.T) {
 	}
 	if pe.Path != "$.a.n" {
 		t.Errorf("path = %q, want %q", pe.Path, "$.a.n")
+	}
+}
+
+
+func BenchmarkReadOMLFlat(b *testing.B) {
+	sizes := []int{100, 1000, 5000, 10000}
+	for _, size := range sizes {
+		b.Run(strconv.Itoa(size), func(b *testing.B) {
+			var sb strings.Builder
+			for i := 0; i < size; i++ {
+				fmt.Fprintf(&sb, "item_%d: %d\n", i, i)
+			}
+			src := sb.String()
+			limits := omnist.DefaultLimits()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_, _ = Read(src, limits)
+			}
+		})
+	}
+}
+
+func TestPeekRuneAtEOF(t *testing.T) {
+	l := newLexer("a", omnist.NewLimitChecker(omnist.DefaultLimits()))
+	if r := l.peekRuneAt(10); r != 0 {
+		t.Errorf("expected 0, got %v", r)
 	}
 }

--- a/oml/oml_parser_test.go
+++ b/oml/oml_parser_test.go
@@ -1002,7 +1002,6 @@ func TestIntDigitsLimitUsesNestedDocumentPath(t *testing.T) {
 	}
 }
 
-
 func BenchmarkReadOMLFlat(b *testing.B) {
 	sizes := []int{100, 1000, 5000, 10000}
 	for _, size := range sizes {

--- a/osd/osd_lexer.go
+++ b/osd/osd_lexer.go
@@ -1,6 +1,7 @@
 package osd
 
 import (
+	"unicode/utf8"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -45,28 +46,30 @@ type osdToken struct {
 // single ordered alternation, with whitespace and `#`-to-end-of-line
 // comments discarded before the parser ever sees a token.
 type osdLexer struct {
-	src  []rune
-	pos  int
-	line int
-	col  int
+	raw     string
+	bytePos int
+	line    int
+	col     int
 }
 
 func newOSDLexer(text string) *osdLexer {
-	return &osdLexer{src: []rune(text), pos: 0, line: 1, col: 1}
+	return &osdLexer{raw: text, bytePos: 0, line: 1, col: 1}
 }
 
-func (l *osdLexer) atEOF() bool { return l.pos >= len(l.src) }
+func (l *osdLexer) atEOF() bool { return l.bytePos >= len(l.raw) }
 
-// peekRune returns the rune at the current position. Every call site
-// guards with atEOF first (the same trust-the-caller convention advance
-// uses), so this does not re-check bounds itself.
+// peekRune returns the rune at the current position.
 func (l *osdLexer) peekRune() rune {
-	return l.src[l.pos]
+	if l.atEOF() {
+		return 0
+	}
+	r, _ := utf8.DecodeRuneInString(l.raw[l.bytePos:])
+	return r
 }
 
 func (l *osdLexer) advance() rune {
-	r := l.src[l.pos]
-	l.pos++
+	r, width := utf8.DecodeRuneInString(l.raw[l.bytePos:])
+	l.bytePos += width
 	if r == '\n' {
 		l.line++
 		l.col = 1
@@ -109,7 +112,7 @@ var (
 )
 
 func (l *osdLexer) remainingString() string {
-	return string(l.src[l.pos:])
+	return l.raw[l.bytePos:]
 }
 
 func (l *osdLexer) errAt(line, col int, code omnist.Code, msg string) *omnist.ParseError {

--- a/osd/osd_lexer.go
+++ b/osd/osd_lexer.go
@@ -1,11 +1,11 @@
 package osd
 
 import (
-	"unicode/utf8"
 	"fmt"
 	"regexp"
 	"strconv"
 	"strings"
+	"unicode/utf8"
 
 	omnist "github.com/omnist-dev/omnist-go"
 )

--- a/osd/osd_parser_test.go
+++ b/osd/osd_parser_test.go
@@ -1,6 +1,9 @@
 package osd
 
 import (
+	"fmt"
+	"strings"
+	"strconv"
 	"testing"
 
 	omnist "github.com/omnist-dev/omnist-go"
@@ -625,5 +628,32 @@ func TestCardinalityBoundOverflowsInt64(t *testing.T) {
 	c := s.Env["R"].Fields[0].Cardinality
 	if c.Min != 0 || c.Max != 1 {
 		t.Fatalf("got %+v", c)
+	}
+}
+
+
+func BenchmarkReadOSDManyFields(b *testing.B) {
+	sizes := []int{100, 1000, 5000, 10000}
+	for _, size := range sizes {
+		b.Run(strconv.Itoa(size), func(b *testing.B) {
+			var sb strings.Builder
+			sb.WriteString("record ManyFields {\n")
+			for i := 0; i < size; i++ {
+				fmt.Fprintf(&sb, "  field_%d: string,\n", i)
+			}
+			sb.WriteString("}\nroot ManyFields\n")
+			src := sb.String()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_, _ = Read(src)
+			}
+		})
+	}
+}
+
+func TestOSDPeekRuneAtEOF(t *testing.T) {
+	l := newOSDLexer("")
+	if r := l.peekRune(); r != 0 {
+		t.Errorf("expected 0 at EOF, got %v", r)
 	}
 }

--- a/osd/osd_parser_test.go
+++ b/osd/osd_parser_test.go
@@ -2,8 +2,8 @@ package osd
 
 import (
 	"fmt"
-	"strings"
 	"strconv"
+	"strings"
 	"testing"
 
 	omnist "github.com/omnist-dev/omnist-go"
@@ -630,7 +630,6 @@ func TestCardinalityBoundOverflowsInt64(t *testing.T) {
 		t.Fatalf("got %+v", c)
 	}
 }
-
 
 func BenchmarkReadOSDManyFields(b *testing.B) {
 	sizes := []int{100, 1000, 5000, 10000}


### PR DESCRIPTION
Fixes #72 by scanning raw string byte offsets directly instead of allocating fresh string slices from []rune on every token in OML and OSD lexers.