### PR TITLE
Make duplicate OSD root declaration an error

### DIFF
--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -17,7 +17,7 @@ conformance harness, and fuzz tests on every reader (`go test -fuzz`).
 
 Track 2 ([`tools/conformance/`](https://github.com/omnist-dev/omnist-go/tree/main/tools/conformance),
 JSON-vector, run against `omnist-spec`'s `test-suite/`) currently reports
-**151 pass / 0 fail / 1 skip** of 152 vectors. Track 1 (fixture-based,
+**152 pass / 0 fail / 1 skip** of 153 vectors. Track 1 (fixture-based,
 `conformance/fixtures/`) reports **19 pass / 0 fail / 0 skip** of 19
 fixtures. Both tracks are at zero real fails — the two prior fails, filed
 as [`omnist-spec#41`](https://github.com/omnist-dev/omnist-spec/issues/41)
@@ -63,9 +63,10 @@ gap — see the ledger's Go `Resource caps` row (source-audited clean,
 
 ## Spec version targeted
 
-`omnist-spec` at commit `f6ec180` (`v0.2.2-alpha`), pinned via the
-`vendor/omnist-spec` git submodule. This repo does not track the spec's
-`main` branch — the pin is bumped deliberately, in its own commit.
+`omnist-spec` at commit `964af7b` (`v0.3.0-alpha`, 2 commits past the tag —
+closes D-2's spec gap, issue #91), pinned via the `vendor/omnist-spec`
+git submodule. This repo does not track the spec's `main` branch — the
+pin is bumped deliberately, in its own commit.
 
 See `omnist-spec`'s own [§9.3 status table](https://github.com/omnist-dev/omnist-spec/blob/main/docs/09-divergence-ledger.md#93-status-table)
 for the cross-implementation divergence ledger this repo reports into.

--- a/errors.go
+++ b/errors.go
@@ -49,6 +49,11 @@ const (
 	// legally appear there, since type position only ever accepts a bare
 	// schema name (a scalar keyword, `any`, or a reference).
 	CodeSchemaQuotedType Code = "schema.quoted-type"
+	// CodeSchemaDuplicateRoot is raised when a schema contains more than
+	// one `root` declaration. Per spec §5.8 (updated 2026-08-23, closing
+	// chapter 9 divergence-ledger D-2), this is normatively an error, not
+	// an implementation-defined choice.
+	CodeSchemaDuplicateRoot Code = "schema.duplicate-root"
 )
 
 // validate.* — document against schema (spec §8.3.4).

--- a/osd/osd_parser.go
+++ b/osd/osd_parser.go
@@ -90,20 +90,17 @@ func (p *osdParser) parseSchema() (omnist.Schema, error) {
 			if err != nil {
 				return omnist.Schema{}, err
 			}
-			// spec §5.8 / chapter 9 divergence-ledger D-2: a second `root`
-			// declaration's behavior is an explicitly acknowledged open
-			// item (the spec does not yet mandate erroring, though a future
-			// spec-level change may make it one). This implementation
-			// picks "first root wins" — the earliest `root` declaration in
-			// source order is authoritative and later ones are parsed (so
-			// their own syntax is still validated) but otherwise ignored.
-			// This is one of the two defensible choices the issue names;
-			// it is not a blocking ambiguity, per the issue's own
-			// instruction not to treat D-2 as one.
-			if !rootSet {
-				schema.Root = name
-				rootSet = true
+			// spec §5.8 (updated 2026-08-23, closing chapter 9
+			// divergence-ledger D-2): a schema with more than one `root`
+			// declaration is normatively an error, not an
+			// implementation-defined choice. The second (and any later)
+			// `root` declaration's own syntax is still validated by
+			// parseRootDef above, but its presence at all is rejected here.
+			if rootSet {
+				return omnist.Schema{}, schemaError("$", omnist.CodeSchemaDuplicateRoot, fmt.Sprintf("a schema must declare exactly one root; %q is a second root declaration", name))
 			}
+			schema.Root = name
+			rootSet = true
 		default:
 			return omnist.Schema{}, p.errAt(p.cur, omnist.CodeParseUnexpectedToken, "expected 'record' or 'root'")
 		}

--- a/osd/osd_parser_test.go
+++ b/osd/osd_parser_test.go
@@ -300,14 +300,13 @@ func TestS1RootMissingIsError(t *testing.T) {
 	wantDiag(t, err, omnist.CodeSchemaNoRoot, "$")
 }
 
-func TestS1DuplicateRootFirstWins(t *testing.T) {
-	// D-2 (chapter 9, open divergence item): this implementation's chosen
-	// resolution is "first root wins" -- see the comment in
-	// parseSchema's `case "root":` branch for the full reasoning.
-	s := mustParseOSD(t, `record A{"x":string} record B{"x":string} root A root B`)
-	if s.Root != "A" {
-		t.Fatalf("Root = %q, want %q (first root should win)", s.Root, "A")
-	}
+func TestS1DuplicateRootIsError(t *testing.T) {
+	// D-2 (chapter 9 divergence-ledger, closed by spec §5.8's 2026-08-23
+	// update): a schema with more than one `root` declaration is
+	// normatively an error, not an implementation-defined choice -- see
+	// the comment in parseSchema's `case "root":` branch.
+	err := mustFailOSD(t, `record A{"x":string} record B{"x":string} root A root B`)
+	wantDiag(t, err, omnist.CodeSchemaDuplicateRoot, "$")
 }
 
 // S-2: cardinality bounds.

--- a/version.go
+++ b/version.go
@@ -3,4 +3,4 @@ package omnist
 
 // SpecVersion is the omnist-spec version this module targets, pinned via
 // the vendor/omnist-spec git submodule. See docs/limitations.md.
-const SpecVersion = "v0.2.2-alpha"
+const SpecVersion = "v0.3.0-alpha"


### PR DESCRIPTION
Resolves #91. omnist-spec Sec5.8 was updated to make a second root declaration in OSD a normative error (schema.duplicate-root, path $), closing divergence-ledger D-2 -- was previously implementation-defined first-root-wins behavior in this repo. Also fixes a real SpecVersion/limitations.md drift caught by TestSpecVersionMatchesSubmodule that the earlier submodule-pin-bump commit introduced. Track 2 conformance: 152/0/1 of 153 vectors (was 151/1/1 before the fix -- the one new vector now passes).