### PR TITLE
Define NUMBER/INTEGER lexical grammar and DATE/TIME/DATETIME value ranges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,24 +168,9 @@ jobs:
           go-version: '1.26.6'
       - name: Run conformance harness (Track 2, JSON-vector)
         run: |
-          # Gated CI execution (issue #74): fails build on nonzero fail count (§8.5.5).
-          #
-          # TEMPORARILY non-blocking for the #95-103 spec-correctness audit
-          # batch (2026-08-30): the vendor/omnist-spec pin was bumped once,
-          # to 0ac1eac, ahead of all 9 fixes landing incrementally -- each
-          # fix's own PR is cut from a main that already carries every
-          # vector the whole batch needs, so this job stays red on every
-          # intermediate PR through no fault of that PR's own change,
-          # exactly the situation issue #74 itself was created to prevent
-          # going forward. Reverting to strict gating (removing `|| true`)
-          # is issue #103's own responsibility -- the last issue in the
-          # batch -- once its merge brings the real fail count back to
-          # zero, matching the target state every other CI job here still
-          # enforces unconditionally throughout this transition.
-          go run ./tools/conformance/cmd/conformance || true
+          # Gated CI execution (issue #74): fails build on nonzero fail count (section 8.5.5).
+          go run ./tools/conformance/cmd/conformance
       - name: Run conformance harness (Track 1, fixture-based)
         run: |
-          # Gated CI execution (issue #74): fails build on nonzero fail count (§8.5.5).
-          # TEMPORARILY non-blocking for the #95-103 batch -- see the Track 2
-          # step's comment above for the full explanation and revert plan.
-          go run ./tools/conformance/cmd/conformance-fixtures || true
+          # Gated CI execution (issue #74): fails build on nonzero fail count (section 8.5.5).
+          go run ./tools/conformance/cmd/conformance-fixtures

--- a/errors.go
+++ b/errors.go
@@ -20,6 +20,26 @@ const (
 	CodeParseEmptyArray         Code = "parse.empty-array"
 	CodeParseNestedArray        Code = "parse.nested-array"
 	CodeParseSeparatorInArray   Code = "parse.separator-in-array"
+	// CodeParseLeadingZero is raised when a NUMBER/INTEGER literal's
+	// integer part has a leading zero (e.g. "01", "00.5"). Per spec
+	// section 4.2.3 (added 2026-08-29): int-part = "0" / (a nonzero
+	// digit followed by any digits) -- a bare "0" alone, or "-0", is
+	// never a leading zero and remains valid.
+	CodeParseLeadingZero Code = "parse.leading-zero"
+	// CodeParseInvalidDate is raised when a DATE token (or DATETIME's
+	// date portion) is a valid ISO-8601 shape but not a valid calendar
+	// date -- month out of 01-12, or day invalid for month/year
+	// (including leap years). Per spec section 4.2.4 (added
+	// 2026-08-29).
+	CodeParseInvalidDate Code = "parse.invalid-date"
+	// CodeParseInvalidTime is raised when a TIME token (or DATETIME's
+	// time portion, or a tz-offset) is a valid ISO-8601 shape but not a
+	// valid clock value -- hour out of 00-23, minute or second out of
+	// 00-59 (no leap-second spelling), or -- for a tz-offset -- the
+	// same hour/minute ranges TIME itself uses. Per spec section 4.2.4
+	// (added 2026-08-29): tz-offset shares TIME's exact range check,
+	// not a separately implemented one.
+	CodeParseInvalidTime Code = "parse.invalid-time"
 )
 
 // document.* — building and limits (spec §8.3.2).

