### PR TITLE
Phase 4: Design/hardening items (#76, #77, #78)

### DIFF
--- a/algebra/compatible_with_test.go
+++ b/algebra/compatible_with_test.go
@@ -39,7 +39,6 @@ func TestScalarSub(t *testing.T) {
 	}
 }
 
-
 func BenchmarkCompatibleWithManyFields(b *testing.B) {
 	sizes := []int{50, 200, 1000}
 	for _, size := range sizes {

--- a/cmd/omnist/io.go
+++ b/cmd/omnist/io.go
@@ -6,19 +6,39 @@ import (
 	"os"
 )
 
+// maxInputBytes is the safety ceiling on raw input bytes read from stdin
+// or file (100 MiB), preventing unbounded memory allocation before any
+// parser limit runs (issue #76).
+const maxInputBytes = 100 * 1024 * 1024 // 100 MiB
+
 // readInput reads a document/schema body from path, or from stdin when
-// path is "" or "-", matching common Unix CLI convention.
+// path is "" or "-", matching common Unix CLI convention, bounded by
+// maxInputBytes.
 func readInput(path string, stdin io.Reader) (string, error) {
 	if path == "" || path == "-" {
-		b, err := io.ReadAll(stdin)
+		lr := io.LimitReader(stdin, maxInputBytes+1)
+		b, err := io.ReadAll(lr)
 		if err != nil {
 			return "", fmt.Errorf("reading stdin: %w", err)
 		}
+		if len(b) > maxInputBytes {
+			return "", fmt.Errorf("reading stdin: input exceeds maximum size limit of %d bytes (100 MiB)", maxInputBytes)
+		}
 		return string(b), nil
 	}
-	b, err := os.ReadFile(path)
+	f, err := os.Open(path)
 	if err != nil {
 		return "", fmt.Errorf("reading %s: %w", path, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	lr := io.LimitReader(f, maxInputBytes+1)
+	b, err := io.ReadAll(lr)
+	if err != nil {
+		return "", fmt.Errorf("reading %s: %w", path, err)
+	}
+	if len(b) > maxInputBytes {
+		return "", fmt.Errorf("reading %s: input exceeds maximum size limit of %d bytes (100 MiB)", path, maxInputBytes)
 	}
 	return string(b), nil
 }

--- a/cmd/omnist/io_test.go
+++ b/cmd/omnist/io_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -88,5 +89,57 @@ func TestReadInputStdinError(t *testing.T) {
 	_, err := readInput("-", failingReader{})
 	if err == nil {
 		t.Error("readInput: expected error from a failing stdin reader, got nil")
+	}
+}
+
+type repeatingReader struct {
+	remaining int64
+}
+
+func (r *repeatingReader) Read(p []byte) (int, error) {
+	if r.remaining <= 0 {
+		return 0, io.EOF
+	}
+	n := len(p)
+	if int64(n) > r.remaining {
+		n = int(r.remaining)
+	}
+	for i := 0; i < n; i++ {
+		p[i] = 'a'
+	}
+	r.remaining -= int64(n)
+	return n, nil
+}
+
+func TestReadInputExceedsMaxInputBytesStdin(t *testing.T) {
+	oversized := &repeatingReader{remaining: maxInputBytes + 10}
+	_, err := readInput("-", oversized)
+	if err == nil || !strings.Contains(err.Error(), "exceeds maximum size limit") {
+		t.Errorf("expected size limit error, got %v", err)
+	}
+}
+
+func TestReadInputExceedsMaxInputBytesFile(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "large.txt")
+	f, err := os.Create(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Truncate(int64(maxInputBytes + 10)); err != nil {
+		t.Fatal(err)
+	}
+	_ = f.Close()
+
+	_, err = readInput(p, nil)
+	if err == nil || !strings.Contains(err.Error(), "exceeds maximum size limit") {
+		t.Errorf("expected size limit error for oversized file, got %v", err)
+	}
+}
+
+func TestReadInputDirectoryError(t *testing.T) {
+	_, err := readInput(t.TempDir(), nil)
+	if err == nil {
+		t.Error("expected error when reading directory as file, got nil")
 	}
 }

--- a/document.go
+++ b/document.go
@@ -224,6 +224,9 @@ func (t Target) Value() (Value, bool) {
 }
 
 // Edge is a single (label, target) pair within a Node's ordered edge list.
+//
+// Validity contract (issue #77): in a valid Document, edges form a strictly
+// finite, acyclic tree with no shared or cyclic references.
 type Edge struct {
 	Label  string
 	Target Target
@@ -232,6 +235,12 @@ type Edge struct {
 // Node is an ordered list of labeled edges (spec §2.1/§2.2). Labels MAY
 // repeat; nothing in the Document model constrains uniqueness, ordering,
 // or the relationship between repeated labels (spec §2.2.2).
+//
+// Validity contract (issue #77): A Node and its descendant edges must form
+// a strictly finite, acyclic tree. Nodes must not be mutated concurrently
+// once constructed. Trees produced by omnist-go's format readers are
+// guaranteed acyclic by construction; callers constructing Node trees
+// programmatically are responsible for preserving acyclicity.
 //
 // Per the design decision recorded in docs/workflow-playbook.md §2.3, Node
 // stays edge-list-native everywhere: there is no separate map-collapsed
@@ -263,6 +272,11 @@ func (n *Node) AddNode(label string, child *Node) *Node {
 
 // Document is a node or a bare value (spec §2.2: `Document = node | value`).
 // Exactly one of Node or Value is meaningful, selected by IsNode.
+//
+// Validity contract (issue #77): A Document represents an immutable,
+// finite, acyclic tree. Operations throughout this package (validation,
+// materialization, algebra, serialization) assume this contract and do
+// not perform cyclic-graph checks during recursive descent.
 type Document struct {
 	IsNode bool
 	Node   *Node

--- a/limits.go
+++ b/limits.go
@@ -1,5 +1,7 @@
 package omnist
 
+import "fmt"
+
 // Limits bounds the work a Document builder will do before refusing to
 // continue, per spec §2.4. The existence and meaning of the three limits
 // is normative; the specific numbers are not, so Limits is a configurable
@@ -101,6 +103,47 @@ func (c *LimitChecker) CheckIntDigits(path string, digitCount int) *Diagnostic {
 			Message:  "integer literal exceeds the configured digit limit",
 			Severity: SeverityError,
 		}
+	}
+	return nil
+}
+
+// Recommended limit ceilings for Limits.Validate:
+// While spec §2.4 mandates that every implementation must enforce finite positive
+// limits for MaxDepth, MaxNodes, and MaxIntDigits, setting astronomically large limits
+// (e.g. math.MaxInt) practically defeats the safety purpose of resource bounding.
+const (
+	// MaxRecommendedDepth is the upper bound above which recursive algorithms risk stack exhaustion.
+	MaxRecommendedDepth = 10_000
+	// MaxRecommendedNodes is the upper bound above which node materialization risks heap exhaustion.
+	MaxRecommendedNodes = 100_000_000
+	// MaxRecommendedIntDigits is the upper bound above which arbitrary-precision integer parsing risks CPU exhaustion.
+	MaxRecommendedIntDigits = 1_000_000
+)
+
+// Validate checks that l specifies strictly positive values within sane, recommended safety
+// bounds (issue #78). It returns an error if any field is <= 0 or exceeds recommended ceilings.
+//
+// Validate is purely opt-in: NewLimitChecker does not enforce it, so callers who require
+// custom or unusually large limits retain full control. For standard production use,
+// DefaultLimits() is recommended.
+func (l Limits) Validate() error {
+	if l.MaxDepth <= 0 {
+		return fmt.Errorf("MaxDepth must be positive, got %d", l.MaxDepth)
+	}
+	if l.MaxDepth > MaxRecommendedDepth {
+		return fmt.Errorf("MaxDepth %d exceeds recommended safety ceiling (%d)", l.MaxDepth, MaxRecommendedDepth)
+	}
+	if l.MaxNodes <= 0 {
+		return fmt.Errorf("MaxNodes must be positive, got %d", l.MaxNodes)
+	}
+	if l.MaxNodes > MaxRecommendedNodes {
+		return fmt.Errorf("MaxNodes %d exceeds recommended safety ceiling (%d)", l.MaxNodes, MaxRecommendedNodes)
+	}
+	if l.MaxIntDigits <= 0 {
+		return fmt.Errorf("MaxIntDigits must be positive, got %d", l.MaxIntDigits)
+	}
+	if l.MaxIntDigits > MaxRecommendedIntDigits {
+		return fmt.Errorf("MaxIntDigits %d exceeds recommended safety ceiling (%d)", l.MaxIntDigits, MaxRecommendedIntDigits)
 	}
 	return nil
 }

--- a/limits_test.go
+++ b/limits_test.go
@@ -90,3 +90,32 @@ func TestLimitCheckerIntDigits(t *testing.T) {
 		t.Errorf("Path = %q, want %q", diag.Path, "$.n")
 	}
 }
+
+func TestLimitsValidate(t *testing.T) {
+	// DefaultLimits() is valid
+	if err := DefaultLimits().Validate(); err != nil {
+		t.Errorf("DefaultLimits().Validate() failed: %v", err)
+	}
+
+	// Non-positive values
+	if err := (Limits{MaxDepth: 0, MaxNodes: 100, MaxIntDigits: 10}).Validate(); err == nil {
+		t.Error("expected error for MaxDepth <= 0")
+	}
+	if err := (Limits{MaxDepth: 10, MaxNodes: 0, MaxIntDigits: 10}).Validate(); err == nil {
+		t.Error("expected error for MaxNodes <= 0")
+	}
+	if err := (Limits{MaxDepth: 10, MaxNodes: 100, MaxIntDigits: 0}).Validate(); err == nil {
+		t.Error("expected error for MaxIntDigits <= 0")
+	}
+
+	// Values exceeding recommended ceilings
+	if err := (Limits{MaxDepth: MaxRecommendedDepth + 1, MaxNodes: 100, MaxIntDigits: 10}).Validate(); err == nil {
+		t.Error("expected error for MaxDepth > MaxRecommendedDepth")
+	}
+	if err := (Limits{MaxDepth: 10, MaxNodes: MaxRecommendedNodes + 1, MaxIntDigits: 10}).Validate(); err == nil {
+		t.Error("expected error for MaxNodes > MaxRecommendedNodes")
+	}
+	if err := (Limits{MaxDepth: 10, MaxNodes: 100, MaxIntDigits: MaxRecommendedIntDigits + 1}).Validate(); err == nil {
+		t.Error("expected error for MaxIntDigits > MaxRecommendedIntDigits")
+	}
+}

--- a/validate_test.go
+++ b/validate_test.go
@@ -1,8 +1,8 @@
 package omnist
 
 import (
-	"strconv"
 	"math/big"
+	"strconv"
 	"testing"
 )
 
@@ -496,7 +496,6 @@ func TestValidateUnresolvableRef(t *testing.T) {
 		t.Fatalf("Validate() = %+v, want single unexpected-field at $.ghost.x (unresolvable ref treated as empty closed record)", got)
 	}
 }
-
 
 func BenchmarkValidateManyEdges(b *testing.B) {
 	sizes := []int{100, 1000, 5000, 10000}


### PR DESCRIPTION
Implements Phase 4 hardening items: Limits.Validate() helper (#78), Document/Node validity contracts documentation (#77), and CLI 100 MiB input size cap (#76).