### PR TITLE
Document ReadWithSchema and Limits.Validate; fix stale CI-gating claim

### DIFF
--- a/doc_examples_reference_test.go
+++ b/doc_examples_reference_test.go
@@ -404,3 +404,52 @@ func Example_xmlLeafTyping() {
 	fmt.Println(v.Scalar.Kind, v.Scalar.Str)
 	// Output: string 42
 }
+
+// Example_limitsValidate backs reference.md's Limits section:
+// Validate checks that configured limits are strictly positive and do not
+// exceed sane recommended safety bounds.
+func Example_limitsValidate() {
+	// DefaultLimits() satisfies all recommended bounds:
+	fmt.Println(omnist.DefaultLimits().Validate())
+
+	// Setting astronomically large limits triggers an error:
+	huge := omnist.Limits{
+		MaxDepth:     200,
+		MaxNodes:     200_000_000, // exceeds MaxRecommendedNodes (100,000,000)
+		MaxIntDigits: 4300,
+	}
+	fmt.Println(huge.Validate())
+	// Output:
+	// <nil>
+	// MaxNodes 200000000 exceeds recommended safety ceiling (100000000)
+}
+
+// Example_xmlReadWithSchema backs reference.md's `formats/xml` section:
+// XML carries no native type information, so plain `Read` leaves every
+// leaf as a string. `ReadWithSchema` uses an OSD schema to pre-type
+// numeric, boolean, and temporal leaves during ingestion per omnist-spec#44.
+func Example_xmlReadWithSchema() {
+	schema, err := osd.Read(`
+		record User { "name": string, "age": integer, "active": boolean }
+		root User
+	`)
+	if err != nil {
+		panic(err)
+	}
+
+	src := `<User><name>Ann</name><age>42</age><active>true</active></User>`
+	doc, err := xml.ReadWithSchema(src, &schema, omnist.DefaultLimits())
+	if err != nil {
+		panic(err)
+	}
+
+	rootNode, _ := doc.Node.Edges[0].Target.Node()
+	for _, edge := range rootNode.Edges {
+		v, _ := edge.Target.Value()
+		fmt.Printf("%s: %s\n", edge.Label, v.Scalar.Kind)
+	}
+	// Output:
+	// name: string
+	// age: integer
+	// active: boolean
+}

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -36,8 +36,13 @@ was always correct (the reference implementation genuinely emits the bare
 extending §8.5.2 rule 4's code-agnostic comparison (already used for
 Track 2's diagnostics) to Track 1's finding `code` field, done in
 `tools/conformance/fixtures.go`. The one Track 2 skip needs a TOML
-strict-mode write parameter this repo hasn't built yet. Not CI-gating yet,
-per `docs/workflow-playbook.md` §4.
+The one Track 2 skip needs a TOML strict-mode write parameter this repo
+hasn't built yet. Both conformance tracks are strictly CI-gating as of
+issue #74.
+
+### Codex audit cycle (#70–#81)
+
+A 12-issue Codex audit cycle (#70–#81) resolved across 4 phases addressed all outstanding audit findings: a precision correctness fix for integer-to-number materialization (#70), a patch for CVE GO-2026-6088 via a Go toolchain pin (1.26.6) and scheduled CI `vulncheck` job (#73), strict CI gating for both conformance tracks (#74), two quadratic CPU-exhaustion DoS fixes across validation/materialization/subtyping path indexing (#71, #80) and OML/OSD zero-copy lexer scanning (#72), schema-aware XML pretyping per `omnist-spec#44` (#81), and design/hardening improvements including `Limits.Validate()` (#78), explicit acyclic validity contracts (#77), and CLI input size caps (#76).
 
 ## Versioning
 

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -36,9 +36,8 @@ was always correct (the reference implementation genuinely emits the bare
 extending §8.5.2 rule 4's code-agnostic comparison (already used for
 Track 2's diagnostics) to Track 1's finding `code` field, done in
 `tools/conformance/fixtures.go`. The one Track 2 skip needs a TOML
-The one Track 2 skip needs a TOML strict-mode write parameter this repo
-hasn't built yet. Both conformance tracks are strictly CI-gating as of
-issue #74.
+strict-mode write parameter this repo hasn't built yet. Both conformance
+tracks are strictly CI-gating as of issue #74.
 
 ### Codex audit cycle (#70–#81)
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -187,6 +187,26 @@ that don't belong to a specific codec or the algebra package.
 - **`Limits`** / **`DefaultLimits()`** — the finite, documented safety
   bounds (depth, node count, integer digit count) spec §2.4 requires every
   implementation to enforce. Passed to every format reader.
+- **`Limits.Validate()`** — opt-in sanity check verifying that configured
+  limits are strictly positive and within recommended safety ceilings
+  (`MaxRecommendedDepth = 10_000`, `MaxRecommendedNodes = 100_000_000`,
+  `MaxRecommendedIntDigits = 1_000_000`).
+
+<!-- verified-by: doc_examples_reference_test.go::Example_limitsValidate -->
+```go
+// DefaultLimits() satisfies all recommended bounds:
+fmt.Println(omnist.DefaultLimits().Validate())
+
+// Setting astronomically large limits triggers an error:
+huge := omnist.Limits{
+    MaxDepth:     200,
+    MaxNodes:     200_000_000, // exceeds MaxRecommendedNodes (100,000,000)
+    MaxIntDigits: 4300,
+}
+fmt.Println(huge.Validate())
+// <nil>
+// MaxNodes 200000000 exceeds recommended safety ceiling (100000000)
+```
 
 ## `oml` — `github.com/omnist-dev/omnist-go/oml`
 
@@ -296,6 +316,36 @@ ageNode, _ := doc.Node.Edges[0].Target.Node()
 v, _ := ageNode.Edges[0].Target.Value()
 fmt.Println(v.Scalar.Kind, v.Scalar.Str)
 // string 42
+```
+
+`xml` also provides **`ReadWithSchema(src string, schema *omnist.Schema, limits omnist.Limits)`**
+to pre-type numeric, boolean, and temporal leaves during ingestion when an OSD schema is
+available (per `omnist-spec#44`):
+
+<!-- verified-by: doc_examples_reference_test.go::Example_xmlReadWithSchema -->
+```go
+schema, err := osd.Read(`
+    record User { "name": string, "age": integer, "active": boolean }
+    root User
+`)
+if err != nil {
+    panic(err)
+}
+
+src := `<User><name>Ann</name><age>42</age><active>true</active></User>`
+doc, err := xml.ReadWithSchema(src, &schema, omnist.DefaultLimits())
+if err != nil {
+    panic(err)
+}
+
+rootNode, _ := doc.Node.Edges[0].Target.Node()
+for _, edge := range rootNode.Edges {
+    v, _ := edge.Target.Value()
+    fmt.Printf("%s: %s\n", edge.Label, v.Scalar.Kind)
+}
+// name: string
+// age: integer
+// active: boolean
 ```
 
 A codec beyond JSON/YAML, showing the shared writer shape:

--- a/formats/xml/xml_reader.go
+++ b/formats/xml/xml_reader.go
@@ -14,7 +14,7 @@ import (
 
 // Read parses XML source text into an omnist.Document without a schema.
 //
-// Every leaf arrives as a string (spec ?7.1, docs/formats/xml.md). Callers
+// Every leaf arrives as a string (spec §7.1, docs/formats/xml.md). Callers
 // with an OSD schema should use ReadWithSchema to pre-type leaves into numeric,
 // boolean, and temporal scalars per omnist-spec#44.
 func Read(src string, limits omnist.Limits) (omnist.Document, error) {
@@ -24,7 +24,7 @@ func Read(src string, limits omnist.Limits) (omnist.Document, error) {
 // ReadWithSchema parses XML source text into an omnist.Document.
 //
 // If schema is non-nil, text leaves are pre-typed into boolean, integer, number,
-// or temporal scalars when the schema's declared field type calls for it (spec ?7.1,
+// or temporal scalars when the schema's declared field type calls for it (spec §7.1,
 // omnist-spec#44). Leaves that do not parse value-exactly remain strings and fall
 // through to normal stage-2 diagnostics.
 //


### PR DESCRIPTION
Post-cycle sweep after the 12-issue Codex audit (#70-81): two new public API additions (xml.ReadWithSchema from #81, Limits.Validate from #78) had zero doc-site coverage -- same recurring staleness pattern as #59/#64/#66. Adds real verified-by examples for both. Also fixes docs/limitations.md's stale "Not CI-gating yet" claim (wrong since #74) and a wrong section citation. Also found and fixed leftover ?7.1 comment corruption in xml_reader.go from Phase 1's #81 (missed at the time -- I only started checking for this pattern in Phase 3).