--- a/oml/oml_lexer.go
+++ b/oml/oml_lexer.go
@@ -183,7 +183,24 @@ var (
 	reNumber  = regexp.MustCompile(`^-?\d+(\.\d+([eE][+-]?\d+)?|[eE][+-]?\d+)`)
 	reInteger = regexp.MustCompile(`^-?\d+`)
 	reIdent   = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_-]*`)
+	// reIntPart isolates the integer part of a matched reNumber/reInteger
+	// literal (everything up to a '.' or 'e'/'E' exponent marker, or the
+	// whole thing for a plain integer), sign already stripped by the
+	// caller -- used only to test the leading-zero rule below.
+	reIntPart = regexp.MustCompile(`^\d+`)
 )
+
+// hasLeadingZeroIntPart reports whether m -- a literal already matched by
+// reNumber or reInteger -- has a leading zero in its integer part. Per
+// spec section 4.2.3 (added 2026-08-29): int-part = "0" / (a nonzero
+// digit followed by any digits) -- so "0" alone (with or without a
+// leading '-') is valid, but "01", "00.5", "-00" etc. are not: the
+// integer part is more than one digit long and starts with '0'.
+func hasLeadingZeroIntPart(m string) bool {
+	m = strings.TrimPrefix(m, "-")
+	intPart := reIntPart.FindString(m)
+	return len(intPart) > 1 && intPart[0] == '0'
+}
 
 // remainingString returns the source from the current position onward, as
 // a string, for regexp matching. Cheap enough: called once per token.
@@ -225,23 +242,47 @@ func (l *lexer) next() (token, *omnist.ParseError) {
 	// Rule 3: DATETIME.
 	if m := omnist.ISODateTimeRegexp.FindString(rest); m != "" {
 		l.consumeRunes(len([]rune(m)))
-		return token{kind: tokDateTime, text: m, dateTimeVal: omnist.ParseISODateTime(m), line: startLine, col: startCol, sepBefore: sawSep, sepLine: sepLine, sepCol: sepCol}, nil
+		dtVal := omnist.ParseISODateTime(m)
+		// Per spec section 4.2.4 (added 2026-08-29): a DATETIME's date
+		// and time portions must each be a valid calendar/clock value,
+		// not merely the right digit shape -- checked in that order so
+		// an out-of-range date is reported as parse.invalid-date even
+		// when the time portion also happens to be out of range.
+		if !omnist.ValidDate(dtVal.Date) {
+			return token{}, l.errAt(startLine, startCol, omnist.CodeParseInvalidDate, fmt.Sprintf("%q is not a valid calendar date", m))
+		}
+		if !omnist.ValidTime(dtVal.Time) || !omnist.ValidOffsetText(m) {
+			return token{}, l.errAt(startLine, startCol, omnist.CodeParseInvalidTime, fmt.Sprintf("%q is not a valid time of day", m))
+		}
+		return token{kind: tokDateTime, text: m, dateTimeVal: dtVal, line: startLine, col: startCol, sepBefore: sawSep, sepLine: sepLine, sepCol: sepCol}, nil
 	}
 
 	// Rule 4: DATE (not followed by a valid DATETIME, already excluded above).
 	if m := omnist.ISODateRegexp.FindString(rest); m != "" {
 		l.consumeRunes(len([]rune(m)))
-		return token{kind: tokDate, text: m, dateVal: omnist.ParseISODate(m), line: startLine, col: startCol, sepBefore: sawSep, sepLine: sepLine, sepCol: sepCol}, nil
+		dateVal := omnist.ParseISODate(m)
+		if !omnist.ValidDate(dateVal) {
+			return token{}, l.errAt(startLine, startCol, omnist.CodeParseInvalidDate, fmt.Sprintf("%q is not a valid calendar date", m))
+		}
+		return token{kind: tokDate, text: m, dateVal: dateVal, line: startLine, col: startCol, sepBefore: sawSep, sepLine: sepLine, sepCol: sepCol}, nil
 	}
 
 	// Rule 5: TIME.
 	if m := omnist.ISOTimeRegexp.FindString(rest); m != "" {
 		l.consumeRunes(len([]rune(m)))
-		return token{kind: tokTime, text: m, timeVal: omnist.ParseISOTime(m), line: startLine, col: startCol, sepBefore: sawSep, sepLine: sepLine, sepCol: sepCol}, nil
+		timeVal := omnist.ParseISOTime(m)
+		if !omnist.ValidTime(timeVal) || !omnist.ValidOffsetText(m) {
+			return token{}, l.errAt(startLine, startCol, omnist.CodeParseInvalidTime, fmt.Sprintf("%q is not a valid time of day", m))
+		}
+		return token{kind: tokTime, text: m, timeVal: timeVal, line: startLine, col: startCol, sepBefore: sawSep, sepLine: sepLine, sepCol: sepCol}, nil
 	}
 
 	// Rule 6: NUMBER (decimal or exponent form).
 	if m := reNumber.FindString(rest); m != "" {
+		if hasLeadingZeroIntPart(m) {
+			l.consumeRunes(len([]rune(m)))
+			return token{}, l.errAt(startLine, startCol, omnist.CodeParseLeadingZero, fmt.Sprintf("numeric literal %q has a leading zero in its integer part", m))
+		}
 		l.consumeRunes(len([]rune(m)))
 		f, _ := strconv.ParseFloat(m, 64)
 		return token{kind: tokNumber, text: m, numVal: f, line: startLine, col: startCol, sepBefore: sawSep, sepLine: sepLine, sepCol: sepCol}, nil
@@ -255,6 +296,10 @@ func (l *lexer) next() (token, *omnist.ParseError) {
 
 	// Rule 8: INTEGER.
 	if m := reInteger.FindString(rest); m != "" {
+		if hasLeadingZeroIntPart(m) {
+			l.consumeRunes(len([]rune(m)))
+			return token{}, l.errAt(startLine, startCol, omnist.CodeParseLeadingZero, fmt.Sprintf("numeric literal %q has a leading zero in its integer part", m))
+		}
 		l.consumeRunes(len([]rune(m)))
 		digits := len(m)
 		if strings.HasPrefix(m, "-") {

--- a/oml/oml_parser_test.go
+++ b/oml/oml_parser_test.go
@@ -650,6 +650,144 @@ func TestNegativeDecimalWithExponent(t *testing.T) {
 	}
 }
 
+// --- leading-zero numeric literals (spec section 4.2.3, issue #101) ---
+
+func TestLeadingZeroIntegerIsAnError(t *testing.T) {
+	pe := mustFail(t, `n: 01`)
+	if pe.Code != omnist.CodeParseLeadingZero {
+		t.Errorf("code = %s, want %s", pe.Code, omnist.CodeParseLeadingZero)
+	}
+	if pe.Path != "1:4" {
+		t.Errorf("path = %s, want 1:4", pe.Path)
+	}
+}
+
+func TestLeadingZeroInDecimalIsAnError(t *testing.T) {
+	// The fractional part does not exempt the integer part.
+	pe := mustFail(t, `n: 00.5`)
+	if pe.Code != omnist.CodeParseLeadingZero {
+		t.Errorf("code = %s, want %s", pe.Code, omnist.CodeParseLeadingZero)
+	}
+}
+
+func TestLeadingZeroInExponentIsAnError(t *testing.T) {
+	pe := mustFail(t, `n: 01e5`)
+	if pe.Code != omnist.CodeParseLeadingZero {
+		t.Errorf("code = %s, want %s", pe.Code, omnist.CodeParseLeadingZero)
+	}
+}
+
+func TestLeadingZeroNegativeIntegerIsAnError(t *testing.T) {
+	pe := mustFail(t, `n: -01`)
+	if pe.Code != omnist.CodeParseLeadingZero {
+		t.Errorf("code = %s, want %s", pe.Code, omnist.CodeParseLeadingZero)
+	}
+}
+
+// TestSingleZeroAndNegativeFormsAreValid backs the conformance vector
+// oml-grammar/numbers/single-zero-and-negative-forms-are-valid: a bare 0
+// alone is never a leading zero.
+func TestSingleZeroAndNegativeFormsAreValid(t *testing.T) {
+	cases := []string{"0", "-0", "0.5", "-12"}
+	for _, c := range cases {
+		t.Run(c, func(t *testing.T) {
+			mustParse(t, c)
+		})
+	}
+}
+
+// --- DATE/TIME/DATETIME calendar/clock range validation (spec section
+// 4.2.4, issue #102) ---
+
+func TestDateWithOutOfRangeMonthIsAnError(t *testing.T) {
+	pe := mustFail(t, `2024-13-01`)
+	if pe.Code != omnist.CodeParseInvalidDate {
+		t.Errorf("code = %s, want %s", pe.Code, omnist.CodeParseInvalidDate)
+	}
+}
+
+func TestDateWithDayInvalidForMonthIsAnError(t *testing.T) {
+	pe := mustFail(t, `2024-04-31`)
+	if pe.Code != omnist.CodeParseInvalidDate {
+		t.Errorf("code = %s, want %s", pe.Code, omnist.CodeParseInvalidDate)
+	}
+}
+
+func TestFebruary29InANonLeapYearIsAnError(t *testing.T) {
+	pe := mustFail(t, `1900-02-29`)
+	if pe.Code != omnist.CodeParseInvalidDate {
+		t.Errorf("code = %s, want %s", pe.Code, omnist.CodeParseInvalidDate)
+	}
+}
+
+func TestFebruary29InALeapYearIsValid(t *testing.T) {
+	mustParse(t, `2000-02-29`)
+}
+
+func TestLeapSecondIsAnError(t *testing.T) {
+	pe := mustFail(t, `23:59:60`)
+	if pe.Code != omnist.CodeParseInvalidTime {
+		t.Errorf("code = %s, want %s", pe.Code, omnist.CodeParseInvalidTime)
+	}
+}
+
+func TestTimeWithOutOfRangeHourIsAnError(t *testing.T) {
+	pe := mustFail(t, `24:00:00`)
+	if pe.Code != omnist.CodeParseInvalidTime {
+		t.Errorf("code = %s, want %s", pe.Code, omnist.CodeParseInvalidTime)
+	}
+}
+
+func TestTimeWithOutOfRangeMinuteIsAnError(t *testing.T) {
+	pe := mustFail(t, `00:60:00`)
+	if pe.Code != omnist.CodeParseInvalidTime {
+		t.Errorf("code = %s, want %s", pe.Code, omnist.CodeParseInvalidTime)
+	}
+}
+
+// TestTZOffsetMinuteOutOfRangeIsAnError is the real bug the issue calls
+// out: a tz-offset like "+00:60" was previously silently accepted and
+// normalized, even though a bare "00:60:00" TIME literal was correctly
+// rejected -- an author who wrote +00:60 by mistake and one who correctly
+// wrote +01:00 would produce indistinguishable results. tz-offset must
+// share TIME's exact range check.
+func TestTZOffsetMinuteOutOfRangeIsAnError(t *testing.T) {
+	pe := mustFail(t, `2024-01-01T10:30+00:60`)
+	if pe.Code != omnist.CodeParseInvalidTime {
+		t.Errorf("code = %s, want %s", pe.Code, omnist.CodeParseInvalidTime)
+	}
+}
+
+func TestTZOffsetHourOutOfRangeIsAnError(t *testing.T) {
+	pe := mustFail(t, `10:30+24:00`)
+	if pe.Code != omnist.CodeParseInvalidTime {
+		t.Errorf("code = %s, want %s", pe.Code, omnist.CodeParseInvalidTime)
+	}
+}
+
+func TestTZOffsetWithinRangeIsValid(t *testing.T) {
+	doc := mustParse(t, `2024-01-01T10:30+05:30`)
+	dt := doc.Value.Scalar.DateTime
+	if !dt.Time.HasOffset || dt.Time.OffsetSeconds != 5*3600+30*60 {
+		t.Errorf("got %+v", dt.Time)
+	}
+}
+
+func TestDateTimeWithInvalidDatePortionIsAnError(t *testing.T) {
+	// A DATETIME's date portion is checked before its time portion.
+	pe := mustFail(t, `2024-02-30T10:30:00`)
+	if pe.Code != omnist.CodeParseInvalidDate {
+		t.Errorf("code = %s, want %s", pe.Code, omnist.CodeParseInvalidDate)
+	}
+}
+
+func TestDateTimeWithInvalidTimePortionIsAnError(t *testing.T) {
+	pe := mustFail(t, `2024-02-15T25:00:00`)
+	if pe.Code != omnist.CodeParseInvalidTime {
+		t.Errorf("code = %s, want %s", pe.Code, omnist.CodeParseInvalidTime)
+	}
+}
+
 func TestReservedInfNumber(t *testing.T) {
 	doc := mustParse(t, `a: inf`)
 	v, _ := doc.Node.Edges[0].Target.Value()

--- a/temporal.go
+++ b/temporal.go
@@ -156,6 +156,98 @@ func ParseISODateTime(s string) DateTimeValue {
 // a real cross-codec dependency this project's package-restructuring plan
 // had not accounted for -- the same class of gap FormatISODate/
 // FormatISOTime/FormatISOFraction above were promoted to fix.
+// --- calendar/clock range validation (spec section 4.2.4, added 2026-08-29) ---
+//
+// ABNF alone can only constrain DATE/TIME/DATETIME tokens to digit
+// counts (e.g. a month is 2DIGIT, i.e. 00-99), not calendar/clock
+// validity -- it has no way to express that a month must be 01-12. This
+// section is what makes those range rules normative: DATE is a valid
+// proleptic Gregorian calendar date (month 01-12, day valid for
+// month/year including leap years); TIME (and DATETIME's time portion)
+// is hour 00-23, minute 00-59, second 00-59 with no leap-second spelling
+// (23:59:60 is an error); and a tz-offset shares TIME's exact hour/minute
+// range check -- deliberately the SAME rule, not a separately
+// implemented one, since a previously-undetected bug (confirmed live
+// against the Python reference) let a tz-offset like "+00:60" through
+// while an equivalent bare TIME "00:60:00" was correctly rejected.
+
+// daysInMonth returns the number of days in the given proleptic
+// Gregorian calendar month (1-12) for year, including the Gregorian leap
+// year rule (divisible by 4, except centuries not divisible by 400 --
+// e.g. 2000-02-29 is valid, 1900-02-29 is not). Only ever called after
+// month has already been range-checked to 1-12 by validDate.
+func daysInMonth(year, month int) int {
+	switch month {
+	case 1, 3, 5, 7, 8, 10, 12:
+		return 31
+	case 4, 6, 9, 11:
+		return 30
+	default: // 2
+		if year%4 == 0 && (year%100 != 0 || year%400 == 0) {
+			return 29
+		}
+		return 28
+	}
+}
+
+// ValidDate reports whether d is a valid proleptic Gregorian calendar
+// date: month 01-12, and day valid for that month/year.
+func ValidDate(d DateValue) bool {
+	if d.Month < 1 || d.Month > 12 {
+		return false
+	}
+	return d.Day >= 1 && d.Day <= daysInMonth(d.Year, d.Month)
+}
+
+// validClockRange reports whether an hour/minute/second triple is a
+// valid clock value: hour 00-23, minute 00-59, second 00-59. No
+// leap-second spelling exists -- 23:59:60 is invalid. This is the single
+// range check both validTime (for TIME/DATETIME's time portion) and
+// validTZOffset (for a tz-offset) call, per spec section 4.2.4's
+// explicit requirement that a tz-offset share TIME's exact range check
+// rather than a separately implemented, possibly looser one.
+func validClockRange(hour, minute, second int) bool {
+	return hour >= 0 && hour <= 23 && minute >= 0 && minute <= 59 && second >= 0 && second <= 59
+}
+
+// ValidTime reports whether t's hour/minute/second are a valid clock
+// value. It deliberately does NOT check t.OffsetSeconds -- see
+// ValidOffsetText below for why an offset must be range-checked from its
+// original source digits, not from this already-normalized field.
+func ValidTime(t TimeValue) bool {
+	return validClockRange(t.Hour, t.Minute, t.Second)
+}
+
+// tzOffsetTailRegexp matches a trailing tz-offset's sign and raw
+// hour/minute digit pair at the end of a string already matched by
+// ISOTimeRegexp or ISODateTimeRegexp.
+var tzOffsetTailRegexp = regexp.MustCompile(`[+-](\d{2}):(\d{2})$`)
+
+// ValidOffsetText reports whether s -- text already matched by
+// ISOTimeRegexp or ISODateTimeRegexp -- has no tz-offset suffix, or has
+// one whose hour/minute are each within TIME's own range (00-23, 00-59)
+// -- deliberately the SAME range check ValidTime/validClockRange applies
+// to TIME itself, per spec section 4.2.4.
+//
+// This checks the offset's raw source digits directly, not
+// TimeValue.OffsetSeconds: an out-of-range minute like "+00:60" folds
+// silently into a normalized total of 3600 seconds (60 minutes) once
+// converted to OffsetSeconds -- indistinguishable, after the fact, from a
+// correctly-written "+01:00". That was a real, previously-undetected bug
+// (confirmed live against the Python reference): "+00:60" was silently
+// accepted and normalized, even though a bare "00:60:00" TIME literal
+// was correctly rejected. Checking the raw digits before they are ever
+// folded into a total is the only way to catch it.
+func ValidOffsetText(s string) bool {
+	m := tzOffsetTailRegexp.FindStringSubmatch(s)
+	if m == nil {
+		return true
+	}
+	hour, _ := strconv.Atoi(m[1])
+	minute, _ := strconv.Atoi(m[2])
+	return validClockRange(hour, minute, 0)
+}
+
 func FracToNanos(digits string) int {
 	padded := (digits + "000000000")[:9]
 	n, _ := strconv.Atoi(padded)

--- a/temporal_test.go
+++ b/temporal_test.go
@@ -105,6 +105,84 @@ func TestFormatISODate(t *testing.T) {
 // fuzzing: regexp.FindString("") == "" whether or not the regex actually
 // matched, so without this guard an empty string would spuriously
 // "match" every kind.
+// --- ValidDate/ValidTime/ValidOffsetText (spec section 4.2.4, issue #102) ---
+//
+// Direct tests restoring this package's own coverage of these functions,
+// independent of which downstream package (oml) happens to call them --
+// see TestParseISOTimeNegativeOffset's doc comment above for why that
+// matters given Go's per-package coverage attribution.
+
+func TestValidDate(t *testing.T) {
+	cases := []struct {
+		name string
+		d    DateValue
+		want bool
+	}{
+		{"ordinary date", DateValue{Year: 2024, Month: 6, Day: 15}, true},
+		{"month zero", DateValue{Year: 2024, Month: 0, Day: 1}, false},
+		{"month 13", DateValue{Year: 2024, Month: 13, Day: 1}, false},
+		{"april 31 (30-day month)", DateValue{Year: 2024, Month: 4, Day: 31}, false},
+		{"december 31", DateValue{Year: 2024, Month: 12, Day: 31}, true},
+		{"leap day in leap year", DateValue{Year: 2000, Month: 2, Day: 29}, true},
+		{"leap day in non-leap century year", DateValue{Year: 1900, Month: 2, Day: 29}, false},
+		{"leap day in ordinary non-leap year", DateValue{Year: 2023, Month: 2, Day: 29}, false},
+		{"feb 28 in non-leap year", DateValue{Year: 2023, Month: 2, Day: 28}, true},
+		{"day zero", DateValue{Year: 2024, Month: 1, Day: 0}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ValidDate(tc.d); got != tc.want {
+				t.Errorf("ValidDate(%+v) = %v, want %v", tc.d, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestValidTime(t *testing.T) {
+	cases := []struct {
+		name string
+		t    TimeValue
+		want bool
+	}{
+		{"ordinary time", TimeValue{Hour: 10, Minute: 30, Second: 15}, true},
+		{"hour 23 is valid", TimeValue{Hour: 23, Minute: 0, Second: 0}, true},
+		{"hour 24 is invalid", TimeValue{Hour: 24, Minute: 0, Second: 0}, false},
+		{"minute 59 is valid", TimeValue{Hour: 0, Minute: 59, Second: 0}, true},
+		{"minute 60 is invalid", TimeValue{Hour: 0, Minute: 60, Second: 0}, false},
+		{"second 59 is valid", TimeValue{Hour: 0, Minute: 0, Second: 59}, true},
+		{"leap second 60 is invalid", TimeValue{Hour: 23, Minute: 59, Second: 60}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ValidTime(tc.t); got != tc.want {
+				t.Errorf("ValidTime(%+v) = %v, want %v", tc.t, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestValidOffsetText(t *testing.T) {
+	cases := []struct {
+		name string
+		s    string
+		want bool
+	}{
+		{"no offset", "10:30:00", true},
+		{"offset within range", "10:30:00+05:30", true},
+		{"negative offset within range", "10:30:00-05:30", true},
+		{"offset hour out of range", "10:30+24:00", false},
+		{"offset minute out of range (the real bug)", "10:30+00:60", false},
+		{"datetime with offset minute out of range", "2024-01-01T10:30+00:60", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ValidOffsetText(tc.s); got != tc.want {
+				t.Errorf("ValidOffsetText(%q) = %v, want %v", tc.s, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestMatchesISOKindEmptyString(t *testing.T) {
 	for _, kind := range []TemporalKind{TemporalDate, TemporalTime, TemporalDateTime} {
 		if MatchesISOKind("", kind) {


### PR DESCRIPTION
Closes #101, closes #102.

Per omnist-spec section 4.2.3/4.2.4: the OML tokenizer's numeric literal grammar now forbids a leading zero in the integer part, and DATE/TIME/DATETIME tokens now require a valid calendar/clock value, not merely the right digit shape. Both are tokenizer-level input-shape rejections in the same file, landed together.

The vendored submodule pin (`0ac1eac`) already contains both spec commits and every vector below, so no submodule bump is included.

## #101
New `parse.leading-zero` code. `oml/oml_lexer.go`'s NUMBER/INTEGER rules now reject `"01"`, `"00.5"`, `"-01"` etc., while a bare `"0"` (with or without a leading `-`) stays valid.

## #102
New `parse.invalid-date`/`parse.invalid-time` codes, plus `temporal.go`'s new `ValidDate` (proleptic Gregorian, leap years included) and `ValidTime` (hour/minute/second ranges, no leap second).

**The real bug** the issue called out: a naive range check that decomposes `TimeValue.OffsetSeconds` back into hour/minute is actually wrong — `"+00:60"` (60 minutes) silently folds into a normalized 3600-second total *before* any range check sees it, making it indistinguishable from a correctly written `"+01:00"`. Confirmed this reproduced live while writing the fix. Fixed with `ValidOffsetText`, which range-checks a tz-offset's raw source digits directly from the matched literal text — the only way to catch the fold. It shares `validClockRange` with `ValidTime`, so tz-offset and TIME genuinely share one check now, not two that can drift apart again.

## Verification
- `go build/vet/test`, `golangci-lint run ./...`, `gofmt -l .` (no new drift), `check_doc_examples` all clean.
- 100% coverage on every touched file.
- Fixture conformance track: 19/19 pass.
- Vector conformance track: **170/172 pass, 0 fail, 2 skip** — both skips pre-date or were already cited in this batch (TOML strict-mode gap from #31/#49; the XML CR vector whitespace defect filed as omnist-dev/omnist-spec#52 during #99). This is the real, final number for the whole #95-#103 batch.
- Checked the coordinator's heads-up re: omnist-spec#51 (tz-offset seconds-canonicalization) against `oml-grammar/temporals/tz-offset-within-range-is-valid` — this port's `FormatISOTime` only emits seconds when nonzero, so its canonical value already matches the vector's expectation with no seconds. Not affected, confirmed by the vector passing.

## CI: restoring strict conformance gating
This is the last of the 9 issues in the batch, and the fail count is now genuinely zero on both tracks. Per the coordinator, removed both `|| true` suffixes and the "TEMPORARILY non-blocking" comment blocks from `.github/workflows/ci.yml`'s `conformance` job in this same PR, restoring the strict gating issue #74 established.
