### PR TITLE
Bump omnist-spec pin to v0.7.0-beta; skip OSD-OML extension honestly

### DIFF
--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -17,8 +17,12 @@ conformance harness, and fuzz tests on every reader (`go test -fuzz`).
 
 Track 2 ([`tools/conformance/`](https://github.com/omnist-dev/omnist-go/tree/main/tools/conformance),
 JSON-vector, run against `omnist-spec`'s `test-suite/`) currently reports
-**171 pass / 0 fail / 1 skip** of 172 vectors (as of the `omnist-spec#52`
-XML-whitespace-normalization fix, `omnist-spec` v0.5.0-beta pin). Track 1
+**174 pass / 0 fail / 25 skip** of 199 vectors (`omnist-spec` v0.7.0-beta
+pin). 24 of those 25 skips are the new OSD-OML extension
+(`parse_schema_oml`/`write_schema_oml`) — not yet implemented in this
+port, cited honestly per §9.5 rather than crashing or failing the
+driver; see [issue #111](https://github.com/omnist-dev/omnist-go/issues/111)
+for implementing it. Track 1
 (fixture-based, `conformance/fixtures/`) reports **19 pass / 0 fail / 0
 skip** of 19 fixtures. Both tracks are at zero real fails — the two prior fails, filed
 as [`omnist-spec#41`](https://github.com/omnist-dev/omnist-spec/issues/41)
@@ -88,19 +92,24 @@ gap — see the ledger's Go `Resource caps` row (source-audited clean,
 
 ## Spec version targeted
 
-`omnist-spec` at commit `aac3ce0`, pinned via the `vendor/omnist-spec` git
-submodule. This repo does not track the spec's `main` branch — the pin is
-bumped deliberately, in its own commit. Past `0ac1eac` (the #95-103
-spec-correctness audit batch), this pin also carries the fix for
-`omnist-spec#52` — a new §8.5.3 rule requiring a harness to strip
-insignificant inter-tag XML whitespace before comparing a `write` vector's
-expected/actual text, since the spec places no requirement on XML writer
-whitespace at all. This repo's own conformance-test skip for that vector
-(cited as `omnist-spec#52` in a prior revision of this doc) is removed —
+`omnist-spec` at commit `c4141d0` (`v0.7.0-beta`), pinned via the
+`vendor/omnist-spec` git submodule. This repo does
+not track the spec's `main` branch — the pin is bumped deliberately, in
+its own commit. Past `0ac1eac` (the #95-103 spec-correctness audit
+batch), this pin also carries the fix for `omnist-spec#52` — a new
+§8.5.3 rule requiring a harness to strip insignificant inter-tag XML
+whitespace before comparing a `write` vector's expected/actual text,
+since the spec places no requirement on XML writer whitespace at all.
+This repo's own conformance-test skip for that vector (cited as
+`omnist-spec#52` in a prior revision of this doc) is removed —
 `formats-xml/basic/carriage-return-written-as-numeric-character-reference`
-now passes outright, bringing Track 2 to 171/0/1 (of 172; the one
-remaining skip is the pre-existing, unrelated TOML strict-mode gap noted
-above).
+now passes outright. Past `aac3ce0`, this pin also carries 3 new §3.3
+canonical-serialization-order characterization vectors
+(`osd-grammar/canonical-output/declaration-order-round-trips-exactly`,
+`prune/basic/survivors-keep-declaration-order-not-alphabetical`,
+`normalize/basic/output-order-is-alphabetical-not-declaration-order`) —
+all three passed green-on-arrival against this repo's existing behavior,
+no code change needed.
 
 See `omnist-spec`'s own [§9.3 status table](https://github.com/omnist-dev/omnist-spec/blob/main/docs/09-divergence-ledger.md#93-status-table)
 for the cross-implementation divergence ledger this repo reports into.

--- a/tools/conformance/runner.go
+++ b/tools/conformance/runner.go
@@ -67,9 +67,10 @@ type findingExpect struct {
 // and compares the result against its "expect" per §8.5.2's rules. It
 // never panics on a vector it cannot execute -- a driver bug produces a
 // Result, not a crash, per the issue's "not yet implemented gets an
-// honest skip, not a crash or a forced pass" requirement (no operation
-// currently falls into that not-yet-implemented bucket as of issue #35,
-// which wired up materialize, the last one).
+// honest skip, not a crash or a forced pass" requirement. parse_schema_oml
+// and write_schema_oml (the OSD-OML extension) are the first operations
+// to actually land in that not-yet-implemented bucket, as cited skips --
+// every other operation below has a real driver.
 func RunVector(v Vector) Result {
 	switch v.Operation {
 	case "parse":
@@ -100,6 +101,17 @@ func RunVector(v Vector) Result {
 		return runInferWithReport(v)
 	case "lint":
 		return runLint(v)
+	case "parse_schema_oml", "write_schema_oml":
+		// OSD-OML extension (omnist-spec PR #53/#55): a schema expressed
+		// as an OML document, read/written via parse_schema_oml/
+		// write_schema_oml. Not yet implemented in this port -- an
+		// honest, cited skip per conformance-harness.md §9.5 ("skips are
+		// permitted and MUST be reported; they are how partial
+		// implementations are tracked honestly"), not a driver failure,
+		// since the spec itself already tracks this as unimplemented
+		// across every port (divergence ledger §9.6). See omnist-go
+		// issue #111 for this port's own implementation.
+		return Result{Vector: v, Status: StatusSkip, Reason: "OSD-OML extension not yet implemented in this port, see omnist-go issue #111"}
 	default:
 		return Result{Vector: v, Status: StatusFail, Reason: fmt.Sprintf("unknown operation %q", v.Operation)}
 	}

--- a/version.go
+++ b/version.go
@@ -3,4 +3,4 @@ package omnist
 
 // SpecVersion is the omnist-spec version this module targets, pinned via
 // the vendor/omnist-spec git submodule. See docs/limitations.md.
-const SpecVersion = "v0.4.0-beta"
+const SpecVersion = "v0.7.0-beta"


### PR DESCRIPTION
Bumps `vendor/omnist-spec` to `c4141d0` (`v0.7.0-beta`).

Confirms 3 §3.3 canonical-serialization-order characterization vectors pass green-on-arrival, no code change needed:
- `osd-grammar/canonical-output/declaration-order-round-trips-exactly`
- `prune/basic/survivors-keep-declaration-order-not-alphabetical`
- `normalize/basic/output-order-is-alphabetical-not-declaration-order`

Also brings in the OSD-OML extension (`parse_schema_oml`/`write_schema_oml`, omnist-spec PR #53/#55) — 24 new conformance vectors this port doesn't implement yet. Rather than fail the driver on an unrecognized operation, `tools/conformance/runner.go` now dispatches these two specific operations to an honest, cited skip per conformance-harness.md §9.5's convention, matching the divergence ledger's own §9.6 tracking of this as not-yet-implemented across every port. Filed #111 to track the actual implementation as unscheduled future work.

Track 2: 174 pass / 0 fail / 25 skip of 199 vectors (24 of the 25 skips are the new OSD-OML extension; the 25th is the pre-existing TOML strict-mode gap). Track 1 unchanged: 19/0/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
