### PR TITLE
Report format.attribute-dropped/namespace-dropped/interleaving-lost (D-3)

### DIFF
--- a/cmd/omnist/cmd_infer.go
+++ b/cmd/omnist/cmd_infer.go
@@ -53,10 +53,18 @@ func cmdInfer(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 			_, _ = fmt.Fprintf(stderr, "%s: %v\n", name, rerr)
 			return ExitUsage
 		}
-		doc, perr := reader(text, omnist.DefaultLimits())
+		doc, readDiags, perr := reader(text, omnist.DefaultLimits())
 		if perr != nil {
 			_, _ = fmt.Fprintf(stderr, "%s: %s: %v\n", name, path, perr)
 			return ExitProblem
+		}
+		// A reader can succeed while still reporting a non-fatal
+		// adjustment (D-3, spec §8.3.8) -- surfaced the same
+		// informational way as --allow-any's fallbacks below, since
+		// infer's contract is best-effort schema drafting, not
+		// round-trip fidelity of the samples themselves.
+		for _, d := range readDiags {
+			_, _ = fmt.Fprintf(stderr, "%s: %s: %s: %s: %s\n", name, path, d.Path, d.Code, d.Message)
 		}
 		samples = append(samples, doc)
 	}

--- a/cmd/omnist/cmd_materialize.go
+++ b/cmd/omnist/cmd_materialize.go
@@ -75,7 +75,7 @@ func cmdMaterialize(args []string, stdin io.Reader, stdout, stderr io.Writer) in
 		return ExitUsage
 	}
 
-	doc, err := reader(text, omnist.DefaultLimits())
+	doc, readDiags, err := reader(text, omnist.DefaultLimits())
 	if err != nil {
 		_, _ = fmt.Fprintf(stderr, "omnist materialize: %v\n", err)
 		return ExitProblem
@@ -86,6 +86,12 @@ func cmdMaterialize(args []string, stdin io.Reader, stdout, stderr io.Writer) in
 		return ExitProblem
 	}
 
+	// A reader can succeed while still reporting a non-fatal adjustment
+	// (D-3, spec §8.3.8) -- printed alongside Materialize's own
+	// diagnostics below, same "path: code: message" convention.
+	for _, d := range readDiags {
+		_, _ = fmt.Fprintf(stdout, "%s: %s: %s\n", d.Path, d.Code, d.Message)
+	}
 	result, diags, err := omnist.Materialize(doc, schema)
 	for _, d := range diags {
 		_, _ = fmt.Fprintf(stdout, "%s: %s: %s\n", d.Path, d.Code, d.Message)
@@ -114,7 +120,7 @@ func cmdMaterialize(args []string, stdin io.Reader, stdout, stderr io.Writer) in
 		}
 	}
 
