### PR TITLE
Forbid [0,0] cardinality

### DIFF
--- a/algebra/algebra_public_test.go
+++ b/algebra/algebra_public_test.go
@@ -145,7 +145,21 @@ func TestPruneRemovesUnreachableRecords(t *testing.T) {
 }
 
 func TestPruneRemovesMaxZeroFields(t *testing.T) {
-	s := mustParseOSD(t, `record R { "a" [0,0]: string, "b": string } root R`)
+	// [0,0] itself is no longer expressible in OSD text (spec section 5.5,
+	// 2026-08-24 -- see issue #95): it is redundant with not declaring the
+	// field at all. Prune still needs to handle a Cardinality{Max: 0}
+	// field correctly wherever one arises structurally, so this test
+	// builds the schema directly instead of through osd.Read.
+	s := omnist.Schema{
+		Root: "R",
+		Env: map[string]*omnist.Record{
+			"R": {Name: "R", Fields: []omnist.Field{
+				{Label: "a", Type: omnist.ScalarType(omnist.KindString, false), Cardinality: omnist.Cardinality{Min: 0, Max: 0}},
+				{Label: "b", Type: omnist.ScalarType(omnist.KindString, false), Cardinality: omnist.DefaultCardinality()},
+			}},
+		},
+		EnvOrder: []string{"R"},
+	}
 	p := algebra.Prune(s)
 	rec := p.Env["R"]
 	if len(rec.Fields) != 1 || rec.Fields[0].Label != "b" {
@@ -179,10 +193,21 @@ func TestPruneRemovesRecordsLeftUnreachableAfterFieldPruning(t *testing.T) {
 }
 
 func TestPruneRootUnsatisfiableKeepsRootFieldsUntouched(t *testing.T) {
-	s := mustParseOSD(t, `
-		record Node { "child": Node, "extra" [0,0]: string }
-		root Node
-	`)
+	// [0,0] itself is no longer expressible in OSD text (spec section 5.5,
+	// 2026-08-24 -- see issue #95): it is redundant with not declaring the
+	// field at all. Prune still needs to handle a Cardinality{Max: 0}
+	// field correctly wherever one arises structurally, so this test
+	// builds the schema directly instead of through osd.Read.
+	s := omnist.Schema{
+		Root: "Node",
+		Env: map[string]*omnist.Record{
+			"Node": {Name: "Node", Fields: []omnist.Field{
+				{Label: "child", Type: omnist.RefType("Node"), Cardinality: omnist.DefaultCardinality()},
+				{Label: "extra", Type: omnist.ScalarType(omnist.KindString, false), Cardinality: omnist.Cardinality{Min: 0, Max: 0}},
+			}},
+		},
+		EnvOrder: []string{"Node"},
+	}
 	p := algebra.Prune(s)
 	rec := p.Env["Node"]
 	// The root is unsatisfiable, so field pruning (including the max==0
@@ -198,11 +223,24 @@ func TestPruneRootUnsatisfiableReachabilityFollowsEveryRootField(t *testing.T) {
 	// once pruned -- but since the root is unsatisfiable, reachability MUST
 	// follow every field of the root, not just the surviving ones. OnlyViaBadField
 	// is reachable only through that [0,0] field, so it must be kept.
-	s := mustParseOSD(t, `
-		record Node { "child": Node, "hidden" [0,0]: OnlyViaBadField }
-		record OnlyViaBadField { "v": string }
-		root Node
-	`)
+	// [0,0] itself is no longer expressible in OSD text (spec section 5.5,
+	// 2026-08-24 -- see issue #95): it is redundant with not declaring the
+	// field at all. Prune still needs to handle a Cardinality{Max: 0} field
+	// correctly wherever one arises structurally, so this test builds the
+	// schema directly instead of through osd.Read.
+	s := omnist.Schema{
+		Root: "Node",
+		Env: map[string]*omnist.Record{
+			"Node": {Name: "Node", Fields: []omnist.Field{
+				{Label: "child", Type: omnist.RefType("Node"), Cardinality: omnist.DefaultCardinality()},
+				{Label: "hidden", Type: omnist.RefType("OnlyViaBadField"), Cardinality: omnist.Cardinality{Min: 0, Max: 0}},
+			}},
+			"OnlyViaBadField": {Name: "OnlyViaBadField", Fields: []omnist.Field{
+				{Label: "v", Type: omnist.ScalarType(omnist.KindString, false), Cardinality: omnist.DefaultCardinality()},
+			}},
+		},
+		EnvOrder: []string{"Node", "OnlyViaBadField"},
+	}
 	p := algebra.Prune(s)
 	if _, ok := p.Env["OnlyViaBadField"]; !ok {
 		t.Fatalf("OnlyViaBadField must be kept: reachability at an unsatisfiable root follows every field, env = %+v", p.Env)

--- a/algebra/compatible_with_public_test.go
+++ b/algebra/compatible_with_public_test.go
@@ -265,10 +265,22 @@ func TestCompatibleWithValueVersusObject(t *testing.T) {
 // emitted per record_sub's own skip, distinct from the optional-vacuous
 // skip) that B doesn't declare at all — must not cause a false rejection.
 func TestCompatibleWithFieldNeverEmitted(t *testing.T) {
-	a := mustParseOSD(t, `
-		record Root { "dead" [0,0]: string, "id": string }
-		root Root
-	`)
+	// [0,0] itself is no longer expressible in OSD text (spec section 5.5,
+	// 2026-08-24 -- see issue #95): it is redundant with not declaring the
+	// field at all. Prune and compatible_with still need to handle a
+	// Cardinality{Max: 0} field correctly wherever one arises structurally
+	// (e.g. produced by schema transformation, not by parsing OSD text), so
+	// this test builds the schema directly instead of through osd.Read.
+	a := omnist.Schema{
+		Root: "Root",
+		Env: map[string]*omnist.Record{
+			"Root": {Name: "Root", Fields: []omnist.Field{
+				{Label: "dead", Type: omnist.ScalarType(omnist.KindString, false), Cardinality: omnist.Cardinality{Min: 0, Max: 0}},
+				{Label: "id", Type: omnist.ScalarType(omnist.KindString, false), Cardinality: omnist.DefaultCardinality()},
+			}},
+		},
+		EnvOrder: []string{"Root"},
+	}
 	b := mustParseOSD(t, `
 		record Root { "id": string }
 		root Root

--- a/cmd/omnist/doc_examples_cli_test.go
+++ b/cmd/omnist/doc_examples_cli_test.go
@@ -116,12 +116,15 @@ func TestCLIExampleSchemaNormalize(t *testing.T) {
 }
 
 // TestCLIExampleSchemaPrune backs cli.md's `schema prune` example: a
-// never-emittable field ([0,0]) and the record it alone referenced both
-// disappear.
+// field that can never be emitted -- optional (min 0) and referencing a
+// record that is itself unsatisfiable, so the record it alone referenced
+// also disappears. ([0,0] cardinality, the most direct spelling of
+// never emitted, was made a parse error by spec section 5.5 (2026-08-24):
+// it is redundant with not declaring the field at all.
 func TestCLIExampleSchemaPrune(t *testing.T) {
 	bin := buildOmnistBinary(t)
 	dir := t.TempDir()
-	schemaPath := writeFileT(t, dir, "dead.osd", "record Root { \"id\": string, \"dead\" [0,0]: Orphan }\nrecord Orphan { \"note\": string }\nroot Root\n")
+	schemaPath := writeFileT(t, dir, "dead.osd", "record Root { \"id\": string, \"dead\" [0,1]: Orphan }\nrecord Orphan { \"self\": Orphan }\nroot Root\n")
 
 	code, stdout, stderr := runBinary(t, bin, "", "schema", "prune", schemaPath)
 	if code != ExitOK {

--- a/doc_examples_reference_test.go
+++ b/doc_examples_reference_test.go
@@ -166,12 +166,13 @@ func Example_algebraLint() {
 }
 
 // Example_algebraPrune backs reference.md's `algebra` section: Prune
-// removes a never-emittable field (cardinality max 0) and, as a
-// consequence, the now-unreachable record it alone referenced.
+// removes a field that can never be emitted (optional, referencing a
+// record that is itself unsatisfiable) and, as a consequence, the
+// now-unreachable record it alone referenced.
 func Example_algebraPrune() {
 	s, err := osd.Read(`
-		record Root { "id": string, "dead" [0,0]: Orphan }
-		record Orphan { "note": string }
+		record Root { "id": string, "dead" [0,1]: Orphan }
+		record Orphan { "self": Orphan }
 		root Root
 	`)
 	if err != nil {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -103,8 +103,9 @@ record Root {
 root Root
 ```
 
-Prune a schema, removing a never-emittable field (`[0,0]`) and, as a
-consequence, the record it alone referenced:
+Prune a schema, removing a field that can never be emitted -- optional and
+referencing a record that is itself unsatisfiable -- and, as a consequence,
+the record it alone referenced:
 
 <!-- verified-by: cmd/omnist/doc_examples_cli_test.go::TestCLIExampleSchemaPrune -->
 ```console

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -448,14 +448,15 @@ for _, f := range findings {
 // lint.unreachable-record Orphan
 ```
 
-`Prune` — removes a never-emittable field (cardinality `[0,0]`) and, as a
-consequence, the now-unreachable record it alone referenced:
+`Prune` — removes a field that can never be emitted (optional, referencing
+a record that is itself unsatisfiable) and, as a consequence, the
+now-unreachable record it alone referenced:
 
 <!-- verified-by: doc_examples_reference_test.go::Example_algebraPrune -->
 ```go
 s, _ := osd.Read(`
-    record Root { "id": string, "dead" [0,0]: Orphan }
-    record Orphan { "note": string }
+    record Root { "id": string, "dead" [0,1]: Orphan }
+    record Orphan { "self": Orphan }
     root Root
 `)
 

--- a/osd/osd_parser.go
+++ b/osd/osd_parser.go
@@ -339,6 +339,9 @@ func (p *osdParser) parseCardinality(recordName, label string) (omnist.Cardinali
 		if firstV < 0 {
 			return omnist.Cardinality{}, schemaError(path, omnist.CodeSchemaInvalidCardinality, "cardinality bound must be non-negative")
 		}
+		if firstV == 0 {
+			return omnist.Cardinality{}, schemaError(path, omnist.CodeSchemaInvalidCardinality, "cardinality [0,0] is redundant with not declaring the field")
+		}
 		return omnist.Cardinality{Min: uint64(firstV), Max: uint64(firstV)}, nil
 	case osdTokComma:
 		if err := p.advance(); err != nil {
@@ -362,6 +365,9 @@ func (p *osdParser) parseCardinality(recordName, label string) (omnist.Cardinali
 		}
 		if firstV < 0 || secondV < 0 || secondV < firstV {
 			return omnist.Cardinality{}, schemaError(path, omnist.CodeSchemaInvalidCardinality, "invalid cardinality range")
+		}
+		if firstV == 0 && secondV == 0 {
+			return omnist.Cardinality{}, schemaError(path, omnist.CodeSchemaInvalidCardinality, "cardinality [0,0] is redundant with not declaring the field")
 		}
 		return omnist.Cardinality{Min: uint64(firstV), Max: uint64(secondV)}, nil
 	default:

--- a/osd/osd_parser_test.go
+++ b/osd/osd_parser_test.go
@@ -120,6 +120,22 @@ func TestWorkedInvertedCardinality(t *testing.T) {
 	wantDiagCode(t, err, omnist.CodeSchemaInvalidCardinality)
 }
 
+func TestWorkedZeroZeroCardinalityIsError(t *testing.T) {
+	// spec section 5.5 (2026-08-24): [0,0] is redundant with not declaring
+	// the field at all -- a field that must occur zero times is
+	// indistinguishable from an undeclared field, which is already
+	// rejected by validate.unexpected-field.
+	err := mustFailOSD(t, `record R { "a" [0,0]: string } root R`)
+	wantDiagCode(t, err, omnist.CodeSchemaInvalidCardinality)
+}
+
+func TestWorkedZeroSingleValueCardinalityIsError(t *testing.T) {
+	// The single-value form [0] means min == max == 0, same redundant
+	// shape as [0,0].
+	err := mustFailOSD(t, `record R { "a" [0]: string } root R`)
+	wantDiagCode(t, err, omnist.CodeSchemaInvalidCardinality)
+}
+
 func TestWorkedNonIntegerCardinality(t *testing.T) {
 	err := mustFailOSD(t, `record R { "a" [1.5]: string } root R`)
 	wantDiagCode(t, err, omnist.CodeSchemaNonIntegerCardinality)

--- a/osd/osd_writer_test.go
+++ b/osd/osd_writer_test.go
@@ -20,14 +20,14 @@ func TestOSDRoundTripProperty(t *testing.T) {
 				Root: "R",
 				Env: map[string]*omnist.Record{
 					"R": {Name: "R", Fields: []omnist.Field{
-						{Label: "a", Type: omnist.ScalarType(omnist.KindString, false)},
-						{Label: "b", Type: omnist.ScalarType(omnist.KindInteger, true)},
-						{Label: "c", Type: omnist.ScalarType(omnist.KindNumber, false)},
-						{Label: "d", Type: omnist.ScalarType(omnist.KindBoolean, false)},
-						{Label: "e", Type: omnist.ScalarType(omnist.KindDate, false)},
-						{Label: "f", Type: omnist.ScalarType(omnist.KindTime, false)},
-						{Label: "g", Type: omnist.ScalarType(omnist.KindDateTime, false)},
-						{Label: "h", Type: omnist.AnyType()},
+						{Label: "a", Type: omnist.ScalarType(omnist.KindString, false), Cardinality: omnist.DefaultCardinality()},
+						{Label: "b", Type: omnist.ScalarType(omnist.KindInteger, true), Cardinality: omnist.DefaultCardinality()},
+						{Label: "c", Type: omnist.ScalarType(omnist.KindNumber, false), Cardinality: omnist.DefaultCardinality()},
+						{Label: "d", Type: omnist.ScalarType(omnist.KindBoolean, false), Cardinality: omnist.DefaultCardinality()},
+						{Label: "e", Type: omnist.ScalarType(omnist.KindDate, false), Cardinality: omnist.DefaultCardinality()},
+						{Label: "f", Type: omnist.ScalarType(omnist.KindTime, false), Cardinality: omnist.DefaultCardinality()},
+						{Label: "g", Type: omnist.ScalarType(omnist.KindDateTime, false), Cardinality: omnist.DefaultCardinality()},
+						{Label: "h", Type: omnist.AnyType(), Cardinality: omnist.DefaultCardinality()},
 					}},
 				},
 				EnvOrder: []string{"R"},
@@ -79,7 +79,7 @@ func TestOSDRoundTripProperty(t *testing.T) {
 				Root: "R",
 				Env: map[string]*omnist.Record{
 					"R": {Name: "R", Fields: []omnist.Field{
-						{Label: `a"b\c` + "\n" + "d", Type: omnist.ScalarType(omnist.KindString, false)},
+						{Label: `a"b\c` + "\n" + "d", Type: omnist.ScalarType(omnist.KindString, false), Cardinality: omnist.DefaultCardinality()},
 					}},
 				},
 				EnvOrder: []string{"R"},
@@ -208,7 +208,7 @@ func TestOSDLabelEscapingBackslashAndQuote(t *testing.T) {
 	schema := omnist.Schema{
 		Root: "R",
 		Env: map[string]*omnist.Record{
-			"R": {Name: "R", Fields: []omnist.Field{{Label: label, Type: omnist.ScalarType(omnist.KindString, false)}}},
+			"R": {Name: "R", Fields: []omnist.Field{{Label: label, Type: omnist.ScalarType(omnist.KindString, false), Cardinality: omnist.DefaultCardinality()}}},
 		},
 		EnvOrder: []string{"R"},
 	}
@@ -251,7 +251,7 @@ func TestOSDLabelEscapingControlCharacterTrap(t *testing.T) {
 	schema := omnist.Schema{
 		Root: "R",
 		Env: map[string]*omnist.Record{
-			"R": {Name: "R", Fields: []omnist.Field{{Label: label, Type: omnist.ScalarType(omnist.KindString, false)}}},
+			"R": {Name: "R", Fields: []omnist.Field{{Label: label, Type: omnist.ScalarType(omnist.KindString, false), Cardinality: omnist.DefaultCardinality()}}},
 		},
 		EnvOrder: []string{"R"},
 	}


### PR DESCRIPTION
Closes #95.

Per omnist-spec section 5.5: an OSD cardinality of exactly `[0,0]` is now a normative error -- redundant with not declaring the field at all, since undeclared fields are already rejected (`validate.unexpected-field`).

The vendored submodule pin (`0ac1eac`, v0.4.0-beta) already contains the spec commit this issue asks for (`cea3b3e` is an ancestor of `0ac1eac`) and the conformance vector (`osd-grammar/cardinality/zero-max-is-invalid-redundant-with-absence`), so no submodule bump is included in this PR.

## Changes
- `osd/osd_parser.go`'\''s `parseCardinality`: reject `min == 0 && max == 0` in both the single-bound (`[0]`) and two-bound (`[0,0]`) forms, reusing the existing `schema.invalid-cardinality` code.
- Fixed several existing tests/doc-examples that relied on `[0,0]` being accepted, either explicitly or via the zero-value `Cardinality{}` implicitly meaning unspecified: switched to `omnist.DefaultCardinality()`, or re-expressed field
