### PR TITLE
Normalize insignificant XML whitespace before comparing write vectors

### DIFF
--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -88,11 +88,19 @@ gap — see the ledger's Go `Resource caps` row (source-audited clean,
 
 ## Spec version targeted
 
-`omnist-spec` at commit `0ac1eac` (`v0.4.0-beta`, 13 commits past the tag
-— omnist-spec has moved from alpha to beta upstream; pins the fixes for
-issues #95-103, a spec-correctness audit batch), pinned via the
-`vendor/omnist-spec` git submodule. This repo does not track the spec's
-`main` branch — the pin is bumped deliberately, in its own commit.
+`omnist-spec` at commit `aac3ce0`, pinned via the `vendor/omnist-spec` git
+submodule. This repo does not track the spec's `main` branch — the pin is
+bumped deliberately, in its own commit. Past `0ac1eac` (the #95-103
+spec-correctness audit batch), this pin also carries the fix for
+`omnist-spec#52` — a new §8.5.3 rule requiring a harness to strip
+insignificant inter-tag XML whitespace before comparing a `write` vector's
+expected/actual text, since the spec places no requirement on XML writer
+whitespace at all. This repo's own conformance-test skip for that vector
+(cited as `omnist-spec#52` in a prior revision of this doc) is removed —
+`formats-xml/basic/carriage-return-written-as-numeric-character-reference`
+now passes outright, bringing Track 2 to 171/0/1 (of 172; the one
+remaining skip is the pre-existing, unrelated TOML strict-mode gap noted
+above).
 
 See `omnist-spec`'s own [§9.3 status table](https://github.com/omnist-dev/omnist-spec/blob/main/docs/09-divergence-ledger.md#93-status-table)
 for the cross-implementation divergence ledger this repo reports into.

--- a/tools/conformance/drivers.go
+++ b/tools/conformance/drivers.go
@@ -3,6 +3,8 @@ package conformance
 import (
 	encjson "encoding/json"
 	"fmt"
+	"strings"
+	"unicode"
 
 	omnist "github.com/omnist-dev/omnist-go"
 	"github.com/omnist-dev/omnist-go/algebra"
@@ -275,21 +277,6 @@ type writeInput struct {
 }
 
 func runWrite(v Vector) Result {
-	if v.Name == "formats-xml/basic/carriage-return-written-as-numeric-character-reference" {
-		// Known, cited spec-vector defect, not a port bug: this vector's
-		// expect.text bakes in pretty-printed whitespace (2-space indent,
-		// one element per line, trailing newline) inconsistent with every
-		// other exact-text write vector in this track (which match each
-		// implementation's own compact convention -- see e.g.
-		// formats-json/basic/repeated-edges-regroup-into-one-array-on-write).
-		// Confirmed empirically (issue #99): this port's \r-escaping fix
-		// produces byte-identical output to the vector's expectation except
-		// for that whitespace -- the escaping itself
-		// (a&#13;b, decimal, not raw \r) is exactly right. Filed as
-		// omnist-dev/omnist-spec#52; skip until resolved upstream, same
-		// pattern as the TOML strict-mode skip below.
-		return Result{Vector: v, Status: StatusSkip, Reason: "known spec-vector defect, not a port bug: expect.text bakes in pretty-printed whitespace no other exact-text write vector in this track requires -- filed as omnist-dev/omnist-spec#52, see issue #99"}
-	}
 	var in writeInput
 	if err := encjson.Unmarshal(v.Input, &in); err != nil {
 		return fail(v, "decode input: %v", err)
@@ -370,10 +357,36 @@ func runWrite(v Vector) Result {
 	if err := encjson.Unmarshal(wantText, &wantTextStr); err != nil {
 		return fail(v, "decode expect.text: %v", err)
 	}
-	if text != wantTextStr {
+	gotText, wantCmp := text, wantTextStr
+	if in.Format == "xml" {
+		gotText, wantCmp = normalizeXMLWhitespace(gotText), normalizeXMLWhitespace(wantCmp)
+	}
+	if gotText != wantCmp {
 		return fail(v, "text mismatch: got %q want %q", text, wantTextStr)
 	}
 	return pass(v)
+}
+
+// normalizeXMLWhitespace implements §8.5.3: strip whitespace strictly
+// between '>' and '<' before comparing a write vector's expected/actual
+// text for XML. Safe because this package never produces mixed-content
+// XML (Document model §2: a node has either child edges or one scalar
+// value, never both), so this whitespace can only ever be inter-tag
+// formatting, never real text data.
+func normalizeXMLWhitespace(text string) string {
+	var b strings.Builder
+	b.Grow(len(text))
+	runes := []rune(text)
+	for i := 0; i < len(runes); i++ {
+		c := runes[i]
+		b.WriteRune(c)
+		if c == '>' {
+			for i+1 < len(runes) && unicode.IsSpace(runes[i+1]) {
+				i++
+			}
+		}
+	}
+	return b.String()
 }
 
 // --- compatible_with / equivalent ---


### PR DESCRIPTION
Normalize insignificant XML whitespace before comparing write vectors

Per omnist-spec#52 (filed by this port while implementing #99): the
formats-xml/basic/carriage-return-written-as-numeric-character-reference
vector's expect.text hardcoded the Python reference's own indentation
choice as if it were normative, when the spec places no requirement on
XML writer whitespace at all -- this port's XML writer never indents,
so the vector failed here for a reason outside this port's own
correctness (the escaping itself, &#13; not a raw byte, was already
confirmed exactly right).

New Sec8.5.3 rule (omnist-spec commit aac3ce0): a harness comparing a
write vector's text for XML MUST strip whitespace strictly between '>'
and '<' from both sides before comparing. Safe because this package
never produces mixed-content XML (Document model Sec2: a node has
either child edges or one scalar value, never both), so this
whitespace can only ever be inter-tag formatting.

Bumps vendor/omnist-spec to aac3ce0 (also carries omnist-spec#51's
fix, no effect on this port). Removes the vector-specific skip added
when #52 was first filed -- the vector now passes outright. Track 2
moves from 170/0/2 to 171/0/1 (of 172; the one remaining skip is the
pre-existing, unrelated TOML strict-mode gap).

Adds normalizeXMLWhitespace() and applies it in runWrite() only when
the target format is XML. docs/limitations.md's spec-version section
updated to cite the new pin and this fix; version_test.go's
TestSpecVersionMatchesSubmodule caught the stale citation immediately.

Verified: go build/vet/test ./... (all pass, 100% coverage on every
non-excluded package -- tools/conformance/** and the two cmd/omnist
functions already excluded from the gate per its own documented
convention), gofmt clean on the changed file, check_doc_examples
clean, both conformance tracks (Track 1 fixtures 19/19, Track 2
171/0/1) all green.
