### PR TITLE
Fail, don't invent: null/float-special/empty-node writes now fail unconditionally

### DIFF
--- a/formats/json/json_reader_test.go
+++ b/formats/json/json_reader_test.go
@@ -328,31 +328,32 @@ func TestJSONRoundTripProperty(t *testing.T) {
 	}
 }
 
-// NaN/Infinity survive a write(lenient)->null->read round trip only in the
-// sense that reading the null back gives omnist.NullValue, not the original NaN
-// (that data is genuinely lost by design) — covered separately below, not
-// as part of the round-trip property (which is explicitly scoped to things
-// JSON CAN represent, per the issue's test list).
-func TestJSONNaNInfinityWriteThenReadBecomesNull(t *testing.T) {
+// TestJSONNaNInfinityWriteFails confirms NaN/Infinity now fails the
+// write outright (spec section 8.3.8/8.3.9, issue #98) instead of
+// surviving a write(lenient)->null->read round trip -- the old lenient
+// substitution this test used to exercise no longer exists (see
+// json_writer.go's Write doc comment).
+func TestJSONNaNInfinityWriteFails(t *testing.T) {
 	doc := omnist.NodeDocument(omnist.NewNode().
 		AddValue("n", omnist.ScalarValue(omnist.NewNumberScalar(math.NaN()))).
 		AddValue("ok", omnist.ScalarValue(omnist.NewStringScalar("still here"))))
-	text, _, err := Write(doc)
-	if err != nil {
-		t.Fatalf("WriteJSON failed: %v", err)
+	_, _, err := Write(doc)
+	if err == nil {
+		t.Fatal("WriteJSON: want error for a NaN leaf, got ok write")
 	}
-	got, err := Read(text, omnist.DefaultLimits())
-	if err != nil {
-		t.Fatalf("ReadJSON failed: %v", err)
+	diag, ok := err.(omnist.Diagnostic)
+	if !ok {
+		t.Fatalf("error is %T, want omnist.Diagnostic", err)
 	}
-	want := omnist.NodeDocument(omnist.NewNode().
-		AddValue("n", omnist.NullValue()).
-		AddValue("ok", omnist.ScalarValue(omnist.NewStringScalar("still here"))))
-	if !docEqual(want, got) {
-		t.Errorf("got %#v, want %#v", got, want)
+	if diag.Code != omnist.CodeWriteUnsupportedValue {
+		t.Errorf("diagnostic code = %s, want %s", diag.Code, omnist.CodeWriteUnsupportedValue)
+	}
+	if diag.Path != "$.n" {
+		t.Errorf("diagnostic path = %s, want $.n", diag.Path)
 	}
 }
 
+// TestJSONCrossFormatStructuralEqualityWithOML moved to
 // TestJSONCrossFormatStructuralEqualityWithOML moved to
 // json_reader_public_test.go (package omnist_test, issue #43): it is the
 // only test in this file that needs oml.Read, and an internal (package

--- a/formats/json/json_writer.go
+++ b/formats/json/json_writer.go
@@ -9,59 +9,65 @@ import (
 	omnist "github.com/omnist-dev/omnist-go"
 )
 
-// Write renders d as JSON text (spec §7.3, docs/formats/json.md),
-// schema-free: a writer MUST NOT accept a schema (§7.3), and this one
-// doesn't. It applies §7.3's two rules (grouping by label, the count-1
-// bare-value-vs-list rule) via writeJSONNode/writeJSONGroup below, plus
-// JSON-specific leaf rendering: temporal leaves are stringified to
-// ISO-8601, and NaN/Infinity — not valid JSON tokens — are substituted
-// with `null` at the leaf (docs/formats/json.md's default lenient mode).
-// Grouping itself can also lose cross-label interleaving; see
-// groupJSONEdges's doc comment.
+// Write renders d as JSON text (spec section 7.3, docs/formats/json.md),
+// schema-free: a writer MUST NOT accept a schema (section 7.3), and this
+// one doesn't. It applies section 7.3's two rules (grouping by label, the
+// count-1 bare-value-vs-list rule) via writeJSONNode/writeJSONGroup
+// below, plus JSON-specific leaf rendering: temporal leaves are
+// stringified to ISO-8601, and NaN/Infinity -- not valid JSON tokens --
+// now fail the write unconditionally (spec section 8.3.8/8.3.9, updated
+// 2026-08-24, issue #98). Grouping itself can also lose cross-label
+// interleaving; see groupJSONEdges's doc comment.
 //
-// The signature returns diagnostics alongside text and error because all
-// three of JSON's adjustments are reportable per spec §7.4 ("a reader or
-// writer SHOULD be able to report the adjustments... this is what makes
-// lossiness auditable") and spec §8.5.3, which documents write as the one
-// operation where a successful `{ok: true, ...}` result and a non-empty
-// diagnostics list are not mutually exclusive: every temporal leaf
-// stringified to ISO-8601 (format.temporal-stringified), every
-// NaN/Infinity substituted with `null` (format.float-special), and every
-// grouping that loses cross-label interleaving (format.interleaving-lost,
-// spec §8.3.8, D-3) is now reported this way. text is non-empty and err
-// is nil whenever the write succeeds, with diagnostics non-empty exactly
-// when an adjustment happened; text is empty and err is non-nil only on
-// WriteStrict's hard NaN/Infinity failure below.
+// # NaN/Infinity: unconditional failure, not a lenient substitution
 //
-// See WriteStrict for the spec's optional MAY: failing instead of
-// substituting.
+// A previous version of this writer substituted `null` for NaN/Infinity
+// by default, with a `WriteStrict` variant that failed instead (the
+// spec's then-optional MAY: "a strict mode MAY instead fail"). That
+// default was removed per spec section 8.3.8/8.3.9: writing a genuine
+// `null` value and writing NaN produce the identical JSON token, and both
+// read back as the identical Document value -- there is no way, after the
+// fact, to tell a substituted NaN from an original null. The correct
+// behavior is write.unsupported-value, unconditionally, matching the
+// null-unrepresentable fix for TOML (issue #97) and XML (issue #96/#97)
+// and the label-sanitization fix (issue #96) -- the same "does the
+// fallback collide with a genuinely different, independently-valid
+// input" test applied consistently.
+//
+// The signature still returns diagnostics alongside text and error
+// because JSON's other adjustment remains reportable per spec section 7.4
+// ("a reader or writer SHOULD be able to report the adjustments... this
+// is what makes lossiness auditable") and section 8.5.3, which documents
+// write as the one operation where a successful `{ok: true, ...}` result
+// and a non-empty diagnostics list are not mutually exclusive: every
+// temporal leaf stringified to ISO-8601 (format.temporal-stringified) and
+// every grouping that loses cross-label interleaving
+// (format.interleaving-lost, spec section 8.3.8, D-3) is reported this
+// way.
 func Write(d omnist.Document) (string, []omnist.Diagnostic, error) {
-	return writeJSONDocument(d, false)
+	return writeJSONDocument(d)
 }
 
-// WriteStrict renders d as JSON text like Write, except a
-// NaN/Infinity leaf is a hard failure instead of a `null` substitution —
-// the strict mode docs/formats/json.md's "no NaN or Infinity" rule
-// describes as a spec MAY ("A strict mode MAY instead fail"). The
-// returned error is a omnist.Diagnostic (code write.unsupported-value, spec
-// §8.3.9), positioned by the omnist.Document path to the offending leaf.
-// A temporal leaf can still be stringified and reported even in strict
-// mode (the two adjustments are independent), so a strict write can
-// succeed with non-empty diagnostics just like Write's.
+// WriteStrict is Deprecated: NaN/Infinity now fails unconditionally in
+// Write (spec section 8.3.8/8.3.9, updated 2026-08-24, issue #98), so
+// WriteStrict is now functionally identical to Write -- the distinction
+// this function used to draw (lenient substitution vs. strict failure)
+// no longer exists. Kept only for source compatibility with existing
+// callers; new code should call Write directly.
 func WriteStrict(d omnist.Document) (string, []omnist.Diagnostic, error) {
-	return writeJSONDocument(d, true)
+	return writeJSONDocument(d)
 }
 
-func writeJSONDocument(d omnist.Document, strict bool) (string, []omnist.Diagnostic, error) {
+func writeJSONDocument(d omnist.Document) (string, []omnist.Diagnostic, error) {
 	var b strings.Builder
 	var diags []omnist.Diagnostic
 	if d.IsNode {
-		if err := writeJSONNode(&b, d.Node, "$", strict, &diags); err != nil {
+		if err := writeJSONNode(&b, d.Node, "$", &diags); err != nil {
 			return "", nil, err
 		}
 		return b.String(), diags, nil
 	}
-	if err := writeJSONValue(&b, d.Value, "$", strict, &diags); err != nil {
+	if err := writeJSONValue(&b, d.Value, "$", &diags); err != nil {
 		return "", nil, err
 	}
 	return b.String(), diags, nil
@@ -80,7 +86,7 @@ type jsonGroup struct {
 // format: group edges sharing a label (grouping rule), then render each
 // group as a bare value when it has exactly one child or as a list
 // otherwise (count-1 rule).
-func writeJSONNode(b *strings.Builder, n *omnist.Node, path string, strict bool, diags *[]omnist.Diagnostic) error {
+func writeJSONNode(b *strings.Builder, n *omnist.Node, path string, diags *[]omnist.Diagnostic) error {
 	groups := groupJSONEdges(n)
 	if n.HasLostInterleaving() {
 		*diags = append(*diags, omnist.Diagnostic{
@@ -101,7 +107,7 @@ func writeJSONNode(b *strings.Builder, n *omnist.Node, path string, strict bool,
 		childPath := path + "." + g.label
 
 		if len(g.children) == 1 {
-			if err := writeJSONTarget(b, g.children[0], childPath, strict, diags); err != nil {
+			if err := writeJSONTarget(b, g.children[0], childPath, diags); err != nil {
 				return err
 			}
 			continue
@@ -111,7 +117,7 @@ func writeJSONNode(b *strings.Builder, n *omnist.Node, path string, strict bool,
 			if j > 0 {
 				b.WriteString(", ")
 			}
-			if err := writeJSONTarget(b, t, fmt.Sprintf("%s[%d]", childPath, j), strict, diags); err != nil {
+			if err := writeJSONTarget(b, t, fmt.Sprintf("%s[%d]", childPath, j), diags); err != nil {
 				return err
 			}
 		}
@@ -143,39 +149,40 @@ func groupJSONEdges(n *omnist.Node) []jsonGroup {
 	return groups
 }
 
-func writeJSONTarget(b *strings.Builder, t omnist.Target, path string, strict bool, diags *[]omnist.Diagnostic) error {
+func writeJSONTarget(b *strings.Builder, t omnist.Target, path string, diags *[]omnist.Diagnostic) error {
 	if node, ok := t.Node(); ok {
-		return writeJSONNode(b, node, path, strict, diags)
+		return writeJSONNode(b, node, path, diags)
 	}
 	v, _ := t.Value()
-	return writeJSONValue(b, v, path, strict, diags)
+	return writeJSONValue(b, v, path, diags)
 }
 
-func writeJSONValue(b *strings.Builder, v omnist.Value, path string, strict bool, diags *[]omnist.Diagnostic) error {
+func writeJSONValue(b *strings.Builder, v omnist.Value, path string, diags *[]omnist.Diagnostic) error {
 	if v.IsNull {
 		b.WriteString("null")
 		return nil
 	}
-	return writeJSONScalar(b, v.Scalar, path, strict, diags)
+	return writeJSONScalar(b, v.Scalar, path, diags)
 }
 
 // writeJSONScalar renders one leaf. Per docs/formats/json.md: "a writer
 // MUST stringify a temporal leaf to ISO-8601" (KindDate/KindTime/
-// KindDateTime), and NaN/Infinity (KindNumber only — JSON's only floating
-// kind) substitute to `null` unless strict, in which case they fail
-// instead. For KindInteger, s.Int is assumed non-nil, mirroring
+// KindDateTime), and NaN/Infinity (KindNumber only -- JSON's only
+// floating kind) now fail the write unconditionally (spec section
+// 8.3.8/8.3.9, issue #98) rather than substituting -- see Write's doc
+// comment. For KindInteger, s.Int is assumed non-nil, mirroring
 // oml_writer.go's writeOMLScalar precondition: every omnist.Scalar of that kind
 // reaching this function was built by omnist.NewIntegerScalar (which always
 // copies a non-nil *big.Int) or produced by ReadJSON, neither of which
 // ever leaves Int nil for KindInteger.
-func writeJSONScalar(b *strings.Builder, s omnist.Scalar, path string, strict bool, diags *[]omnist.Diagnostic) error {
+func writeJSONScalar(b *strings.Builder, s omnist.Scalar, path string, diags *[]omnist.Diagnostic) error {
 	switch s.Kind {
 	case omnist.KindString:
 		writeJSONString(b, s.Str)
 	case omnist.KindInteger:
 		b.WriteString(s.Int.String())
 	case omnist.KindNumber:
-		return writeJSONNumber(b, s.Num, path, strict, diags)
+		return writeJSONNumber(b, s.Num, path)
 	case omnist.KindBoolean:
 		if s.Bool {
 			b.WriteString("true")
@@ -212,30 +219,21 @@ func writeJSONScalar(b *strings.Builder, s omnist.Scalar, path string, strict bo
 
 // writeJSONNumber renders a KindNumber leaf. A finite value always gets a
 // decimal point or exponent (never a bare integer-looking spelling) so
-// that ReadJSON's own integer/number split — decided purely by the
-// literal's shape — reads it back as a number, not an integer; without
+// that ReadJSON's own integer/number split -- decided purely by the
+// literal's shape -- reads it back as a number, not an integer; without
 // this, writing 5.0 as the JSON text `5` would silently flip its kind on
 // round-trip. NaN/Infinity have no valid JSON spelling at all (spec: "not
-// valid JSON... a writer MUST NOT emit them"); the default lenient mode
-// substitutes `null`, strict mode fails with write.unsupported-value.
-func writeJSONNumber(b *strings.Builder, f float64, path string, strict bool, diags *[]omnist.Diagnostic) error {
+// valid JSON... a writer MUST NOT emit them") and now fail the write
+// unconditionally (spec section 8.3.8/8.3.9, issue #98) -- see Write's
+// doc comment for why the old lenient-substitution default was removed.
+func writeJSONNumber(b *strings.Builder, f float64, path string) error {
 	if math.IsNaN(f) || math.IsInf(f, 0) {
-		if strict {
-			return omnist.Diagnostic{
-				Path:     path,
-				Code:     omnist.CodeWriteUnsupportedValue,
-				Message:  "NaN/Infinity has no JSON representation",
-				Severity: omnist.SeverityError,
-			}
-		}
-		b.WriteString("null")
-		*diags = append(*diags, omnist.Diagnostic{
+		return omnist.Diagnostic{
 			Path:     path,
-			Code:     omnist.CodeFormatFloatSpecial,
-			Message:  "NaN/Infinity has no JSON representation, so it is substituted with null",
+			Code:     omnist.CodeWriteUnsupportedValue,
+			Message:  "NaN/Infinity has no JSON representation",
 			Severity: omnist.SeverityError,
-		})
-		return nil
+		}
 	}
 	s := strconv.FormatFloat(f, 'g', -1, 64)
 	if !strings.ContainsAny(s, ".eE") {

--- a/formats/json/json_writer_test.go
+++ b/formats/json/json_writer_test.go
@@ -124,9 +124,17 @@ func TestWriteJSONTimeVariants(t *testing.T) {
 	}
 }
 
-// --- NaN/Infinity: default lenient substitution ---
+// --- NaN/Infinity: unconditional write failure ---
+//
+// Per spec section 8.3.8/8.3.9 (updated 2026-08-24, issue #98): writing a
+// genuine null value and writing NaN used to produce the identical JSON
+// token, with no way to tell a substituted NaN from an original null on
+// read-back -- the same collision shape as the label-sanitization fix in
+// issue #96. Write and WriteStrict are now functionally identical: both
+// fail unconditionally instead of one of them substituting `null`. See
+// Write's doc comment.
 
-func TestWriteJSONNaNInfinitySubstitutesNull(t *testing.T) {
+func TestWriteJSONNaNInfinityFailsUnconditionally(t *testing.T) {
 	cases := []struct {
 		name string
 		num  float64
@@ -141,30 +149,23 @@ func TestWriteJSONNaNInfinitySubstitutesNull(t *testing.T) {
 				AddValue("before", omnist.ScalarValue(omnist.NewStringScalar("kept"))).
 				AddValue("n", omnist.ScalarValue(omnist.NewNumberScalar(tc.num))).
 				AddValue("after", omnist.ScalarValue(omnist.NewIntegerScalar(big.NewInt(7)))))
-			got, diags, err := Write(doc)
-			if err != nil {
-				t.Fatalf("WriteJSON failed: %v", err)
+			_, _, err := Write(doc)
+			if err == nil {
+				t.Fatalf("Write(%v): want error, got ok write", tc.num)
 			}
-			want := `{"before": "kept", "n": null, "after": 7}`
-			if got != want {
-				t.Errorf("got %q, want %q (rest of the document must be otherwise unaffected)", got, want)
+			diag, ok := err.(omnist.Diagnostic)
+			if !ok {
+				t.Fatalf("error is %T, want omnist.Diagnostic", err)
 			}
-			// Issue #49: the substitution is now reported alongside the
-			// successful write (spec §8.5.3).
-			if len(diags) != 1 {
-				t.Fatalf("diags = %v, want exactly one diagnostic", diags)
+			if diag.Code != omnist.CodeWriteUnsupportedValue {
+				t.Errorf("diagnostic code = %s, want %s", diag.Code, omnist.CodeWriteUnsupportedValue)
 			}
-			if diags[0].Code != omnist.CodeFormatFloatSpecial {
-				t.Errorf("diagnostic code = %s, want %s", diags[0].Code, omnist.CodeFormatFloatSpecial)
-			}
-			if diags[0].Path != "$.n" {
-				t.Errorf("diagnostic path = %s, want $.n", diags[0].Path)
+			if diag.Path != "$.n" {
+				t.Errorf("diagnostic path = %s, want $.n", diag.Path)
 			}
 		})
 	}
 }
-
-// --- NaN/Infinity: optional strict mode ---
 
 func TestWriteJSONStrictFailsOnNaNInfinity(t *testing.T) {
 	cases := []float64{math.NaN(), math.Inf(1), math.Inf(-1)}

--- a/formats/toml/toml_writer.go
+++ b/formats/toml/toml_writer.go
@@ -50,32 +50,26 @@ import (
 //
 // # Null: no TOML spelling exists at all
 //
-// docs/formats/toml.md is explicit: "A null-valued leaf cannot be
-// written... Implementations MUST report this as a write-time
-// adjustment rather than inventing a representation." Unlike WriteJSON's
-// NaN/Infinity substitution (which has a lenient default and a strict
-// opt-in that fails instead), TOML has no lenient option to fall back to
-// here — there is no spelling of any kind, not even a lossy one. But
-// per spec §8.5.3, write is the one operation where a successful
-// `{ok: true, ...}` result and a non-empty diagnostics list coexist: the
-// rest of the document can still be written faithfully around a null
-// leaf, so this writer drops the null leaf (per docs/formats/toml.md's
-// own wording, "cannot be written... and is omitted") and reports it as
-// a omnist.Diagnostic (omnist.CodeFormatNullUnrepresentable, spec §8.3.8,
-// warning severity, carrying the omnist.Document path to the offending
-// leaf) rather than failing the whole write. A single-child group whose
-// one value is null omits the entire `key = value` line (there is
-// nothing left to assign the key to); a null inside a multi-child group
-// (an array) instead just omits that one element, keeping the rest of
-// the array intact — see writeTOMLGroupValue.
+// Per spec section 8.3.8/8.3.9 (updated 2026-08-24): writing a
+// null-valued leaf to TOML now fails unconditionally
+// (omnist.CodeWriteUnsupportedValue), whether or not strict mode is
+// requested. TOML has no spelling of any kind for null, not even a
+// lossy one, and unlike every other row in the (now-former)
+// codec-adjustments table there is no substitute value to fall back to
+// -- the only option was to silently drop the edge, which does not just
+// alter what is represented at that position, it erases the edge's
+// existence entirely. Read the output back and there is zero trace an
+// edge with that label ever existed -- the same collision shape as the
+// label-sanitization fix from issue #96, just sharper: there the two
+// possible written forms differed by one collision, here there is no
+// trace left at all. So this writer now fails the whole write the first
+// time it encounters a null leaf anywhere in the document, rather than
+// omitting it and continuing (see writeTOMLTargetOptional).
 //
-// This is different from strict mode's behavior (spec: "Implementations
-// MAY offer a strict mode that fails outright instead"): this repository
-// has no strict-mode parameter on Write today (tracked separately, see
-// tools/conformance/drivers.go's runWrite skip for
-// formats-toml/nulls/strict-mode-refuses-to-write-instead-of-omitting) —
-// out of scope for this change, which is about the diagnostics channel,
-// not adding a new write mode.
+// This repository has no strict-mode parameter on Write today (tracked
+// separately, see tools/conformance/drivers.go's runWrite skip for
+// formats-toml/nulls/null-leaf-cannot-be-written-strict-is-the-same) --
+// moot for this fix regardless, since the failure is unconditional.
 //
 // # Bare-scalar-root: a real error, not malformed output
 //
@@ -96,7 +90,9 @@ func Write(d omnist.Document) (string, []omnist.Diagnostic, error) {
 	}
 	var b strings.Builder
 	var diags []omnist.Diagnostic
-	writeTOMLTopLevel(&b, d.Node, &diags)
+	if err := writeTOMLTopLevel(&b, d.Node, &diags); err != nil {
+		return "", nil, err
+	}
 	return b.String(), diags, nil
 }
 
@@ -137,7 +133,7 @@ func groupTOMLEdges(n *omnist.Node) []tomlGroup {
 // per the grouping and count-1 rules — see Write's doc comment for
 // why nested tables are written as inline-table values here rather than
 // `[section]` headers, and for the null-drop reasoning below.
-func writeTOMLTopLevel(b *strings.Builder, n *omnist.Node, diags *[]omnist.Diagnostic) {
+func writeTOMLTopLevel(b *strings.Builder, n *omnist.Node, diags *[]omnist.Diagnostic) error {
 	groups := groupTOMLEdges(n)
 	if n.HasLostInterleaving() {
 		*diags = append(*diags, omnist.Diagnostic{
@@ -149,89 +145,72 @@ func writeTOMLTopLevel(b *strings.Builder, n *omnist.Node, diags *[]omnist.Diagn
 	}
 	for _, g := range groups {
 		var vb strings.Builder
-		if !writeTOMLGroupValue(&vb, g, "$."+g.label, diags) {
-			// The group's one child was a null leaf with no TOML
-			// spelling at all — see Write's doc comment. There is
-			// nothing to assign the key to, so the whole `key = value`
-			// line is omitted (the diagnostic was already recorded by
-			// writeTOMLGroupValue/writeTOMLTargetOptional).
-			continue
+		if err := writeTOMLGroupValue(&vb, g, "$."+g.label, diags); err != nil {
+			return err
 		}
 		writeTOMLKey(b, g.label)
 		b.WriteString(" = ")
 		b.WriteString(vb.String())
 		b.WriteByte('\n')
 	}
+	return nil
 }
 
-// writeTOMLGroupValue renders one group's value per §7.3.1's count-1
-// rule: a bare rendering of the single target when the group has exactly
-// one child, an inline array of renderings otherwise. The returned bool
-// reports whether anything was written at all — false only for a
-// single-child group whose one child is a dropped null leaf (see Write's
-// doc comment); a multi-child group always writes an array (possibly
-// missing some of its null elements, never entirely omitted, since a
-// `key = []` is a valid, faithful rendering of "some elements dropped").
-//
-// This (and writeTOMLTargetOptional/writeTOMLInlineTable below) carries
-// no error return: since the null-drop case became a diagnostic rather
-// than a hard failure, nothing below the root can fail at all — TOML's
-// only failure mode (a bare-scalar document root) is checked once, in
-// Write, before any of this is ever called.
-func writeTOMLGroupValue(b *strings.Builder, g tomlGroup, path string, diags *[]omnist.Diagnostic) bool {
+// writeTOMLGroupValue renders one group's value per section 7.3.1's
+// count-1 rule: a bare rendering of the single target when the group has
+// exactly one child, an inline array of renderings otherwise. Per spec
+// section 8.3.8/8.3.9 (2026-08-24, issue #97): a null leaf now fails the
+// write unconditionally rather than being silently dropped, so (unlike
+// before that fix) every target this function or writeTOMLTargetOptional
+// touches either writes something or returns a non-nil error -- there is
+// no longer an "ok but nothing was written" case to signal with a bool,
+// so this returns a plain error.
+func writeTOMLGroupValue(b *strings.Builder, g tomlGroup, path string, diags *[]omnist.Diagnostic) error {
 	if len(g.children) == 1 {
 		return writeTOMLTargetOptional(b, g.children[0], path, diags)
 	}
 	b.WriteByte('[')
-	first := true
 	for i, t := range g.children {
-		var eb strings.Builder
-		if !writeTOMLTargetOptional(&eb, t, fmt.Sprintf("%s[%d]", path, i), diags) {
-			continue
-		}
-		if !first {
+		if i > 0 {
 			b.WriteString(", ")
 		}
-		b.WriteString(eb.String())
-		first = false
+		if err := writeTOMLTargetOptional(b, t, fmt.Sprintf("%s[%d]", path, i), diags); err != nil {
+			return err
+		}
 	}
 	b.WriteByte(']')
-	return true
+	return nil
 }
 
 // writeTOMLTargetOptional renders one Target: an inline table for a
 // omnist.Node, a scalar literal for a non-null omnist.Value. A null
-// omnist.Value has no TOML spelling at all (see Write's doc comment); it
-// writes nothing, records the format.null-unrepresentable diagnostic, and
-// reports false so the caller (writeTOMLGroupValue/writeTOMLTopLevel)
-// knows to drop the key or the array element rather than emit an empty
-// placeholder.
-func writeTOMLTargetOptional(b *strings.Builder, t omnist.Target, path string, diags *[]omnist.Diagnostic) bool {
+// omnist.Value has no TOML spelling at all (see Write's doc comment); per
+// spec section 8.3.8/8.3.9 (2026-08-24), writing it is now an
+// unconditional failure (omnist.CodeWriteUnsupportedValue) -- there is no
+// substitute value to fall back to, and silently dropping the edge erases
+// its existence entirely with no trace on read-back (the null-leaf
+// analogue of the label-sanitization collision fixed in issue #96).
+func writeTOMLTargetOptional(b *strings.Builder, t omnist.Target, path string, diags *[]omnist.Diagnostic) error {
 	if node, ok := t.Node(); ok {
-		writeTOMLInlineTable(b, node, path, diags)
-		return true
+		return writeTOMLInlineTable(b, node, path, diags)
 	}
 	v, _ := t.Value()
 	if v.IsNull {
-		*diags = append(*diags, omnist.Diagnostic{
+		return omnist.Diagnostic{
 			Path:     path,
-			Code:     omnist.CodeFormatNullUnrepresentable,
-			Message:  "a null leaf cannot be written in TOML, so it is dropped",
-			Severity: omnist.SeverityWarning,
-		})
-		return false
+			Code:     omnist.CodeWriteUnsupportedValue,
+			Message:  "a null leaf has no TOML spelling and cannot be written",
+			Severity: omnist.SeverityError,
+		}
 	}
 	writeTOMLScalar(b, v.Scalar)
-	return true
+	return nil
 }
 
 // writeTOMLInlineTable renders n as a TOML inline table (`{k = v, ...}`),
 // applying the same grouping/count-1 rules writeTOMLTopLevel applies at
-// the root — an inline table is exactly a nested write(node, format).
-// Mirroring writeTOMLTopLevel, a group whose value is entirely dropped
-// (a single null child) omits its `k = v` entry from the table rather
-// than leaving a dangling key.
-func writeTOMLInlineTable(b *strings.Builder, n *omnist.Node, path string, diags *[]omnist.Diagnostic) {
+// the root -- an inline table is exactly a nested write(node, format).
+func writeTOMLInlineTable(b *strings.Builder, n *omnist.Node, path string, diags *[]omnist.Diagnostic) error {
 	groups := groupTOMLEdges(n)
 	if n.HasLostInterleaving() {
 		*diags = append(*diags, omnist.Diagnostic{
@@ -242,21 +221,20 @@ func writeTOMLInlineTable(b *strings.Builder, n *omnist.Node, path string, diags
 		})
 	}
 	b.WriteByte('{')
-	first := true
-	for _, g := range groups {
-		var vb strings.Builder
-		if !writeTOMLGroupValue(&vb, g, path+"."+g.label, diags) {
-			continue
-		}
-		if !first {
+	for i, g := range groups {
+		if i > 0 {
 			b.WriteString(", ")
+		}
+		var vb strings.Builder
+		if err := writeTOMLGroupValue(&vb, g, path+"."+g.label, diags); err != nil {
+			return err
 		}
 		writeTOMLKey(b, g.label)
 		b.WriteString(" = ")
 		b.WriteString(vb.String())
-		first = false
 	}
 	b.WriteByte('}')
+	return nil
 }
 
 // writeTOMLKey renders a label as a TOML quoted (basic string) key,
@@ -340,7 +318,7 @@ func writeTOMLNumber(b *strings.Builder, f float64) {
 
 // writeTOMLString renders s as a TOML basic string literal (double
 // quoted), escaping exactly what TOML's basic-string grammar requires:
-// '"', '\\', the named short escapes for backspace/formfeed/newline/
+// '"', '\', the named short escapes for backspace/formfeed/newline/
 // CR/tab, and \u00XX for every other control character — the same escape
 // set writeJSONString (json_writer.go) uses, which TOML's basic-string
 // grammar shares control-character-for-control-character with JSON's.

--- a/formats/toml/toml_writer_test.go
+++ b/formats/toml/toml_writer_test.go
@@ -133,28 +133,25 @@ func TestWriteTOMLOffsetDateTimeRoundTrips(t *testing.T) {
 	}
 }
 
-// --- null: write-time adjustment, reported not invented ---
+// --- null: unconditional write failure, not a reported adjustment ---
 
-// Since issue #49, a null leaf is a non-fatal write-time adjustment: the
-// write still succeeds (err == nil), the null is dropped from the
-// output, and the drop is reported via the returned []omnist.Diagnostic
-// rather than aborting the whole write (spec §8.5.3's write-only
-// ok:true+diagnostics coexistence).
-func TestWriteTOMLNullReportsAdjustment(t *testing.T) {
+// Per spec section 8.3.8/8.3.9 (updated 2026-08-24, issue #97): a null
+// leaf with no TOML spelling now fails the write unconditionally
+// (omnist.CodeWriteUnsupportedValue) instead of being silently dropped
+// with a warning -- dropping the edge erased its existence entirely,
+// with zero trace on read-back.
+func TestWriteTOMLNullFailsUnconditionally(t *testing.T) {
 	d := omnist.NodeDocument(omnist.NewNode().AddValue("coupon", omnist.NullValue()))
 	out, diags, err := Write(d)
-	if err != nil {
-		t.Fatalf("Write: unexpected error: %v", err)
+	if err == nil {
+		t.Fatalf("Write: want error, got ok write out=%q diags=%v", out, diags)
 	}
-	if out != "" {
-		t.Errorf("out = %q, want empty (the only key was a dropped null)", out)
+	diag, ok := err.(omnist.Diagnostic)
+	if !ok {
+		t.Fatalf("err = %T, want omnist.Diagnostic", err)
 	}
-	if len(diags) != 1 {
-		t.Fatalf("diags = %v, want exactly one diagnostic", diags)
-	}
-	diag := diags[0]
-	if diag.Code != omnist.CodeFormatNullUnrepresentable {
-		t.Errorf("omnist.Diagnostic.Code = %s, want %s", diag.Code, omnist.CodeFormatNullUnrepresentable)
+	if diag.Code != omnist.CodeWriteUnsupportedValue {
+		t.Errorf("omnist.Diagnostic.Code = %s, want %s", diag.Code, omnist.CodeWriteUnsupportedValue)
 	}
 	if diag.Path != "$.coupon" {
 		t.Errorf("omnist.Diagnostic.Path = %s, want $.coupon", diag.Path)
@@ -164,42 +161,98 @@ func TestWriteTOMLNullReportsAdjustment(t *testing.T) {
 	}
 }
 
-func TestWriteTOMLNullInsideNestedNodeReportsAdjustment(t *testing.T) {
+func TestWriteTOMLNullInsideNestedNodeFailsUnconditionally(t *testing.T) {
 	d := omnist.NodeDocument(omnist.NewNode().AddNode("order", omnist.NewNode().AddValue("coupon", omnist.NullValue())))
-	out, diags, err := Write(d)
-	if err != nil {
-		t.Fatalf("Write: unexpected error: %v", err)
+	_, _, err := Write(d)
+	if err == nil {
+		t.Fatal("Write: want error for a null leaf nested inside a table, got ok write")
 	}
-	if out != `"order" = {}`+"\n" {
-		t.Errorf("out = %q, want the order table with its only key (the dropped null) omitted", out)
+	diag, ok := err.(omnist.Diagnostic)
+	if !ok {
+		t.Fatalf("err = %T, want omnist.Diagnostic", err)
 	}
-	if len(diags) != 1 {
-		t.Fatalf("diags = %v, want exactly one diagnostic", diags)
-	}
-	if diags[0].Path != "$.order.coupon" {
-		t.Errorf("omnist.Diagnostic.Path = %s, want $.order.coupon", diags[0].Path)
+	if diag.Path != "$.order.coupon" {
+		t.Errorf("omnist.Diagnostic.Path = %s, want $.order.coupon", diag.Path)
 	}
 }
 
-func TestWriteTOMLNullInsideListReportsAdjustment(t *testing.T) {
+func TestWriteTOMLNullInsideListFailsUnconditionally(t *testing.T) {
 	d := omnist.NodeDocument(omnist.NewNode().
 		AddValue("m", omnist.ScalarValue(omnist.NewStringScalar("A"))).
 		AddValue("m", omnist.NullValue()))
-	out, diags, err := Write(d)
-	if err != nil {
-		t.Fatalf("Write: unexpected error: %v", err)
+	_, _, err := Write(d)
+	if err == nil {
+		t.Fatal("Write: want error for a null leaf inside a repeated-label array, got ok write")
 	}
-	if out != `"m" = ["A"]`+"\n" {
-		t.Errorf("out = %q, want the array with its dropped null element omitted", out)
+	diag, ok := err.(omnist.Diagnostic)
+	if !ok {
+		t.Fatalf("err = %T, want omnist.Diagnostic", err)
 	}
-	if len(diags) != 1 {
-		t.Fatalf("diags = %v, want exactly one diagnostic", diags)
+	if diag.Code != omnist.CodeWriteUnsupportedValue {
+		t.Errorf("omnist.Diagnostic.Code = %s, want %s", diag.Code, omnist.CodeWriteUnsupportedValue)
 	}
-	if diags[0].Code != omnist.CodeFormatNullUnrepresentable {
-		t.Errorf("omnist.Diagnostic.Code = %s, want %s", diags[0].Code, omnist.CodeFormatNullUnrepresentable)
+	if diag.Path != "$.m[1]" {
+		t.Errorf("omnist.Diagnostic.Path = %s, want $.m[1]", diag.Path)
 	}
-	if diags[0].Path != "$.m[1]" {
-		t.Errorf("omnist.Diagnostic.Path = %s, want $.m[1]", diags[0].Path)
+}
+
+func TestWriteTOMLNullFailsAfterEarlierTopLevelKeySucceeded(t *testing.T) {
+	// Exercises writeTOMLTopLevel's error return on a later group after
+	// an earlier one already wrote successfully -- not just the
+	// single-group case.
+	d := omnist.NodeDocument(omnist.NewNode().
+		AddValue("a", omnist.ScalarValue(omnist.NewStringScalar("ok"))).
+		AddValue("b", omnist.NullValue()))
+	_, _, err := Write(d)
+	if err == nil {
+		t.Fatal("Write: want error, got ok write")
+	}
+	diag, ok := err.(omnist.Diagnostic)
+	if !ok || diag.Code != omnist.CodeWriteUnsupportedValue {
+		t.Errorf("error = %#v, want write.unsupported-value omnist.Diagnostic", err)
+	}
+	if diag.Path != "$.b" {
+		t.Errorf("omnist.Diagnostic.Path = %s, want $.b", diag.Path)
+	}
+}
+
+func TestWriteTOMLNullFailsAfterEarlierInlineTableKeySucceeded(t *testing.T) {
+	// Exercises writeTOMLInlineTable's error return on a later group
+	// after an earlier one already wrote successfully.
+	d := omnist.NodeDocument(omnist.NewNode().AddNode("order", omnist.NewNode().
+		AddValue("a", omnist.ScalarValue(omnist.NewStringScalar("ok"))).
+		AddValue("b", omnist.NullValue())))
+	_, _, err := Write(d)
+	if err == nil {
+		t.Fatal("Write: want error, got ok write")
+	}
+	diag, ok := err.(omnist.Diagnostic)
+	if !ok || diag.Code != omnist.CodeWriteUnsupportedValue {
+		t.Errorf("error = %#v, want write.unsupported-value omnist.Diagnostic", err)
+	}
+	if diag.Path != "$.order.b" {
+		t.Errorf("omnist.Diagnostic.Path = %s, want $.order.b", diag.Path)
+	}
+}
+
+func TestWriteTOMLNullInsideListFailsAfterEarlierElementSucceeded(t *testing.T) {
+	// Exercises writeTOMLGroupValue's multi-child array branch: the
+	// error return after an earlier element already wrote successfully
+	// AND the eventual bool return path when nothing errors.
+	d := omnist.NodeDocument(omnist.NewNode().
+		AddValue("m", omnist.ScalarValue(omnist.NewStringScalar("A"))).
+		AddValue("m", omnist.ScalarValue(omnist.NewStringScalar("B"))).
+		AddValue("m", omnist.NullValue()))
+	_, _, err := Write(d)
+	if err == nil {
+		t.Fatal("Write: want error, got ok write")
+	}
+	diag, ok := err.(omnist.Diagnostic)
+	if !ok || diag.Code != omnist.CodeWriteUnsupportedValue {
+		t.Errorf("error = %#v, want write.unsupported-value omnist.Diagnostic", err)
+	}
+	if diag.Path != "$.m[2]" {
+		t.Errorf("omnist.Diagnostic.Path = %s, want $.m[2]", diag.Path)
 	}
 }
 

--- a/formats/xml/xml_writer.go
+++ b/formats/xml/xml_writer.go
@@ -115,6 +115,27 @@ func writeXMLElement(b *strings.Builder, label string, t omnist.Target, path str
 	}
 
 	if node, ok := t.Node(); ok {
+		if len(node.Edges) == 0 {
+			// Per spec section 8.3.8/8.3.9 (updated 2026-08-24): an internal
+			// node with zero edges has no XML spelling distinct from an
+			// empty-string leaf -- both would write as the self-closing
+			// `<label/>` (equivalently `<label></label>`), and the
+			// internal-node-ness is gone, silently, with no way to recover
+			// it on read-back. This is a genuine gap (this writer previously
+			// emitted the self-closing form here with no diagnostic at all),
+			// not a strictness flip: fail unconditionally
+			// (omnist.CodeWriteUnsupportedValue) rather than emit the
+			// ambiguous output. This does not affect a omnist.Value target
+			// holding an empty string, which is fine and unrelated -- see
+			// the v.IsNull branch below and writeXMLElement's own doc
+			// comment on empty-string leaves.
+			return omnist.Diagnostic{
+				Path:     path,
+				Code:     omnist.CodeWriteUnsupportedValue,
+				Message:  "an internal node with no edges has no XML spelling distinct from an empty string leaf and cannot be written",
+				Severity: omnist.SeverityError,
+			}
+		}
 		b.WriteByte('<')
 		b.WriteString(label)
 		b.WriteByte('>')
@@ -134,30 +155,21 @@ func writeXMLElement(b *strings.Builder, label string, t omnist.Target, path str
 	b.WriteString(label)
 	b.WriteByte('>')
 	if v.IsNull {
-		// docs/formats/xml.md does not discuss null explicitly, but XML
-		// text has no spelling for "absent" distinct from "empty" any more
-		// than TOML has a spelling for null at all (see WriteTOML's doc
-		// comment on omnist.CodeFormatNullUnrepresentable) — the plainly-correct,
-		// narrow/cosmetic reading taken here is the same one: report the
-		// same warning-severity adjustment code TOML's writer already
-		// uses for "this leaf has no representation in this format, so it
-		// is written as empty/dropped", applied to XML's own empty-element
-		// spelling instead of TOML's outright omission. Unlike TOML
-		// (which has no spelling at all and must drop the leaf), XML's
-		// empty-element spelling is a real, if lossy, representation, so
-		// per spec §8.5.3 (write's ok:true + diagnostics coexistence) this
-		// is now a non-fatal diagnostic rather than a hard failure that
-		// discards the rest of the document.
-		*diags = append(*diags, omnist.Diagnostic{
+		// Per spec section 8.3.8/8.3.9 (updated 2026-08-24): writing a null
+		// leaf now fails unconditionally (omnist.CodeWriteUnsupportedValue)
+		// rather than substituting a lossy fallback. XML's only candidate
+		// fallback -- an empty element, `<label></label>` -- collides with
+		// a genuinely different, independently-valid input: writing a real
+		// empty-string leaf produces the exact same bytes, and there is no
+		// way to tell the two apart on read-back. Same collision shape as
+		// the label-sanitization fix in issue #96 and the TOML null fix in
+		// issue #97, here for XML's own null-has-no-distinct-spelling case.
+		return omnist.Diagnostic{
 			Path:     path,
-			Code:     omnist.CodeFormatNullUnrepresentable,
-			Message:  "a null leaf cannot be written in XML, so it is written as an empty element",
-			Severity: omnist.SeverityWarning,
-		})
-		b.WriteString("</")
-		b.WriteString(label)
-		b.WriteByte('>')
-		return nil
+			Code:     omnist.CodeWriteUnsupportedValue,
+			Message:  "a null leaf has no XML spelling distinct from an empty string and cannot be written",
+			Severity: omnist.SeverityError,
+		}
 	}
 	// encxml.EscapeText's only failure mode is its io.Writer returning an
 	// error; xmlTextWriter wraps a *strings.Builder, whose Write never

--- a/formats/xml/xml_writer_test.go
+++ b/formats/xml/xml_writer_test.go
@@ -212,32 +212,77 @@ func TestWriteXMLNaNInfinity(t *testing.T) {
 	}
 }
 
-// --- null leaf: reported as a warning-severity adjustment (mirroring
-// WriteTOML's identical null handling, see TestWriteTOMLNullReportsAdjustment) ---
+// --- null leaf: unconditional write failure, not a reported adjustment ---
 
-func TestWriteXMLNullLeafReportsAdjustment(t *testing.T) {
+func TestWriteXMLNullLeafFailsUnconditionally(t *testing.T) {
+	// Per spec section 8.3.8/8.3.9 (updated 2026-08-24, issue #97/#96):
+	// a null leaf's only XML fallback -- an empty element -- collides
+	// with a genuinely different, independently-valid input (a real
+	// empty-string leaf writes identically), so the write now fails
+	// unconditionally instead of substituting the ambiguous empty
+	// element with a warning.
 	d := omnist.NodeDocument(omnist.NewNode().AddValue("a", omnist.NullValue()))
-	out, diags, err := Write(d)
-	if err != nil {
-		t.Fatalf("Write: unexpected error: %v", err)
+	_, _, err := Write(d)
+	if err == nil {
+		t.Fatal("Write: want error for a null leaf, got ok write")
 	}
-	if out != "<a></a>" {
-		t.Errorf("out = %q, want the null leaf written as an empty element", out)
+	diag, ok := err.(omnist.Diagnostic)
+	if !ok {
+		t.Fatalf("err = %T, want omnist.Diagnostic", err)
 	}
-	if len(diags) != 1 {
-		t.Fatalf("diags = %v, want exactly one diagnostic", diags)
+	if diag.Code != omnist.CodeWriteUnsupportedValue {
+		t.Fatalf("got code %v, want omnist.CodeWriteUnsupportedValue", diag.Code)
 	}
-	diag := diags[0]
-	if diag.Code != omnist.CodeFormatNullUnrepresentable {
-		t.Fatalf("got code %v, want omnist.CodeFormatNullUnrepresentable", diag.Code)
-	}
-	if diag.Severity != omnist.SeverityWarning {
-		t.Errorf("got severity %v, want omnist.SeverityWarning", diag.Severity)
+	if diag.Severity != omnist.SeverityError {
+		t.Errorf("got severity %v, want omnist.SeverityError", diag.Severity)
 	}
 	if diag.Path != "$.a" {
 		t.Errorf("got path %q, want $.a", diag.Path)
 	}
 }
+
+// --- empty internal node: unconditional write failure ---
+
+func TestWriteXMLEmptyInternalNodeFailsUnconditionally(t *testing.T) {
+	// Per spec section 8.3.8/8.3.9 (updated 2026-08-24, issue #98): an
+	// internal node with zero edges has no XML spelling distinct from an
+	// empty-string leaf -- both would write as the self-closing form --
+	// so the write now fails unconditionally. This is a genuine gap fix
+	// (no diagnostic existed for this at all before), not a strictness
+	// flip.
+	d := omnist.NodeDocument(omnist.NewNode().AddNode("a", omnist.NewNode()))
+	_, _, err := Write(d)
+	if err == nil {
+		t.Fatal("Write: want error for an empty internal node, got ok write")
+	}
+	diag, ok := err.(omnist.Diagnostic)
+	if !ok {
+		t.Fatalf("err = %T, want omnist.Diagnostic", err)
+	}
+	if diag.Code != omnist.CodeWriteUnsupportedValue {
+		t.Fatalf("got code %v, want omnist.CodeWriteUnsupportedValue", diag.Code)
+	}
+	if diag.Path != "$.a" {
+		t.Errorf("got path %q, want $.a", diag.Path)
+	}
+}
+
+// TestWriteXMLEmptyStringLeafStillWrites confirms the empty-internal-node
+// failure above does NOT extend to a Value target holding an empty
+// string -- that case is fine and unrelated (writeXMLElement's own doc
+// comment on the self-closing form already discusses this distinction).
+func TestWriteXMLEmptyStringLeafStillWrites(t *testing.T) {
+	d := omnist.NodeDocument(omnist.NewNode().AddValue("a", omnist.ScalarValue(omnist.NewStringScalar(""))))
+	out, _, err := Write(d)
+	if err != nil {
+		t.Fatalf("Write: unexpected error for an empty-string leaf: %v", err)
+	}
+	if out != "<a></a>" {
+		t.Errorf("out = %q, want <a></a>", out)
+	}
+}
+
+// --- invalid element names are rejected, not silently mangled ---
 
 // --- invalid element names are rejected, not silently mangled ---
 
@@ -250,6 +295,30 @@ func TestWriteXMLRejectsInvalidLabel(t *testing.T) {
 	diag, ok := err.(omnist.Diagnostic)
 	if !ok || diag.Code != omnist.CodeWriteUnsupportedValue {
 		t.Fatalf("got %v (%T), want omnist.CodeWriteUnsupportedValue", err, err)
+	}
+}
+
+// TestWriteXMLRejectsSpaceInLabelMatchesVector backs conformance vector
+// formats-xml/basic/label-with-illegal-xml-characters-cannot-be-written
+// (issue #96): confirmed by cross-port verification that this port's
+// isValidXMLName/writeXMLElement already fail closed here (hard error,
+// no sanitize-and-succeed fallback), so this is a confirming test, not a
+// bug fix -- see the issue's own comment thread.
+func TestWriteXMLRejectsSpaceInLabelMatchesVector(t *testing.T) {
+	d := omnist.NodeDocument(omnist.NewNode().AddNode("root", omnist.NewNode().AddValue("my label", omnist.ScalarValue(omnist.NewStringScalar("hi")))))
+	_, _, err := Write(d)
+	if err == nil {
+		t.Fatal("expected an error for a space in a label")
+	}
+	diag, ok := err.(omnist.Diagnostic)
+	if !ok {
+		t.Fatalf("error is %T, want omnist.Diagnostic", err)
+	}
+	if diag.Code != omnist.CodeWriteUnsupportedValue {
+		t.Errorf("got code %v, want omnist.CodeWriteUnsupportedValue", diag.Code)
+	}
+	if diag.Path != "$.root.my label" {
+		t.Errorf("got path %q, want $.root.my label", diag.Path)
 	}
 }
 


### PR DESCRIPTION
Closes #96, closes #97, closes #98.

Per omnist-spec section 8.3.8/8.3.9: a write whose only fallback collides with a genuinely different, independently-valid input must now fail outright (`write.unsupported-value`), not substitute-and-warn. `format.key-sanitized`/`string-illegal-char`, `format.null-unrepresentable`, and `format.float-special`/`shape-empty-ambiguous` are removed from the codec-adjustments table for this reason. All three issues are the same underlying principle, landed together.

The vendored submodule pin (`0ac1eac`) already contains every spec commit these issues need, so no submodule bump is included.

## #96 — confirmation only, no code change
Per the issue's own comment thread: this port's `isValidXMLName`/`writeXMLElement` already fail closed on an illegal XML label with a hard error — no sanitizer to remove, no collision to reproduce. Added a test confirming the exact vector shape (path `$.root.my label`).

## #97
- TOML: a null leaf now fails the whole write instead of being silently dropped with a warning. Simplified the writer's internal `(bool, error)` returns down to a plain `error` once the "ok but nothing written" case stopped being reachable — kept the code from developing dead branches.
- XML: checked empirically (per the issue's instruction) whether XML needed the same fix — it did (same code, same collision shape with an empty-string leaf), even though no conformance vector exercises it today; leaving XML emit a removed code would be its own gap.
- Left `CodeFormatNullUnrepresentable` defined (unused now) rather than deleting public API as a side effect.

## #98
- JSON: NaN/Infinity now fails unconditionally. This makes `Write` and `WriteStrict` functionally identical (confirmed `strict` had no other use in the file) — deprecated `WriteStrict` via doc comment rather than removing it outright, since removing public API is a bigger call than adding a check. Open to a maintainer's call on removing it in a follow-up.
- XML: an empty internal node (zero edges) now fails the write — a genuine gap fix (no diagnostic existed for this before), verified not to affect a real empty-string leaf, which still writes fine.

## Verification
- `go build/vet/test`, `golangci-lint run ./...`, `gofmt -l .` (no new drift vs. `main`), `check_doc_examples` all clean.
- 100% coverage on every touched writer file.
- Fixture conformance track: 19/19 pass.
- Vector conformance track: all four vectors these issues target now pass. Remaining failures on this branch belong to the other issues in this batch (#95, #99-#103).

Per the coordinator: this repo's `conformance` CI job is temporarily non-blocking for the whole #95-#103 batch (see `d522337`); merging once this PR's other jobs are green.
