### PR TITLE
Reject empty-string and bracket-containing field labels

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -54,6 +54,24 @@ const (
 	// chapter 9 divergence-ledger D-2), this is normatively an error, not
 	// an implementation-defined choice.
 	CodeSchemaDuplicateRoot Code = "schema.duplicate-root"
+	// CodeSchemaEmptyLabel is raised when a field label is the empty
+	// string. Per spec section 5.4 (added 2026-08-29): a label is an
+	// identifier, not a value -- an empty label names nothing a caller
+	// could ever reference. Path is the enclosing record, the same
+	// convention CodeSchemaUnquotedLabel uses when the label itself is
+	// the problem.
+	CodeSchemaEmptyLabel Code = "schema.empty-label"
+	// CodeSchemaBracketInLabel is raised when a field label contains a
+	// literal '[' or ']' character. Per spec section 5.4 (added
+	// 2026-08-29): section 3.6.1's validate() pseudocode appends "[i]"
+	// to a repeated label's second and later occurrences when building a
+	// diagnostic path, so a label containing a literal bracket can
+	// collide with that convention (e.g. a repeatable field "a" and a
+	// separately declared field literally named "a[1]" can both path as
+	// $.a[1]). Rejecting the character vocabulary in labels is the
+	// narrowest fix. Path is the enclosing record, same convention as
+	// CodeSchemaEmptyLabel/CodeSchemaUnquotedLabel.
+	CodeSchemaBracketInLabel Code = "schema.bracket-in-label"
 )
 
 // validate.* — document against schema (spec §8.3.4).

--- a/osd/osd_parser.go
+++ b/osd/osd_parser.go
@@ -2,6 +2,7 @@ package osd
 
 import (
 	"fmt"
+	"strings"
 
 	omnist "github.com/omnist-dev/omnist-go"
 )
@@ -255,6 +256,12 @@ func (p *osdParser) parseField(recordName string) (omnist.Field, error) {
 		return omnist.Field{}, p.errAt(p.cur, omnist.CodeParseUnexpectedToken, "expected a quoted field name")
 	}
 	label := p.cur.strVal
+	if label == "" {
+		return omnist.Field{}, schemaError(recordName, omnist.CodeSchemaEmptyLabel, "field label must not be empty")
+	}
+	if strings.ContainsAny(label, "[]") {
+		return omnist.Field{}, schemaError(recordName, omnist.CodeSchemaBracketInLabel, "field label must not contain '[' or ']'")
+	}
 	if err := p.advance(); err != nil {
 		return omnist.Field{}, err
 	}

--- a/osd/osd_parser_test.go
+++ b/osd/osd_parser_test.go
@@ -110,6 +110,28 @@ func TestWorkedEmptyCardinality(t *testing.T) {
 	wantDiagCode(t, err, omnist.CodeSchemaEmptyCardinality)
 }
 
+func TestSchemaEmptyLabelIsRejected(t *testing.T) {
+	// spec section 5.4 (2026-08-29): an empty-string field label is an
+	// identifier-position value that names nothing, and is now rejected.
+	err := mustFailOSD(t, `record R { "": string } root R`)
+	wantDiag(t, err, omnist.CodeSchemaEmptyLabel, "R")
+}
+
+func TestSchemaBracketInLabelIsRejected(t *testing.T) {
+	// spec section 5.4 (2026-08-29): a label containing '[' or ']' can
+	// collide with the "[i]" suffix validate() appends to a repeated
+	// label's diagnostic path.
+	err := mustFailOSD(t, `record R { "a[1]": string } root R`)
+	wantDiag(t, err, omnist.CodeSchemaBracketInLabel, "R")
+}
+
+func TestSchemaClosingBracketAloneInLabelIsRejected(t *testing.T) {
+	// The rule is about the character vocabulary, not specifically a
+	// matched [i] pattern -- a lone ']' with no '[' is also rejected.
+	err := mustFailOSD(t, `record R { "total]": string } root R`)
+	wantDiag(t, err, omnist.CodeSchemaBracketInLabel, "R")
+}
+
 func TestWorkedNegativeCardinality(t *testing.T) {
 	err := mustFailOSD(t, `record R { "a" [-1]: string } root R`)
 	wantDiagCode(t, err, omnist.CodeSchemaInvalidCardinality)


### PR DESCRIPTION
Closes #100, closes #103.

Per omnist-spec section 5.4: a field label that is the empty string, or that contains a literal `[` or `]`, is now a normative parse error. Both are the same shape of fix (a check on the decoded label content at the same point in `parseField`), so they land together.

The vendored submodule pin (`0ac1eac`) already contains both spec commits and all three conformance vectors, so no submodule bump is included.

## Changes
- `errors.go`: new `schema.empty-label` and `schema.bracket-in-label` codes.
- `osd/osd_parser.go`'\''s `parseField`: reject an empty decoded label, and reject any label containing `[` or `]` (covers both the matched `a[1]` shape and a lone `total]`).
- Added tests for both new codes plus the closing-bracket-alone case.

## Verification
- `go build/vet/test`, `golangci-lint run ./...`, `gofmt -l .` (no new drift vs. `main`), `check_doc_examples` all clean.
- 100% coverage on `osd/osd_parser.go`.
- Vector conformance: all three new vectors now pass. Remaining failures on this branch belong to the other issues in this audit batch (#95-#99, #101, #102), confirmed by diff against the known failure set.

Per the coordinator's note: **not merging** -- leaving this open pending the batch-wide CI-gating decision (the `conformance` job is currently red on `main` itself for unrelated reasons; see PR #104).