-	if len(diags) > 0 || writeDiagCount > 0 {
+	if len(readDiags) > 0 || len(diags) > 0 || writeDiagCount > 0 {
 		return ExitProblem
 	}
 	return ExitOK

--- a/cmd/omnist/cmd_parse.go
+++ b/cmd/omnist/cmd_parse.go
@@ -56,10 +56,17 @@ func cmdParse(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		return ExitUsage
 	}
 
-	doc, err := reader(text, omnist.DefaultLimits())
+	doc, readDiags, err := reader(text, omnist.DefaultLimits())
 	if err != nil {
 		_, _ = fmt.Fprintf(stderr, "omnist parse: %v\n", err)
 		return ExitProblem
+	}
+	// A reader can succeed while still reporting a non-fatal adjustment
+	// too (D-3, spec §8.3.8: an XML attribute or namespace prefix
+	// dropped on read) -- same channel and printing convention as a
+	// writer's diagnostics below, just surfaced before the write happens.
+	for _, d := range readDiags {
+		_, _ = fmt.Fprintf(stderr, "omnist parse: %s: %s: %s\n", d.Path, d.Code, d.Message)
 	}
 	outText, diags, err := writer(doc)
 	if err != nil {
@@ -78,7 +85,7 @@ func cmdParse(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		_, _ = fmt.Fprintf(stderr, "omnist parse: %v\n", err)
 		return ExitUsage
 	}
-	if len(diags) > 0 {
+	if len(readDiags) > 0 || len(diags) > 0 {
 		return ExitProblem
 	}
 	return ExitOK

--- a/cmd/omnist/cmd_validate.go
+++ b/cmd/omnist/cmd_validate.go
@@ -56,7 +56,7 @@ func cmdValidate(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		return ExitUsage
 	}
 
-	doc, err := reader(text, omnist.DefaultLimits())
+	doc, readDiags, err := reader(text, omnist.DefaultLimits())
 	if err != nil {
 		_, _ = fmt.Fprintf(stderr, "omnist validate: %v\n", err)
 		return ExitProblem
@@ -67,11 +67,17 @@ func cmdValidate(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		return ExitProblem
 	}
 
+	// A reader can succeed while still reporting a non-fatal adjustment
+	// (D-3, spec §8.3.8) -- printed alongside Validate's own
+	// diagnostics below, same "path: code: message" convention.
+	for _, d := range readDiags {
+		_, _ = fmt.Fprintf(stdout, "%s: %s: %s\n", d.Path, d.Code, d.Message)
+	}
 	diags := omnist.Validate(doc, schema)
 	for _, d := range diags {
 		_, _ = fmt.Fprintf(stdout, "%s: %s: %s\n", d.Path, d.Code, d.Message)
 	}
-	if len(diags) > 0 {
+	if len(readDiags) > 0 || len(diags) > 0 {
 		return ExitProblem
 	}
 	return ExitOK

--- a/cmd/omnist/format.go
+++ b/cmd/omnist/format.go
@@ -18,7 +18,15 @@ import (
 // table below can be built once and shared by every subcommand that
 // needs format dispatch (parse, validate, materialize, infer), instead
 // of six separate copies of the same format-name switch statement.
-type formatReaderFunc func(text string, limits omnist.Limits) (omnist.Document, error)
+//
+// formatReaderFunc's diagnostics return mirrors formatWriterFunc's below:
+// a read can succeed (err == nil) while still reporting a non-fatal
+// adjustment via the returned []omnist.Diagnostic. Today only xml.Read
+// ever populates it (an attribute or namespace prefix dropped, D-3, spec
+// §8.3.8) -- json/yaml/toml/oml have nothing to report on read, so
+// they're wrapped below to return nil diagnostics, the same way oml.Write
+// is wrapped in formatWriters for the identical reason.
+type formatReaderFunc func(text string, limits omnist.Limits) (omnist.Document, []omnist.Diagnostic, error)
 
 // formatWriterFunc's diagnostics return is the ok:true+diagnostics
 // channel added in issue #49: a writer can succeed (err == nil) while
@@ -27,12 +35,22 @@ type formatReaderFunc func(text string, limits omnist.Limits) (omnist.Document, 
 // []omnist.Diagnostic, per spec §8.5.3.
 type formatWriterFunc func(d omnist.Document) (string, []omnist.Diagnostic, error)
 
+// noReadDiagnostics adapts a reader with no diagnostics channel of its
+// own (json.Read, yaml.Read, toml.Read, oml.Read) to formatReaderFunc,
+// mirroring formatWriters' oml.Write wrapper below.
+func noReadDiagnostics(read func(string, omnist.Limits) (omnist.Document, error)) formatReaderFunc {
+	return func(text string, limits omnist.Limits) (omnist.Document, []omnist.Diagnostic, error) {
+		doc, err := read(text, limits)
+		return doc, nil, err
+	}
+}
+
 var formatReaders = map[string]formatReaderFunc{
-	"json": json.Read,
-	"yaml": yaml.Read,
-	"toml": toml.Read,
+	"json": noReadDiagnostics(json.Read),
+	"yaml": noReadDiagnostics(yaml.Read),
+	"toml": noReadDiagnostics(toml.Read),
 	"xml":  xml.Read,
-	"oml":  oml.Read,
+	"oml":  noReadDiagnostics(oml.Read),
 }
 
 var formatWriters = map[string]formatWriterFunc{

--- a/cmd/omnist/run_test.go
+++ b/cmd/omnist/run_test.go
@@ -130,6 +130,25 @@ func TestCmdParseWriteToFile(t *testing.T) {
 	}
 }
 
+// TestCmdParseXMLReadDiagnostics exercises the D-3 (spec §8.3.8) read-side
+// diagnostics channel added to xml.Read: a dropped attribute is surfaced
+// to stderr the same way a writer's non-fatal adjustment already was
+// (issue #49's ok:true+diagnostics convention), and the command still
+// exits ExitProblem even though the parse itself succeeded and produced
+// output.
+func TestCmdParseXMLReadDiagnostics(t *testing.T) {
+	code, stdout, stderr := runCLI(t, []string{"parse", "--from", "xml", "--to", "json", "-"}, `<a x="1"><b>hi</b></a>`)
+	if code != ExitProblem {
+		t.Errorf("exit = %d, want %d", code, ExitProblem)
+	}
+	if !strings.Contains(stderr, "format.attribute-dropped") {
+		t.Errorf("stderr = %q, want a format.attribute-dropped diagnostic", stderr)
+	}
+	if !strings.Contains(stdout, "\"b\": \"hi\"") {
+		t.Errorf("stdout = %q, want the converted document despite the diagnostic", stdout)
+	}
+}
+
 func TestCmdValidateSuccess(t *testing.T) {
 	schemaPath := writeTemp(t, "s.osd", testSchema)
 	code, stdout, _ := runCLI(t, []string{"validate", "--from", "json", "--schema", schemaPath, "-"}, `{"name": "Ada", "age": 12}`)
@@ -178,6 +197,17 @@ func TestCmdValidateMissingSchemaFile(t *testing.T) {
 	}
 }
 
+func TestCmdValidateXMLReadDiagnostics(t *testing.T) {
+	schemaPath := writeTemp(t, "s.osd", `record Root { "a": string } root Root`)
+	code, stdout, _ := runCLI(t, []string{"validate", "--from", "xml", "--schema", schemaPath, "-"}, `<a x="1">hi</a>`)
+	if code != ExitProblem {
+		t.Errorf("exit = %d, want %d", code, ExitProblem)
+	}
+	if !strings.Contains(stdout, "format.attribute-dropped") {
+		t.Errorf("stdout = %q, want a format.attribute-dropped diagnostic", stdout)
+	}
+}
+
 func TestCmdMaterializeSuccessNoOutput(t *testing.T) {
 	schemaPath := writeTemp(t, "s.osd", testSchema)
 	code, stdout, _ := runCLI(t, []string{"materialize", "--from", "json", "--schema", schemaPath, "-"}, `{"name": "Ada", "age": 12}`)
@@ -208,6 +238,17 @@ func TestCmdMaterializeDiagnostics(t *testing.T) {
 	}
 	if !strings.Contains(stdout, "validate.cardinality") {
 		t.Errorf("stdout = %q", stdout)
+	}
+}
+
+func TestCmdMaterializeXMLReadDiagnostics(t *testing.T) {
+	schemaPath := writeTemp(t, "s.osd", `record Root { "a": string } root Root`)
+	code, stdout, _ := runCLI(t, []string{"materialize", "--from", "xml", "--schema", schemaPath, "-"}, `<a x="1">hi</a>`)
+	if code != ExitProblem {
+		t.Errorf("exit = %d, want %d", code, ExitProblem)
+	}
+	if !strings.Contains(stdout, "format.attribute-dropped") {
+		t.Errorf("stdout = %q, want a format.attribute-dropped diagnostic", stdout)
 	}
 }
 
@@ -401,6 +442,20 @@ func TestCmdInferAllowAnyFallback(t *testing.T) {
 	}
 	if !strings.Contains(stdout, "any") {
 		t.Errorf("stdout = %q, want any-typed field", stdout)
+	}
+}
+
+func TestCmdInferXMLReadDiagnostics(t *testing.T) {
+	f1 := writeTemp(t, "a.xml", `<a x="1">hi</a>`)
+	code, stdout, stderr := runCLI(t, []string{"infer", "--from", "xml", f1}, "")
+	if code != ExitOK {
+		t.Fatalf("exit = %d, stderr = %q", code, stderr)
+	}
+	if !strings.Contains(stderr, "format.attribute-dropped") {
+		t.Errorf("stderr = %q, want a format.attribute-dropped note (informational, not a failure for infer)", stderr)
+	}
+	if !strings.Contains(stdout, "record Root") {
+		t.Errorf("stdout = %q", stdout)
 	}
 }
 

--- a/doc_examples_reference_test.go
+++ b/doc_examples_reference_test.go
@@ -394,7 +394,7 @@ func Example_yamlSexagesimal() {
 // scalar -- unlike JSON/YAML/TOML, `42` inside an element is never
 // resolved to an integer.
 func Example_xmlLeafTyping() {
-	doc, err := xml.Read(`<root><age>42</age></root>`, omnist.DefaultLimits())
+	doc, _, err := xml.Read(`<root><age>42</age></root>`, omnist.DefaultLimits())
 	if err != nil {
 		panic(err)
 	}
@@ -438,7 +438,7 @@ func Example_xmlReadWithSchema() {
 	}
 
 	src := `<User><name>Ann</name><age>42</age><active>true</active></User>`
-	doc, err := xml.ReadWithSchema(src, &schema, omnist.DefaultLimits())
+	doc, _, err := xml.ReadWithSchema(src, &schema, omnist.DefaultLimits())
 	if err != nil {
 		panic(err)
 	}

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -303,7 +303,7 @@ other kind the way JSON/YAML/TOML would:
 
 <!-- verified-by: doc_examples_reference_test.go::Example_xmlLeafTyping -->
 ```go
-doc, err := xml.Read(`<root><age>42</age></root>`, omnist.DefaultLimits())
+doc, _, err := xml.Read(`<root><age>42</age></root>`, omnist.DefaultLimits())
 if err != nil {
     panic(err)
 }
@@ -329,7 +329,7 @@ if err != nil {
 }
 
 src := `<User><name>Ann</name><age>42</age><active>true</active></User>`
-doc, err := xml.ReadWithSchema(src, &schema, omnist.DefaultLimits())
+doc, _, err := xml.ReadWithSchema(src, &schema, omnist.DefaultLimits())
 if err != nil {
     panic(err)
 }

--- a/document.go
+++ b/document.go
@@ -270,6 +270,47 @@ func (n *Node) AddNode(label string, child *Node) *Node {
 	return n
 }
 
+// HasLostInterleaving reports whether grouping n's edges by label (spec
+// §7.3.1's `groups` construction, shared by every JSON-family writer —
+// formats/json, formats/yaml, formats/toml) would lose cross-label
+// interleaving: some label's edges are not all contiguous in n.Edges.
+//
+// This is the shared home for the check because all three writer
+// packages already depend on this root-level omnist package (the same
+// placement precedent as schema.go's FieldIndex), and the algorithm
+// itself is format-independent — it only inspects n.Edges' label order,
+// never any format-specific rendering.
+//
+// The distinction that matters (spec §8.3.8, D-3): a label reappearing
+// immediately after its own prior occurrence is NOT interleaving loss —
+// [(m,A),(m,B),(x,X)] groups to {"m":[A,B],"x":X} with nothing lost,
+// since m's two edges were already contiguous before grouping. Only a
+// genuine interruption — a different label's edge appearing between two
+// edges of the same label, e.g. [(m,A),(x,X),(m,B)] — loses information:
+// grouping produces {"m":[A,B],"x":X}, which can no longer tell that X
+// originally sat between A and B.
+//
+// Detection walks n.Edges once, tracking the most recently seen label at
+// each position and the set of labels considered "closed" (a different
+// label has appeared since we last saw them). If a closed label reappears,
+// its edges were not contiguous, so interleaving was lost.
+func (n *Node) HasLostInterleaving() bool {
+	var lastLabel string
+	haveLast := false
+	closed := make(map[string]bool, len(n.Edges))
+	for _, e := range n.Edges {
+		if haveLast && e.Label != lastLabel {
+			closed[lastLabel] = true
+		}
+		if closed[e.Label] {
+			return true
+		}
+		lastLabel = e.Label
+		haveLast = true
+	}
+	return false
+}
+
 // Document is a node or a bare value (spec §2.2: `Document = node | value`).
 // Exactly one of Node or Value is meaningful, selected by IsNode.
 //

--- a/document_test.go
+++ b/document_test.go
@@ -231,3 +231,36 @@ func TestDocumentConstructors(t *testing.T) {
 		t.Errorf("ValueDocument: got %+v", d2)
 	}
 }
+
+// TestHasLostInterleaving covers the D-3 distinction (spec §8.3.8):
+// contiguous repeats of one label are not interleaving loss, but a
+// different label's edge appearing between two occurrences of the same
+// label is.
+func TestHasLostInterleaving(t *testing.T) {
+	tests := []struct {
+		name   string
+		labels []string
+		want   bool
+	}{
+		{"empty", nil, false},
+		{"single edge", []string{"m"}, false},
+		{"all distinct labels", []string{"m", "x", "y"}, false},
+		{"contiguous repeat, not interleaved", []string{"m", "m", "x"}, false},
+		{"contiguous repeat then another label", []string{"m", "m", "x", "x"}, false},
+		{"genuine interleaving", []string{"m", "x", "m"}, true},
+		{"interleaving after a third label", []string{"m", "x", "y", "m"}, true},
+		{"interleaving in the middle of a longer run", []string{"a", "m", "x", "m", "b"}, true},
+		{"two separately-interleaved labels", []string{"m", "x", "m", "y", "x"}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			n := NewNode()
+			for _, label := range tt.labels {
+				n.AddValue(label, ScalarValue(NewStringScalar("v")))
+			}
+			if got := n.HasLostInterleaving(); got != tt.want {
+				t.Errorf("HasLostInterleaving() = %v, want %v (labels %v)", got, tt.want, tt.labels)
+			}
+		})
+	}
+}

--- a/formats/json/json_writer.go
+++ b/formats/json/json_writer.go
@@ -16,19 +16,22 @@ import (
 // JSON-specific leaf rendering: temporal leaves are stringified to
 // ISO-8601, and NaN/Infinity — not valid JSON tokens — are substituted
 // with `null` at the leaf (docs/formats/json.md's default lenient mode).
+// Grouping itself can also lose cross-label interleaving; see
+// groupJSONEdges's doc comment.
 //
-// The signature returns diagnostics alongside text and error because both
-// of JSON's leaf adjustments are reportable per spec §7.4 ("a reader or
+// The signature returns diagnostics alongside text and error because all
+// three of JSON's adjustments are reportable per spec §7.4 ("a reader or
 // writer SHOULD be able to report the adjustments... this is what makes
 // lossiness auditable") and spec §8.5.3, which documents write as the one
 // operation where a successful `{ok: true, ...}` result and a non-empty
 // diagnostics list are not mutually exclusive: every temporal leaf
-// stringified to ISO-8601 (format.temporal-stringified) and every
-// NaN/Infinity substituted with `null` (format.float-special) is now
-// reported this way. text is non-empty and err is nil whenever the write
-// succeeds, with diagnostics non-empty exactly when an adjustment
-// happened; text is empty and err is non-nil only on WriteStrict's hard
-// NaN/Infinity failure below.
+// stringified to ISO-8601 (format.temporal-stringified), every
+// NaN/Infinity substituted with `null` (format.float-special), and every
+// grouping that loses cross-label interleaving (format.interleaving-lost,
+// spec §8.3.8, D-3) is now reported this way. text is non-empty and err
+// is nil whenever the write succeeds, with diagnostics non-empty exactly
+// when an adjustment happened; text is empty and err is non-nil only on
+// WriteStrict's hard NaN/Infinity failure below.
 //
 // See WriteStrict for the spec's optional MAY: failing instead of
 // substituting.
@@ -79,6 +82,14 @@ type jsonGroup struct {
 // otherwise (count-1 rule).
 func writeJSONNode(b *strings.Builder, n *omnist.Node, path string, strict bool, diags *[]omnist.Diagnostic) error {
 	groups := groupJSONEdges(n)
+	if n.HasLostInterleaving() {
+		*diags = append(*diags, omnist.Diagnostic{
+			Path:     path,
+			Code:     omnist.CodeFormatInterleavingLost,
+			Message:  "cross-label interleaving cannot be expressed in JSON, so it is lost",
+			Severity: omnist.SeverityWarning,
+		})
+	}
 
 	b.WriteByte('{')
 	for i, g := range groups {
@@ -114,7 +125,10 @@ func writeJSONNode(b *strings.Builder, n *omnist.Node, path string, strict bool,
 // a label collapse into one group, in first-seen label order, preserving
 // each label's own children in their original edge order. Cross-label
 // interleaving (e.g. [(m,A),(x,X),(m,B)]) is lost here, exactly as §7.3
-// states JSON must ("no format in the JSON family can express it").
+// states JSON must ("no format in the JSON family can express it") --
+// writeJSONNode reports this loss via omnist.CodeFormatInterleavingLost
+// (spec §8.3.8, D-3) whenever it actually happens (omnist.Node.HasLostInterleaving,
+// document.go), rather than silently, as it did before.
 func groupJSONEdges(n *omnist.Node) []jsonGroup {
 	var groups []jsonGroup
 	index := make(map[string]int, len(n.Edges))

--- a/formats/json/json_writer_test.go
+++ b/formats/json/json_writer_test.go
@@ -322,3 +322,66 @@ func TestWriteJSONNestedNode(t *testing.T) {
 		t.Errorf("got %q, want %q", got, want)
 	}
 }
+
+// --- cross-label interleaving loss (D-3, spec §8.3.8) ---
+
+func TestWriteJSONInterleavingLostReportsDiagnostic(t *testing.T) {
+	// formats-json/basic/cross-label-interleaving-lost-and-reported
+	doc := omnist.NodeDocument(omnist.NewNode().
+		AddValue("m", omnist.ScalarValue(omnist.NewStringScalar("A"))).
+		AddValue("x", omnist.ScalarValue(omnist.NewStringScalar("X"))).
+		AddValue("m", omnist.ScalarValue(omnist.NewStringScalar("B"))))
+	got, diags, err := Write(doc)
+	if err != nil {
+		t.Fatalf("WriteJSON failed: %v", err)
+	}
+	if want := `{"m": ["A", "B"], "x": "X"}`; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+	if len(diags) != 1 {
+		t.Fatalf("diags = %+v, want exactly 1", diags)
+	}
+	if diags[0].Path != "$" || diags[0].Code != omnist.CodeFormatInterleavingLost || diags[0].Severity != omnist.SeverityWarning {
+		t.Errorf("got diagnostic %+v, want {Path: $, Code: %s, Severity: warning}", diags[0], omnist.CodeFormatInterleavingLost)
+	}
+}
+
+func TestWriteJSONContiguousRepeatNoInterleavingDiagnostic(t *testing.T) {
+	// A label repeating back-to-back, with no other label between its
+	// occurrences, loses nothing and must NOT report interleaving-lost --
+	// the distinction the issue calls out as the trickiest part.
+	doc := omnist.NodeDocument(omnist.NewNode().
+		AddValue("m", omnist.ScalarValue(omnist.NewStringScalar("A"))).
+		AddValue("m", omnist.ScalarValue(omnist.NewStringScalar("B"))).
+		AddValue("x", omnist.ScalarValue(omnist.NewStringScalar("X"))))
+	got, diags, err := Write(doc)
+	if err != nil {
+		t.Fatalf("WriteJSON failed: %v", err)
+	}
+	if want := `{"m": ["A", "B"], "x": "X"}`; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+	if len(diags) != 0 {
+		t.Errorf("diags = %+v, want none (contiguous repeat loses nothing)", diags)
+	}
+}
+
+func TestWriteJSONInterleavingLostAtNestedPath(t *testing.T) {
+	// The check runs per node, not just at the document root -- interleaving
+	// lost inside a nested object is reported at that object's own path.
+	inner := omnist.NewNode().
+		AddValue("m", omnist.ScalarValue(omnist.NewStringScalar("A"))).
+		AddValue("x", omnist.ScalarValue(omnist.NewStringScalar("X"))).
+		AddValue("m", omnist.ScalarValue(omnist.NewStringScalar("B")))
+	doc := omnist.NodeDocument(omnist.NewNode().AddNode("outer", inner))
+	_, diags, err := Write(doc)
+	if err != nil {
+		t.Fatalf("WriteJSON failed: %v", err)
+	}
+	if len(diags) != 1 {
+		t.Fatalf("diags = %+v, want exactly 1", diags)
+	}
+	if diags[0].Path != "$.outer" || diags[0].Code != omnist.CodeFormatInterleavingLost {
+		t.Errorf("got diagnostic %+v, want {Path: $.outer, Code: %s}", diags[0], omnist.CodeFormatInterleavingLost)
+	}
+}

--- a/formats/toml/toml_writer.go
+++ b/formats/toml/toml_writer.go
@@ -108,6 +108,16 @@ type tomlGroup struct {
 	children []omnist.Target
 }
 
+// groupTOMLEdges mirrors groupJSONEdges/groupYAMLEdges
+// (json_writer.go/yaml_writer.go): edges sharing a label collapse into
+// one group, in first-seen label order, preserving each label's own
+// children in their original edge order. Cross-label interleaving (e.g.
+// [(m,A),(x,X),(m,B)]) is lost here, exactly as §7.3 states the JSON
+// family must ("no format in the JSON family can express it") --
+// writeTOMLTopLevel/writeTOMLInlineTable report this loss via
+// omnist.CodeFormatInterleavingLost (spec §8.3.8, D-3) whenever it
+// actually happens (omnist.Node.HasLostInterleaving, document.go), rather
+// than silently, as it did before.
 func groupTOMLEdges(n *omnist.Node) []tomlGroup {
 	var groups []tomlGroup
 	index := make(map[string]int, len(n.Edges))
@@ -129,6 +139,14 @@ func groupTOMLEdges(n *omnist.Node) []tomlGroup {
 // `[section]` headers, and for the null-drop reasoning below.
 func writeTOMLTopLevel(b *strings.Builder, n *omnist.Node, diags *[]omnist.Diagnostic) {
 	groups := groupTOMLEdges(n)
+	if n.HasLostInterleaving() {
+		*diags = append(*diags, omnist.Diagnostic{
+			Path:     "$",
+			Code:     omnist.CodeFormatInterleavingLost,
+			Message:  "cross-label interleaving cannot be expressed in TOML, so it is lost",
+			Severity: omnist.SeverityWarning,
+		})
+	}
 	for _, g := range groups {
 		var vb strings.Builder
 		if !writeTOMLGroupValue(&vb, g, "$."+g.label, diags) {
@@ -215,6 +233,14 @@ func writeTOMLTargetOptional(b *strings.Builder, t omnist.Target, path string, d
 // than leaving a dangling key.
 func writeTOMLInlineTable(b *strings.Builder, n *omnist.Node, path string, diags *[]omnist.Diagnostic) {
 	groups := groupTOMLEdges(n)
+	if n.HasLostInterleaving() {
+		*diags = append(*diags, omnist.Diagnostic{
+			Path:     path,
+			Code:     omnist.CodeFormatInterleavingLost,
+			Message:  "cross-label interleaving cannot be expressed in TOML, so it is lost",
+			Severity: omnist.SeverityWarning,
+		})
+	}
 	b.WriteByte('{')
 	first := true
 	for _, g := range groups {

--- a/formats/toml/toml_writer_test.go
+++ b/formats/toml/toml_writer_test.go
@@ -359,3 +359,57 @@ func TestWriteTOMLNestedNode(t *testing.T) {
 		t.Errorf("round-trip mismatch: wrote %q,\ngot  %+v,\nwant %+v", out, back, d)
 	}
 }
+
+// --- cross-label interleaving loss (D-3, spec §8.3.8) ---
+
+func TestWriteTOMLInterleavingLostReportsDiagnostic(t *testing.T) {
+	doc := omnist.NodeDocument(omnist.NewNode().
+		AddValue("m", omnist.ScalarValue(omnist.NewStringScalar("A"))).
+		AddValue("x", omnist.ScalarValue(omnist.NewStringScalar("X"))).
+		AddValue("m", omnist.ScalarValue(omnist.NewStringScalar("B"))))
+	_, diags, err := Write(doc)
+	if err != nil {
+		t.Fatalf("WriteTOML failed: %v", err)
+	}
+	if len(diags) != 1 {
+		t.Fatalf("diags = %+v, want exactly 1", diags)
+	}
+	if diags[0].Path != "$" || diags[0].Code != omnist.CodeFormatInterleavingLost || diags[0].Severity != omnist.SeverityWarning {
+		t.Errorf("got diagnostic %+v, want {Path: $, Code: %s, Severity: warning}", diags[0], omnist.CodeFormatInterleavingLost)
+	}
+}
+
+func TestWriteTOMLContiguousRepeatNoInterleavingDiagnostic(t *testing.T) {
+	doc := omnist.NodeDocument(omnist.NewNode().
+		AddValue("m", omnist.ScalarValue(omnist.NewStringScalar("A"))).
+		AddValue("m", omnist.ScalarValue(omnist.NewStringScalar("B"))).
+		AddValue("x", omnist.ScalarValue(omnist.NewStringScalar("X"))))
+	_, diags, err := Write(doc)
+	if err != nil {
+		t.Fatalf("WriteTOML failed: %v", err)
+	}
+	if len(diags) != 0 {
+		t.Errorf("diags = %+v, want none (contiguous repeat loses nothing)", diags)
+	}
+}
+
+func TestWriteTOMLInterleavingLostAtNestedPath(t *testing.T) {
+	// Exercises writeTOMLInlineTable's own check, not just
+	// writeTOMLTopLevel's -- the loss is reported at the nested inline
+	// table's own path, not "$".
+	inner := omnist.NewNode().
+		AddValue("m", omnist.ScalarValue(omnist.NewStringScalar("A"))).
+		AddValue("x", omnist.ScalarValue(omnist.NewStringScalar("X"))).
+		AddValue("m", omnist.ScalarValue(omnist.NewStringScalar("B")))
+	doc := omnist.NodeDocument(omnist.NewNode().AddNode("outer", inner))
+	_, diags, err := Write(doc)
+	if err != nil {
+		t.Fatalf("WriteTOML failed: %v", err)
+	}
+	if len(diags) != 1 {
+		t.Fatalf("diags = %+v, want exactly 1", diags)
+	}
+	if diags[0].Path != "$.outer" || diags[0].Code != omnist.CodeFormatInterleavingLost {
+		t.Errorf("got diagnostic %+v, want {Path: $.outer, Code: %s}", diags[0], omnist.CodeFormatInterleavingLost)
+	}
+}

--- a/formats/xml/xml_fuzz_test.go
+++ b/formats/xml/xml_fuzz_test.go
@@ -67,7 +67,7 @@ func FuzzRead(f *testing.F) {
 	f.Add("<a>hello<b>x</b>world</a>")                  // repo-test-literal
 
 	f.Fuzz(func(t *testing.T, text string) {
-		doc, err := Read(text, fuzzLimits())
+		doc, _, err := Read(text, fuzzLimits())
 		if err != nil {
 			if _, ok := err.(*omnist.ParseError); !ok {
 				t.Fatalf("Read returned a non-*omnist.ParseError error: %T: %v", err, err)

--- a/formats/xml/xml_reader.go
+++ b/formats/xml/xml_reader.go
@@ -17,7 +17,15 @@ import (
 // Every leaf arrives as a string (spec §7.1, docs/formats/xml.md). Callers
 // with an OSD schema should use ReadWithSchema to pre-type leaves into numeric,
 // boolean, and temporal scalars per omnist-spec#44.
-func Read(src string, limits omnist.Limits) (omnist.Document, error) {
+//
+// The signature returns diagnostics alongside the omnist.Document and error,
+// matching every writer in this repository (issue #49) and, as of D-3
+// (spec §8.3.8), this reader too: every dropped attribute
+// (format.attribute-dropped) and every dropped namespace prefix
+// (format.namespace-dropped) is now reported this way rather than
+// silently -- see ReadWithSchema's "Attribute and namespace-prefix
+// dropping" section below.
+func Read(src string, limits omnist.Limits) (omnist.Document, []omnist.Diagnostic, error) {
 	return ReadWithSchema(src, nil, limits)
 }
 
@@ -75,10 +83,18 @@ func Read(src string, limits omnist.Limits) (omnist.Document, error) {
 // Per docs/formats/xml.md ("Attributes and namespace prefixes are
 // dropped"), attributes leave no trace in the resulting omnist.Document, and any
 // StartElement/EndElement Name.Space prefix is discarded, keeping only
-// Name.Local as the edge label.
-func ReadWithSchema(src string, schema *omnist.Schema, limits omnist.Limits) (omnist.Document, error) {
+// Name.Local as the edge label. Per D-3 (spec §8.3.8), both drops are now
+// reported rather than silent: an element with one or more attributes
+// emits one omnist.CodeFormatAttributeDropped warning at that element's own
+// Document path (e.g. "$.a" for `<a x="1"><b>hi</b></a>`), and an element
+// whose tag carried a namespace prefix emits one
+// omnist.CodeFormatNamespaceDropped warning, also at that element's own
+// Document path (e.g. "$.a.b" for `<a><ns:b>hi</ns:b></a>`). Both checks
+// live in readStart, run once per StartElement token (root and every
+// child alike) as soon as that element's own Document path is known.
+func ReadWithSchema(src string, schema *omnist.Schema, limits omnist.Limits) (omnist.Document, []omnist.Diagnostic, error) {
 	if len(src) == 0 {
-		return omnist.Document{}, &omnist.ParseError{
+		return omnist.Document{}, nil, &omnist.ParseError{
 			Path:    "1:0",
 			Code:    omnist.CodeParseUnexpectedToken,
 			Message: "unexpected end of input",
@@ -91,10 +107,10 @@ func ReadWithSchema(src string, schema *omnist.Schema, limits omnist.Limits) (om
 	}
 	label, node, isLeaf, leafText, err := r.readRoot()
 	if err != nil {
-		return omnist.Document{}, err
+		return omnist.Document{}, nil, err
 	}
 	if err := r.checkTrailing(); err != nil {
-		return omnist.Document{}, err
+		return omnist.Document{}, nil, err
 	}
 	root := omnist.NewNode()
 	if isLeaf {
@@ -103,7 +119,7 @@ func ReadWithSchema(src string, schema *omnist.Schema, limits omnist.Limits) (om
 				if f := findField(rootRec, label); f != nil && f.Type.Kind == omnist.TypeScalarKind {
 					if sc, ok := pretypeScalar(leafText, f.Type.ScalarKind); ok {
 						root.AddValue(label, omnist.ScalarValue(sc))
-						return omnist.NodeDocument(root), nil
+						return omnist.NodeDocument(root), r.diags, nil
 					}
 				}
 			}
@@ -112,13 +128,14 @@ func ReadWithSchema(src string, schema *omnist.Schema, limits omnist.Limits) (om
 	} else {
 		root.AddNode(label, node)
 	}
-	return omnist.NodeDocument(root), nil
+	return omnist.NodeDocument(root), r.diags, nil
 }
 
 type xmlReader struct {
 	dec     *encxml.Decoder
 	checker *omnist.LimitChecker
 	schema  *omnist.Schema
+	diags   []omnist.Diagnostic
 }
 
 // readRoot finds the single document element, consumes it via
@@ -135,6 +152,8 @@ func (r *xmlReader) readRoot() (label string, node *omnist.Node, isLeaf bool, le
 		switch t := tok.(type) {
 		case encxml.StartElement:
 			label = t.Name.Local
+			docPath := "$." + label
+			r.readStart(t, docPath)
 			var currentRec *omnist.Record
 			if r.schema != nil {
 				if rootRec := r.schema.Env[r.schema.Root]; rootRec != nil {
@@ -151,7 +170,7 @@ func (r *xmlReader) readRoot() (label string, node *omnist.Node, isLeaf bool, le
 					currentRec = r.schema.Env[label]
 				}
 			}
-			node, isLeaf, leafText, err = r.readElementBody(currentRec)
+			node, isLeaf, leafText, err = r.readElementBody(currentRec, docPath)
 			return label, node, isLeaf, leafText, err
 		case encxml.CharData:
 			if len(strings.TrimSpace(string(t))) != 0 {
@@ -228,7 +247,7 @@ func (r *xmlReader) pathHere() string {
 
 // readElementBody reads one element's children up to and including the matching
 // EndElement.
-func (r *xmlReader) readElementBody(currentRec *omnist.Record) (node *omnist.Node, isLeaf bool, leafText string, err error) {
+func (r *xmlReader) readElementBody(currentRec *omnist.Record, docPath string) (node *omnist.Node, isLeaf bool, leafText string, err error) {
 	var text strings.Builder
 	var children *omnist.Node
 
@@ -255,7 +274,8 @@ func (r *xmlReader) readElementBody(currentRec *omnist.Record) (node *omnist.Nod
 			if f != nil && f.Type.Kind == omnist.TypeRefKind && r.schema != nil {
 				childRec = r.schema.Env[f.Type.RefName]
 			}
-			childNode, childIsLeaf, childText, err := r.readChild(childRec)
+			childDocPath := docPath + "." + label
+			childNode, childIsLeaf, childText, err := r.readChild(childRec, t, childDocPath)
 			if err != nil {
 				return nil, false, "", err
 			}
@@ -278,13 +298,41 @@ func (r *xmlReader) readElementBody(currentRec *omnist.Record) (node *omnist.Nod
 
 // readChild reads one non-root element, enforcing MaxDepth/MaxNodes via
 // the shared omnist.LimitChecker.
-func (r *xmlReader) readChild(childRec *omnist.Record) (node *omnist.Node, isLeaf bool, leafText string, err error) {
+func (r *xmlReader) readChild(childRec *omnist.Record, start encxml.StartElement, docPath string) (node *omnist.Node, isLeaf bool, leafText string, err error) {
 	path := r.pathHere()
 	if diag := r.checker.EnterNode(path); diag != nil {
 		return nil, false, "", &omnist.ParseError{Path: diag.Path, Code: diag.Code, Message: diag.Message}
 	}
 	defer r.checker.LeaveNode()
-	return r.readElementBody(childRec)
+	r.readStart(start, docPath)
+	return r.readElementBody(childRec, docPath)
+}
+
+// readStart records D-3's two report-not-silently-drop diagnostics (spec
+// §8.3.8) for one StartElement, at that element's own Document path
+// docPath: one omnist.CodeFormatAttributeDropped warning if the element
+// carries one or more attributes, and one omnist.CodeFormatNamespaceDropped
+// warning if the element's tag itself had a namespace prefix
+// (start.Name.Space != ""). Called once per StartElement -- root
+// (readRoot) and every child (readChild) alike -- as soon as that
+// element's docPath is known, before its body is read.
+func (r *xmlReader) readStart(start encxml.StartElement, docPath string) {
+	if len(start.Attr) > 0 {
+		r.diags = append(r.diags, omnist.Diagnostic{
+			Path:     docPath,
+			Code:     omnist.CodeFormatAttributeDropped,
+			Message:  "an XML attribute was discarded on read",
+			Severity: omnist.SeverityWarning,
+		})
+	}
+	if start.Name.Space != "" {
+		r.diags = append(r.diags, omnist.Diagnostic{
+			Path:     docPath,
+			Code:     omnist.CodeFormatNamespaceDropped,
+			Message:  "an XML namespace prefix was discarded on read",
+			Severity: omnist.SeverityWarning,
+		})
+	}
 }
 
 func findField(rec *omnist.Record, label string) *omnist.Field {

--- a/formats/xml/xml_reader_test.go
+++ b/formats/xml/xml_reader_test.go
@@ -13,7 +13,7 @@ import (
 // --- interleaving preservation: the highest-priority test in this issue ---
 
 func TestReadXMLPreservesInterleaving(t *testing.T) {
-	d, err := Read(`<root><m/><x/><m/></root>`, omnist.DefaultLimits())
+	d, _, err := Read(`<root><m/><x/><m/></root>`, omnist.DefaultLimits())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -37,7 +37,7 @@ func TestReadXMLPreservesInterleaving(t *testing.T) {
 func TestReadXMLInterleavingNotRegrouped(t *testing.T) {
 	// A grouping reader (like WriteJSON's write side) would produce
 	// [(m,[A,B]),(x,X)] — 2 edges. This must stay 3 edges in source order.
-	d, err := Read(`<root><m>A</m><x>X</x><m>B</m></root>`, omnist.DefaultLimits())
+	d, _, err := Read(`<root><m>A</m><x>X</x><m>B</m></root>`, omnist.DefaultLimits())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -62,7 +62,7 @@ func TestReadXMLWorkedExampleStage1Untyped(t *testing.T) {
   <items><sku>W</sku><qty>3</qty><price>9.99</price></items>
   <items><sku>G</sku><qty>1</qty><price>9.99</price></items>
 </order>`
-	d, err := Read(src, omnist.DefaultLimits())
+	d, _, err := Read(src, omnist.DefaultLimits())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -100,7 +100,7 @@ func TestReadXMLWorkedExampleStage1Untyped(t *testing.T) {
 // --- repeated elements -> repeated labels, no wrapper ---
 
 func TestReadXMLRepeatedElementsNoWrapper(t *testing.T) {
-	d, err := Read(`<root><items>a</items><items>b</items><items>c</items></root>`, omnist.DefaultLimits())
+	d, _, err := Read(`<root><items>a</items><items>b</items><items>c</items></root>`, omnist.DefaultLimits())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -119,22 +119,32 @@ func TestReadXMLRepeatedElementsNoWrapper(t *testing.T) {
 	}
 }
 
-// --- attribute dropping: silent, no diagnostic ---
+// --- attribute dropping: now reported, not silent (D-3, spec §8.3.8) ---
 
-func TestReadXMLDropsAttributesSilently(t *testing.T) {
-	d, err := Read(`<a x="1"><b>hi</b></a>`, omnist.DefaultLimits())
+func TestReadXMLDropsAttributesAndReportsDiagnostic(t *testing.T) {
+	// formats-xml/basic/attributes-are-dropped-on-read
+	d, diags, err := Read(`<a x="1"><b>hi</b></a>`, omnist.DefaultLimits())
 	if err != nil {
 		t.Fatalf("expected a clean nil error, got %v", err)
 	}
 	b := omnist.NewNode().AddValue("b", omnist.ScalarValue(omnist.NewStringScalar("hi")))
 	want := omnist.NodeDocument(omnist.NewNode().AddNode("a", b))
 	if !docEqual(d, want) {
-		t.Errorf("got %+v, want %+v (attribute must leave no trace)", d, want)
+		t.Errorf("got %+v, want %+v (attribute must leave no trace in the Document)", d, want)
+	}
+	if len(diags) != 1 {
+		t.Fatalf("diags = %+v, want exactly 1", diags)
+	}
+	if diags[0].Path != "$.a" || diags[0].Code != omnist.CodeFormatAttributeDropped || diags[0].Severity != omnist.SeverityWarning {
+		t.Errorf("got diagnostic %+v, want {Path: $.a, Code: %s, Severity: warning}", diags[0], omnist.CodeFormatAttributeDropped)
 	}
 }
 
-func TestReadXMLDropsMultipleAttributesSilently(t *testing.T) {
-	d, err := Read(`<a x="1" y="2" z="3"/>`, omnist.DefaultLimits())
+func TestReadXMLDropsMultipleAttributesReportsOneDiagnostic(t *testing.T) {
+	// One element with several dropped attributes still reports exactly
+	// one format.attribute-dropped diagnostic -- the loss is per element,
+	// not per attribute.
+	d, diags, err := Read(`<a x="1" y="2" z="3"/>`, omnist.DefaultLimits())
 	if err != nil {
 		t.Fatalf("expected a clean nil error, got %v", err)
 	}
@@ -142,12 +152,22 @@ func TestReadXMLDropsMultipleAttributesSilently(t *testing.T) {
 	if !docEqual(d, want) {
 		t.Errorf("got %+v, want %+v", d, want)
 	}
+	if len(diags) != 1 {
+		t.Fatalf("diags = %+v, want exactly 1", diags)
+	}
+	if diags[0].Path != "$.a" || diags[0].Code != omnist.CodeFormatAttributeDropped || diags[0].Severity != omnist.SeverityWarning {
+		t.Errorf("got diagnostic %+v, want {Path: $.a, Code: %s, Severity: warning}", diags[0], omnist.CodeFormatAttributeDropped)
+	}
 }
 
-// --- namespace-prefix dropping ---
+// --- namespace-prefix dropping: now reported, not silent (D-3, spec §8.3.8) ---
 
-func TestReadXMLDropsNamespacePrefix(t *testing.T) {
-	d, err := Read(`<root xmlns:ns="http://example.com/ns"><ns:b>hi</ns:b></root>`, omnist.DefaultLimits())
+func TestReadXMLDropsNamespacePrefixAndReportsDiagnostic(t *testing.T) {
+	// formats-xml/basic/namespace-prefix-is-dropped-on-read (with an
+	// explicit xmlns declaration this time, rather than the vector's
+	// undeclared-prefix spelling -- see
+	// TestReadXMLDropsUndeclaredNamespacePrefix below for that one).
+	d, diags, err := Read(`<root xmlns:ns="http://example.com/ns"><ns:b>hi</ns:b></root>`, omnist.DefaultLimits())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -155,17 +175,40 @@ func TestReadXMLDropsNamespacePrefix(t *testing.T) {
 	if len(node.Edges) != 1 || node.Edges[0].Label != "b" {
 		t.Fatalf("expected a single edge labeled b (prefix dropped), got %+v", node.Edges)
 	}
+	// The root element carries the xmlns:ns declaration itself as an
+	// XML attribute, so this also reports format.attribute-dropped for
+	// $.root alongside the namespace-prefix drop on $.root.b.
+	if len(diags) != 2 {
+		t.Fatalf("diags = %+v, want exactly 2", diags)
+	}
+	wantDiags := []omnist.Diagnostic{
+		{Path: "$.root", Code: omnist.CodeFormatAttributeDropped, Message: "an XML attribute was discarded on read", Severity: omnist.SeverityWarning},
+		{Path: "$.root.b", Code: omnist.CodeFormatNamespaceDropped, Message: "an XML namespace prefix was discarded on read", Severity: omnist.SeverityWarning},
+	}
+	for i, want := range wantDiags {
+		if diags[i] != want {
+			t.Errorf("diag[%d] = %+v, want %+v", i, diags[i], want)
+		}
+	}
 }
 
 func TestReadXMLDropsUndeclaredNamespacePrefix(t *testing.T) {
 	// A prefix with no matching xmlns declaration must still resolve to
-	// the local name only.
-	d, err := Read(`<ns:b>hi</ns:b>`, omnist.DefaultLimits())
+	// the local name only, and still reports format.namespace-dropped --
+	// this time on the document element itself, since the prefixed tag
+	// is the root.
+	d, diags, err := Read(`<ns:b>hi</ns:b>`, omnist.DefaultLimits())
 	if err != nil {
 		t.Fatal(err)
 	}
 	if d.Node.Edges[0].Label != "b" {
 		t.Fatalf("got label %q, want b", d.Node.Edges[0].Label)
+	}
+	if len(diags) != 1 {
+		t.Fatalf("diags = %+v, want exactly 1", diags)
+	}
+	if diags[0].Path != "$.b" || diags[0].Code != omnist.CodeFormatNamespaceDropped || diags[0].Severity != omnist.SeverityWarning {
+		t.Errorf("got diagnostic %+v, want {Path: $.b, Code: %s, Severity: warning}", diags[0], omnist.CodeFormatNamespaceDropped)
 	}
 }
 
@@ -173,7 +216,7 @@ func TestReadXMLDropsUndeclaredNamespacePrefix(t *testing.T) {
 
 func TestReadXMLTextAlwaysString(t *testing.T) {
 	src := `<root><d>2024-01-15</d><i>42</i><b>true</b></root>`
-	d, err := Read(src, omnist.DefaultLimits())
+	d, _, err := Read(src, omnist.DefaultLimits())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -192,7 +235,7 @@ func TestReadXMLTextAlwaysString(t *testing.T) {
 // --- self-closing / empty leaf ---
 
 func TestReadXMLSelfClosingElementIsEmptyString(t *testing.T) {
-	d, err := Read(`<a/>`, omnist.DefaultLimits())
+	d, _, err := Read(`<a/>`, omnist.DefaultLimits())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -206,7 +249,7 @@ func TestReadXMLSelfClosingElementIsEmptyString(t *testing.T) {
 
 func TestReadXMLSkipsPrologAndComments(t *testing.T) {
 	src := "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!-- a comment -->\n<a>hi</a>\n"
-	d, err := Read(src, omnist.DefaultLimits())
+	d, _, err := Read(src, omnist.DefaultLimits())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -219,7 +262,7 @@ func TestReadXMLSkipsPrologAndComments(t *testing.T) {
 // --- multiple top-level elements are rejected on read (not well-formed) ---
 
 func TestReadXMLRejectsMultipleTopLevelElements(t *testing.T) {
-	_, err := Read(`<a/><b/>`, omnist.DefaultLimits())
+	_, _, err := Read(`<a/><b/>`, omnist.DefaultLimits())
 	if err == nil {
 		t.Fatal("expected an error for multiple top-level elements")
 	}
@@ -233,14 +276,14 @@ func TestReadXMLRejectsMultipleTopLevelElements(t *testing.T) {
 }
 
 func TestReadXMLRejectsTextBeforeRoot(t *testing.T) {
-	_, err := Read(`stray text<a/>`, omnist.DefaultLimits())
+	_, _, err := Read(`stray text<a/>`, omnist.DefaultLimits())
 	if err == nil {
 		t.Fatal("expected an error for text before the root element")
 	}
 }
 
 func TestReadXMLRejectsStrayEndElementBeforeRoot(t *testing.T) {
-	_, err := Read(`</a>`, omnist.DefaultLimits())
+	_, _, err := Read(`</a>`, omnist.DefaultLimits())
 	if err == nil {
 		t.Fatal("expected an error for a stray closing tag before any root element")
 	}
@@ -250,7 +293,7 @@ func TestReadXMLSkipsCommentAndProcInstInsideElementBody(t *testing.T) {
 	// A comment/processing instruction interleaved with actual child
 	// elements must be ignored without disturbing sibling order.
 	src := "<a><b/><!-- c --><?pi d?><e/></a>"
-	d, err := Read(src, omnist.DefaultLimits())
+	d, _, err := Read(src, omnist.DefaultLimits())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -265,7 +308,7 @@ func TestReadXMLSkipsCommentAndProcInstInsideElementBody(t *testing.T) {
 
 func TestReadXMLSkipsCommentAndProcInstAfterRoot(t *testing.T) {
 	src := "<a/>\n<!-- trailing comment -->\n<?pi data?>\n"
-	d, err := Read(src, omnist.DefaultLimits())
+	d, _, err := Read(src, omnist.DefaultLimits())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -279,7 +322,7 @@ func TestReadXMLRejectsMalformedContentAfterRoot(t *testing.T) {
 	// Unterminated element after the root closes: a genuine decoder error,
 	// not just a trailing-content shape violation, must surface from
 	// checkTrailing too.
-	_, err := Read(`<a/><b`, omnist.DefaultLimits())
+	_, _, err := Read(`<a/><b`, omnist.DefaultLimits())
 	if err == nil {
 		t.Fatal("expected an error for malformed content after the root element")
 	}
@@ -289,7 +332,7 @@ func TestReadXMLRejectsMalformedContentAfterRoot(t *testing.T) {
 }
 
 func TestReadXMLRejectsTextAfterRoot(t *testing.T) {
-	_, err := Read(`<a/>stray`, omnist.DefaultLimits())
+	_, _, err := Read(`<a/>stray`, omnist.DefaultLimits())
 	if err == nil {
 		t.Fatal("expected an error for text after the root element")
 	}
@@ -300,7 +343,7 @@ func TestReadXMLRejectsTextAfterRoot(t *testing.T) {
 }
 
 func TestReadXMLRejectsEmptyInput(t *testing.T) {
-	_, err := Read(``, omnist.DefaultLimits())
+	_, _, err := Read(``, omnist.DefaultLimits())
 	if err == nil {
 		t.Fatal("expected an error for empty input")
 	}
@@ -311,7 +354,7 @@ func TestReadXMLRejectsEmptyInput(t *testing.T) {
 func TestReadXMLEnforcesMaxDepth(t *testing.T) {
 	src := "<a><b><c><d>x</d></c></b></a>"
 	limits := omnist.Limits{MaxDepth: 2, MaxNodes: 1_000_000, MaxIntDigits: 4300}
-	_, err := Read(src, limits)
+	_, _, err := Read(src, limits)
 	if err == nil {
 		t.Fatal("expected a depth-limit error")
 	}
@@ -324,7 +367,7 @@ func TestReadXMLEnforcesMaxDepth(t *testing.T) {
 func TestReadXMLEnforcesMaxNodes(t *testing.T) {
 	src := "<a><b/><c/><d/></a>"
 	limits := omnist.Limits{MaxDepth: 200, MaxNodes: 2, MaxIntDigits: 4300}
-	_, err := Read(src, limits)
+	_, _, err := Read(src, limits)
 	if err == nil {
 		t.Fatal("expected a node-count-limit error")
 	}
@@ -337,7 +380,7 @@ func TestReadXMLEnforcesMaxNodes(t *testing.T) {
 // --- malformed XML surfaces a parse error, not a panic ---
 
 func TestReadXMLMalformedInputReturnsParseError(t *testing.T) {
-	_, err := Read(`<a><b></a>`, omnist.DefaultLimits())
+	_, _, err := Read(`<a><b></a>`, omnist.DefaultLimits())
 	if err == nil {
 		t.Fatal("expected an error for mismatched tags")
 	}
@@ -347,7 +390,7 @@ func TestReadXMLMalformedInputReturnsParseError(t *testing.T) {
 }
 
 func TestReadXMLUnterminatedElementReturnsParseError(t *testing.T) {
-	_, err := Read(`<a><b>`, omnist.DefaultLimits())
+	_, _, err := Read(`<a><b>`, omnist.DefaultLimits())
 	if err == nil {
 		t.Fatal("expected an error for unterminated element")
 	}
@@ -359,7 +402,7 @@ func TestReadXMLUnterminatedElementReturnsParseError(t *testing.T) {
 // --- mixed content: narrow/cosmetic, elements win over stray text ---
 
 func TestReadXMLMixedContentDiscardsStrayText(t *testing.T) {
-	d, err := Read(`<a>hello<b>x</b>world</a>`, omnist.DefaultLimits())
+	d, _, err := Read(`<a>hello<b>x</b>world</a>`, omnist.DefaultLimits())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -407,7 +450,7 @@ root Root
   <items><sku>G</sku><qty>1</qty><price>9.99</price></items>
 </order>`
 
-	doc, err := ReadWithSchema(src, &schema, omnist.DefaultLimits())
+	doc, _, err := ReadWithSchema(src, &schema, omnist.DefaultLimits())
 	if err != nil {
 		t.Fatalf("unexpected read error: %v", err)
 	}
@@ -483,7 +526,7 @@ func TestReadXMLWithSchemaAllScalarKinds(t *testing.T) {
   <s>hello</s>
 </R>`
 
-	doc, err := ReadWithSchema(src, schema, omnist.DefaultLimits())
+	doc, _, err := ReadWithSchema(src, schema, omnist.DefaultLimits())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -558,7 +601,7 @@ func TestReadXMLWithSchemaInvalidLiteralsRemainStrings(t *testing.T) {
   <unknown>val</unknown>
 </R>`
 
-	doc, err := ReadWithSchema(src, schema, omnist.DefaultLimits())
+	doc, _, err := ReadWithSchema(src, schema, omnist.DefaultLimits())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -587,7 +630,7 @@ func TestReadXMLWithSchemaRootElementIsLeaf(t *testing.T) {
 	}
 
 	src := `<count>42</count>`
-	doc, err := ReadWithSchema(src, schema, omnist.DefaultLimits())
+	doc, _, err := ReadWithSchema(src, schema, omnist.DefaultLimits())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -619,7 +662,7 @@ func TestReadXMLWithSchemaRootFallback(t *testing.T) {
 	}
 
 	src := `<Target><num>100</num></Target>`
-	doc, err := ReadWithSchema(src, schema, omnist.DefaultLimits())
+	doc, _, err := ReadWithSchema(src, schema, omnist.DefaultLimits())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -642,7 +685,7 @@ func TestReadXMLWithSchemaRootFallback(t *testing.T) {
 		},
 		EnvOrder: []string{"Target"},
 	}
-	doc2, err := ReadWithSchema(src, schemaNoRoot, omnist.DefaultLimits())
+	doc2, _, err := ReadWithSchema(src, schemaNoRoot, omnist.DefaultLimits())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -661,7 +704,7 @@ func TestPretypeScalarDefault(t *testing.T) {
 }
 
 func TestReadXMLUnexpectedEOFInsideBody(t *testing.T) {
-	_, err := Read("<root><child>", omnist.DefaultLimits())
+	_, _, err := Read("<root><child>", omnist.DefaultLimits())
 	if err == nil {
 		t.Fatal("expected error for unterminated tag")
 	}

--- a/formats/xml/xml_writer_test.go
+++ b/formats/xml/xml_writer_test.go
@@ -29,7 +29,7 @@ func TestWriteXMLPreservesInterleaving(t *testing.T) {
 
 	// Read it back and confirm the interleaving survived the full
 	// round trip, not just the writer's raw string output.
-	back, err := Read(out, omnist.DefaultLimits())
+	back, _, err := Read(out, omnist.DefaultLimits())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -105,7 +105,7 @@ func TestWriteXMLRejectsBareScalarRoot(t *testing.T) {
 
 func TestWriteXMLRoundTripsWorkedExample(t *testing.T) {
 	src := `<order><id>A1</id><status>shipped</status><total>29.97</total><address><street>1 Main</street><city>London</city></address><items><sku>W</sku><qty>3</qty><price>9.99</price></items><items><sku>G</sku><qty>1</qty><price>9.99</price></items></order>`
-	d, err := Read(src, omnist.DefaultLimits())
+	d, _, err := Read(src, omnist.DefaultLimits())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -113,7 +113,7 @@ func TestWriteXMLRoundTripsWorkedExample(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	back, err := Read(out, omnist.DefaultLimits())
+	back, _, err := Read(out, omnist.DefaultLimits())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -123,7 +123,7 @@ func TestWriteXMLRoundTripsWorkedExample(t *testing.T) {
 }
 
 func TestWriteXMLRoundTripsSelfClosingLeaf(t *testing.T) {
-	d, err := Read(`<a/>`, omnist.DefaultLimits())
+	d, _, err := Read(`<a/>`, omnist.DefaultLimits())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -131,7 +131,7 @@ func TestWriteXMLRoundTripsSelfClosingLeaf(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	back, err := Read(out, omnist.DefaultLimits())
+	back, _, err := Read(out, omnist.DefaultLimits())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/formats/yaml/yaml_writer.go
+++ b/formats/yaml/yaml_writer.go
@@ -113,6 +113,15 @@ type yamlGroup struct {
 	children []omnist.Target
 }
 
+// groupYAMLEdges mirrors groupJSONEdges (json_writer.go): edges sharing a
+// label collapse into one group, in first-seen label order, preserving
+// each label's own children in their original edge order. Cross-label
+// interleaving (e.g. [(m,A),(x,X),(m,B)]) is lost here, exactly as §7.3
+// states the JSON family must ("no format in the JSON family can express
+// it") -- buildYAMLNode reports this loss via
+// omnist.CodeFormatInterleavingLost (spec §8.3.8, D-3) whenever it
+// actually happens (omnist.Node.HasLostInterleaving, document.go), rather
+// than silently, as it did before.
 func groupYAMLEdges(n *omnist.Node) []yamlGroup {
 	var groups []yamlGroup
 	index := make(map[string]int, len(n.Edges))
@@ -134,6 +143,14 @@ func groupYAMLEdges(n *omnist.Node) []yamlGroup {
 // yamllib.Node values instead of directly-written text.
 func buildYAMLNode(n *omnist.Node, path string, diags *[]omnist.Diagnostic) *yamllib.Node {
 	groups := groupYAMLEdges(n)
+	if n.HasLostInterleaving() {
+		*diags = append(*diags, omnist.Diagnostic{
+			Path:     path,
+			Code:     omnist.CodeFormatInterleavingLost,
+			Message:  "cross-label interleaving cannot be expressed in YAML, so it is lost",
+			Severity: omnist.SeverityWarning,
+		})
+	}
 	m := &yamllib.Node{Kind: yamllib.MappingNode}
 	for _, g := range groups {
 		// Every label is written double-quoted unconditionally, never

--- a/formats/yaml/yaml_writer_test.go
+++ b/formats/yaml/yaml_writer_test.go
@@ -354,3 +354,54 @@ func TestWriteYAMLNestedNode(t *testing.T) {
 		t.Errorf("wrote %q, got %+v", out, back)
 	}
 }
+
+// --- cross-label interleaving loss (D-3, spec §8.3.8) ---
+
+func TestWriteYAMLInterleavingLostReportsDiagnostic(t *testing.T) {
+	doc := omnist.NodeDocument(omnist.NewNode().
+		AddValue("m", omnist.ScalarValue(omnist.NewStringScalar("A"))).
+		AddValue("x", omnist.ScalarValue(omnist.NewStringScalar("X"))).
+		AddValue("m", omnist.ScalarValue(omnist.NewStringScalar("B"))))
+	_, diags, err := Write(doc)
+	if err != nil {
+		t.Fatalf("WriteYAML failed: %v", err)
+	}
+	if len(diags) != 1 {
+		t.Fatalf("diags = %+v, want exactly 1", diags)
+	}
+	if diags[0].Path != "$" || diags[0].Code != omnist.CodeFormatInterleavingLost || diags[0].Severity != omnist.SeverityWarning {
+		t.Errorf("got diagnostic %+v, want {Path: $, Code: %s, Severity: warning}", diags[0], omnist.CodeFormatInterleavingLost)
+	}
+}
+
+func TestWriteYAMLContiguousRepeatNoInterleavingDiagnostic(t *testing.T) {
+	doc := omnist.NodeDocument(omnist.NewNode().
+		AddValue("m", omnist.ScalarValue(omnist.NewStringScalar("A"))).
+		AddValue("m", omnist.ScalarValue(omnist.NewStringScalar("B"))).
+		AddValue("x", omnist.ScalarValue(omnist.NewStringScalar("X"))))
+	_, diags, err := Write(doc)
+	if err != nil {
+		t.Fatalf("WriteYAML failed: %v", err)
+	}
+	if len(diags) != 0 {
+		t.Errorf("diags = %+v, want none (contiguous repeat loses nothing)", diags)
+	}
+}
+
+func TestWriteYAMLInterleavingLostAtNestedPath(t *testing.T) {
+	inner := omnist.NewNode().
+		AddValue("m", omnist.ScalarValue(omnist.NewStringScalar("A"))).
+		AddValue("x", omnist.ScalarValue(omnist.NewStringScalar("X"))).
+		AddValue("m", omnist.ScalarValue(omnist.NewStringScalar("B")))
+	doc := omnist.NodeDocument(omnist.NewNode().AddNode("outer", inner))
+	_, diags, err := Write(doc)
+	if err != nil {
+		t.Fatalf("WriteYAML failed: %v", err)
+	}
+	if len(diags) != 1 {
+		t.Fatalf("diags = %+v, want exactly 1", diags)
+	}
+	if diags[0].Path != "$.outer" || diags[0].Code != omnist.CodeFormatInterleavingLost {
+		t.Errorf("got diagnostic %+v, want {Path: $.outer, Code: %s}", diags[0], omnist.CodeFormatInterleavingLost)
+	}
+}

--- a/tools/conformance/drivers.go
+++ b/tools/conformance/drivers.go
@@ -42,20 +42,29 @@ func limitsFromInput(in parseInput) omnist.Limits {
 	return l
 }
 
-func readByFormat(format, text string, limits omnist.Limits) (omnist.Document, error) {
+// readByFormat's diagnostics return mirrors runWrite's below: today only
+// xml.Read ever populates it (an attribute or namespace prefix dropped,
+// D-3, spec §8.3.8) -- every other reader has nothing to report on
+// read, so it returns nil there, same as oml.Write's nil-diagnostics case
+// in runWrite when nothing was adjusted.
+func readByFormat(format, text string, limits omnist.Limits) (omnist.Document, []omnist.Diagnostic, error) {
 	switch format {
 	case "oml":
-		return oml.Read(text, limits)
+		doc, err := oml.Read(text, limits)
+		return doc, nil, err
 	case "json":
-		return json.Read(text, limits)
+		doc, err := json.Read(text, limits)
+		return doc, nil, err
 	case "yaml":
-		return yaml.Read(text, limits)
+		doc, err := yaml.Read(text, limits)
+		return doc, nil, err
 	case "toml":
-		return toml.Read(text, limits)
+		doc, err := toml.Read(text, limits)
+		return doc, nil, err
 	case "xml":
 		return xml.Read(text, limits)
 	default:
-		return omnist.Document{}, fmt.Errorf("unrecognized format %q", format)
+		return omnist.Document{}, nil, fmt.Errorf("unrecognized format %q", format)
 	}
 }
 
@@ -68,7 +77,7 @@ func runParse(v Vector) Result {
 	if err != nil {
 		return fail(v, "decode expect: %v", err)
 	}
-	doc, rerr := readByFormat(in.Format, in.Text, limitsFromInput(in))
+	doc, gotDiags, rerr := readByFormat(in.Format, in.Text, limitsFromInput(in))
 	wantOK := expectOK(expect)
 	if rerr != nil {
 		if wantOK {
@@ -87,6 +96,19 @@ func runParse(v Vector) Result {
 	}
 	if !wantOK {
 		return fail(v, "expected error, got ok document")
+	}
+	// parse is also an operation where ok:true and diagnostics can
+	// coexist, since D-3 (spec §8.3.8): xml.Read reports a dropped
+	// attribute/namespace prefix without failing the read. Compared here
+	// exactly like runWrite compares a successful write's diagnostics.
+	if wantDiags, err := decodeExpectDiagnostics(expect); err != nil {
+		return fail(v, "decode expect.diagnostics: %v", err)
+	} else if _, hasDiagsKey := expect["diagnostics"]; hasDiagsKey {
+		got := diagsToPairs(gotDiags)
+		want := expectDiagPairs(wantDiags)
+		if !diagnosticSetsEqual(got, want) {
+			return fail(v, "diagnostics mismatch: got %v want %v", diagStrings(got), diagStrings(want))
+		}
 	}
 	wantDocRaw, ok := expect["document"]
 	if !ok {

--- a/tools/conformance/fixtures.go
+++ b/tools/conformance/fixtures.go
@@ -312,7 +312,7 @@ func runFixtureWrite(fc FixtureCase) Result {
 	if err != nil {
 		return fixFail(fc, "reading input.%s: %v", format, err)
 	}
-	doc, rerr := readByFormat(format, inputText, omnist.DefaultLimits())
+	doc, _, rerr := readByFormat(format, inputText, omnist.DefaultLimits())
 	if rerr != nil {
 		return fixFail(fc, "parsing input.%s: %v", format, rerr)
 	}
@@ -320,7 +320,7 @@ func runFixtureWrite(fc FixtureCase) Result {
 	if err != nil {
 		return fixFail(fc, "reading expected.%s: %v", format, err)
 	}
-	wantDoc, werr := readByFormat(format, expectedText, omnist.DefaultLimits())
+	wantDoc, _, werr := readByFormat(format, expectedText, omnist.DefaultLimits())
 	if werr != nil {
 		return fixFail(fc, "parsing expected.%s: %v", format, werr)
 	}
@@ -331,7 +331,7 @@ func runFixtureWrite(fc FixtureCase) Result {
 	// §2's "--compact vs. pretty-printed output must compare equal" note
 	// applies here too: the referee re-parses gotText rather than
 	// byte-comparing it against expectedText.
-	gotDoc, gerr := readByFormat(format, gotText, omnist.DefaultLimits())
+	gotDoc, _, gerr := readByFormat(format, gotText, omnist.DefaultLimits())
 	if gerr != nil {
 		return fixFail(fc, "re-parsing written output: %v (output was %q)", gerr, gotText)
 	}


### PR DESCRIPTION
Resolves #93. Three previously-silent codec adjustments are now reported per omnist-spec Sec8.3.8 (D-3):

- XML read: format.attribute-dropped and format.namespace-dropped, both warning severity at the affected elements own Document path. Required a real, disclosed public API change -- xml.Read/ReadWithSchema now return (Document, []Diagnostic, error), matching the pattern every writer already uses (issue #49). 4 call sites updated.
- JSON/YAML/TOML write: format.interleaving-lost (warning, at the affected nodes own path) via a new shared omnist.Node.HasLostInterleaving() helper (document.go), correctly distinguishing genuine interleaving from mere contiguous repeats.

All three conformance vectors verified against the actual vendored test-suite JSON, not guessed. Track 2: 154/0/1 of 155 (was 152/0/1 of 153 before the submodule bump). No spec clarification was needed.